### PR TITLE
Small changes

### DIFF
--- a/spring-data-neo4j-cross-store/src/test/resources/org/springframework/data/neo4j/partial/Neo4jGraphRecommendationTest-context.xml
+++ b/spring-data-neo4j-cross-store/src/test/resources/org/springframework/data/neo4j/partial/Neo4jGraphRecommendationTest-context.xml
@@ -38,34 +38,6 @@
 	-->
 	<context:spring-configured/>
 
-	<!--
-		This declaration will cause Spring to locate every @Component,
-		@Repository and @Service in your application. In practical terms this
-		allows you to write a POJO and then simply annotate the new POJO as an
-		@Service and Spring will automatically detect, instantiate and
-		dependency inject your service at startup time. Importantly, you can
-		then also have your new service injected into any other class that
-		requires it simply by declaring a field for your service inside the
-		relying class and Spring will inject it. Note that two exclude filters
-		are declared. The first ensures that Spring doesn't spend time
-		introspecting Roo-specific ITD aspects. The second ensures Roo doesn't
-		instantiate your @Controller classes, as these should be instantiated
-		by a web tier application context. Refer to web.xml for more details
-		about the web tier application context setup services.
-		
-		Furthermore, this turns on @Autowired, @PostConstruct etc support. These 
-		annotations allow you to use common Spring and Java Enterprise Edition 
-		annotations in your classes without needing to do any special configuration. 
-		The most commonly used annotation is @Autowired, which instructs Spring to
-		dependency inject an object into your class.
-	-->
-	<context:component-scan base-package="org.springframework.data.neo4j">
-		<context:exclude-filter expression=".*_Roo_.*" type="regex"/>
-		<context:exclude-filter expression="org.springframework.stereotype.Controller" type="annotation"/>
-		<context:exclude-filter expression="org.springframework.context.annotation.Configuration" type="annotation"/>
-	</context:component-scan>
-	
-	
 	<!-- 
 	    Start datastore config
     -->

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
@@ -119,8 +119,9 @@ public abstract class Neo4jConfiguration {
         }
         return infrastructure;
     }
-    @Bean
-	public Neo4jTemplate neo4jTemplate() throws Exception {
+
+    @Bean(initMethod="postConstruct")
+    public Neo4jTemplate neo4jTemplate() throws Exception {
         final Neo4jTemplate neo4jTemplate = new Neo4jTemplate();
         neo4jTemplate.setInfrastructure(mappingInfrastructure());
         nodeEntityStateFactory().setTemplate(neo4jTemplate);

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
@@ -48,7 +48,6 @@ import static org.neo4j.helpers.collection.MapUtil.map;
  * @param <T> GraphBacked target of this finder, enables the finder methods to return this concrete type
  * @param <S> Type of backing state, either Node or Relationship
  */
-@org.springframework.stereotype.Repository
 public abstract class AbstractGraphRepository<S extends PropertyContainer, T> implements GraphRepository<T>, NamedIndexRepository<T>, SpatialRepository<T>, CypherDslRepository<T> {
 
     /*
@@ -102,6 +101,20 @@ public abstract class AbstractGraphRepository<S extends PropertyContainer, T> im
         this.clazz = clazz;
     }
 
+    @Override
+    public T save(T entity) {
+        return (T) template.save(entity);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Iterable<T> save(Iterable<? extends T> entities) {
+        for (T entity : entities) {
+            save(entity);
+        }
+        return (Iterable<T>) entities;
+    }
+    
     /**
      * @return Number of instances of the target type in the graph.
      */

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NodeGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NodeGraphRepositoryImpl.java
@@ -19,7 +19,9 @@ package org.springframework.data.neo4j.repository;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public class NodeGraphRepositoryImpl<T> extends AbstractGraphRepository<Node, T> implements GraphRepository<T>, RelationshipOperationsRepository<T> {
 
     public NodeGraphRepositoryImpl(final Class<T> clazz, final Neo4jTemplate template) {
@@ -34,24 +36,6 @@ public class NodeGraphRepositoryImpl<T> extends AbstractGraphRepository<Node, T>
     @Override
     public <N> Iterable<T> findAllByTraversal(final N start, final TraversalDescription traversalDescription) {
         return template.traverse(start, clazz, traversalDescription);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public T save(T entity) {
-        return (T) template.save(entity);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Iterable<T> save(Iterable<? extends T> entities) {
-        for (T entity : entities) {
-            save(entity);
-
-
-
-        }
-        return (Iterable<T>) entities;
     }
 
     @Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipGraphRepository.java
@@ -19,10 +19,9 @@ package org.springframework.data.neo4j.repository;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
-
+@Repository
 public class RelationshipGraphRepository<T> extends AbstractGraphRepository<Relationship, T> implements GraphRepository<T> {
 
     public RelationshipGraphRepository(final Class<T> clazz, final Neo4jTemplate template) {
@@ -37,21 +36,6 @@ public class RelationshipGraphRepository<T> extends AbstractGraphRepository<Rela
     @Override
     public <N> Iterable<T> findAllByTraversal(final N startNode, final TraversalDescription traversalDescription) {
         throw new UnsupportedOperationException("Traversal not able to start at relationship");
-    }
-
-    @Override
-    public T save(T entity) {
-        return template.save(entity);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Iterable<T> save(Iterable<? extends T> entities) {
-        List<T> result=new ArrayList<T>();
-        for (T entity : entities) {
-            result.add(template.save(entity));
-        }
-        return result;
     }
 }
 


### PR DESCRIPTION
- save methods pushed up to AbstractGraphRepository. Was there a reason why they have been implemented differently in RelationshipGraphRepository and NodeGraphRepositoryImpl.java?
- Neo4jTemplate.postConstruct declared as initMethod so that `<context:annotation-config />` is not needed.
- annotated the repository implementations with `@Repository`, not just the AbstractGraphRepository to make sure all methods have exception translation
