### PR TITLE
Do not convert a property of type Object if it holds a neo4j supported type

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
@@ -54,7 +54,24 @@ public interface Neo4jPersistentProperty extends PersistentProperty<Neo4jPersist
 
     boolean isSerializablePropertyField(final ConversionService conversionService);
 
+    /**
+     * Returns {@code true} if the type of this property is a natively supported neo4j property type. Supported type are listed here:
+     * {@link PropertyContainer#setProperty(String, Object)}.
+     *
+     * @return {@code true} if the given object is a natively supported neo4j property type.
+     * @see PropertyContainer#setProperty(String, Object)
+     */
     boolean isNeo4jPropertyType();
+
+    /**
+     * Returns {@code true} if the given object {@code value} is a natively supported neo4j property type, but not an array. Supported type are listed here:
+     * {@link PropertyContainer#setProperty(String, Object)}.
+     *
+     * @param value the object to check
+     * @return {@code true} if the given object is a natively supported neo4j property type. {@code false} is returned, if {@code value} is an array.
+     * @see PropertyContainer#setProperty(String, Object)
+     */
+    boolean isNeo4jPropertyValue(Object value);
 
     boolean isSyntheticField();
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4JPersistentPropertyImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4JPersistentPropertyImpl.java
@@ -196,6 +196,14 @@ class Neo4jPersistentPropertyImpl extends AbstractPersistentProperty<Neo4jPersis
                 || (fieldType.isArray() && !fieldType.getComponentType().isArray() && isNeo4jPropertyType(fieldType.getComponentType()));
     }
 
+    @Override
+    public boolean isNeo4jPropertyValue(Object value) {
+	if (value == null || value.getClass().isArray()) {
+	    return false;
+	}
+	return isNeo4jPropertyType(value.getClass());
+    }
+
     public boolean isSyntheticField() {
         return getName().contains("$");
     }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jEntityConverterTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jEntityConverterTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.neo4j.model.Friendship;
 import org.springframework.data.neo4j.model.Group;
 import org.springframework.data.neo4j.model.Person;
 import org.springframework.data.neo4j.model.Personality;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Date;
@@ -149,6 +150,33 @@ public class Neo4jEntityConverterTest extends Neo4jPersistentTestBase {
         assertEquals(36, p.getAge());
         assertEquals(new Date(100), p.getBirthdate());
         assertEquals(Personality.EXTROVERT, p.getPersonality());
+    }
+
+    private <T> void neo4jPropertyTest(final T value) {
+        michael.setDynamicProperty(value);
+        storeInGraph(michael);
+        final Person loaded = template.findOne(michael.getId(), Person.class);
+        assertEquals(value, loaded.getDynamicProperty());
+    }
+
+    @Test
+    public void testIntProperty() {
+	neo4jPropertyTest(123);
+    }
+
+    @Test
+    public void testDoubleProperty() {
+	neo4jPropertyTest(3.1415);
+    }
+
+    @Test
+    public void testBooleanProperty() {
+	neo4jPropertyTest(true);
+    }
+
+    @Test
+    public void testIntegerProperty() {
+	neo4jPropertyTest(Integer.valueOf(3));
     }
 
     @Test

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Person.java
@@ -51,6 +51,8 @@ public class Person {
     @Indexed
     private int age;
 
+	private Object dynamicProperty;
+
 	private Short height;
 
 	private transient String thought;
@@ -259,6 +261,14 @@ public class Person {
 	
 	public void setNickname(String nickname) {
 		this.nickname = nickname;
+	}
+
+	public void setDynamicProperty(Object dynamicProperty) {
+		this.dynamicProperty = dynamicProperty;
+	}
+
+	public Object getDynamicProperty() {
+		return dynamicProperty;
 	}
 
     public Person(Long graphId) {


### PR DESCRIPTION
The current implementation of ConvertingNodePropertyFieldAccessor converts all properties that are convertible to a String to - well - strings. If the property is of type Object, the type of the property always changes to "String" when reading the value back from the DB, also when e.g. an Integer has been stored as its value.

``` java
@NodeEntity
public class Foo {
  public Object value;
}
```

These changes do not convert values of properties of type Object, when they contain types that are directly supported by neo4j's PropertyContainer.
