### PR TITLE
continued unleashing IndexProvider

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProvider.java
@@ -44,9 +44,18 @@ public interface IndexProvider {
     /**
      * adjust your indexName for the "__types__" indices
      * 
-     * @param Class<?> type
+     * @param type
      * @return prefixed indexName for Type
      */
     String createIndexValueForType(Class<?> type);
+    
+    /**
+     * possibility to do something with the high level index name 
+     * 
+     * @param indexName
+     * @param type
+     * @return
+     */
+    String customizeIndexName(String indexName, Class<?> type);
 
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProviderImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProviderImpl.java
@@ -58,16 +58,16 @@ public class IndexProviderImpl implements IndexProvider {
         }
 
         final Neo4jPersistentEntityImpl<?> persistentEntity = mappingContext.getPersistentEntity(type);
-        if (indexName == null) indexName = Indexed.Name.get(type);
+        if (indexName == null) indexName = customizeIndexName(Indexed.Name.get(type), type);
         final boolean useExistingIndex = indexType == null;
 
         if (useExistingIndex) {
-            if (persistentEntity.isNodeEntity()) return (Index<S>) graphDatabase.getIndex(indexName);
-            if (persistentEntity.isRelationshipEntity()) return (Index<S>) graphDatabase.getIndex(indexName);
+            if (persistentEntity.isNodeEntity() || persistentEntity.isRelationshipEntity()) return (Index<S>) graphDatabase.getIndex(indexName);
             throw new IllegalArgumentException("Wrong index type supplied: " + type + " expected Node- or Relationship-Entity");
         }
 
-        if (persistentEntity.isNodeEntity()) return (Index<S>) createIndex(Node.class, indexName, indexType);
+        if (persistentEntity.isNodeEntity())
+            return (Index<S>) createIndex(Node.class, indexName, indexType);
         if (persistentEntity.isRelationshipEntity())
             return (Index<S>) createIndex(Relationship.class, indexName, indexType);
         throw new IllegalArgumentException("Wrong index type supplied: " + type + " expected Node- or Relationship-Entity");
@@ -99,11 +99,11 @@ public class IndexProviderImpl implements IndexProvider {
         final Class<?> declaringType = property.getOwner().getType();
         final String providedIndexName = indexedAnnotation==null || indexedAnnotation.indexName().isEmpty() ? null : indexedAnnotation.indexName();
         final Indexed.Level level = indexedAnnotation == null ? Indexed.Level.CLASS : indexedAnnotation.level();
-        String indexName = Indexed.Name.get(level, declaringType, providedIndexName, instanceType);
+        String indexName = customizeIndexName(Indexed.Name.get(level, declaringType, providedIndexName, instanceType), instanceType);
         if (!property.isIndexed() || property.getIndexInfo().getIndexType() == IndexType.SIMPLE) {
             return getIndex(declaringType, indexName, IndexType.SIMPLE);
         }
-        String defaultIndexName = Indexed.Name.get(level, declaringType, null, instanceType.getClass());
+        String defaultIndexName = customizeIndexName(Indexed.Name.get(level, declaringType, null, instanceType.getClass()), instanceType);
         if (providedIndexName==null || providedIndexName.equals(defaultIndexName)) throw new IllegalStateException("Index name for "+property+" must differ from the default name: "+defaultIndexName);
         return getIndex(declaringType, indexName, property.getIndexInfo().getIndexType());
     }
@@ -111,6 +111,11 @@ public class IndexProviderImpl implements IndexProvider {
     @Override
     public String createIndexValueForType(Class<?> type) {
         return type.getName();
+    }
+    
+    @Override
+    public String customizeIndexName(String indexName, Class<?> type) {
+        return indexName;
     }
  
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategyFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategyFactory.java
@@ -79,7 +79,7 @@ public class TypeRepresentationStrategyFactory {
     }
 
     public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy() {
-        return strategy.getRelationshipTypeRepresentationStrategy(graphDatabaseService);
+        return strategy.getRelationshipTypeRepresentationStrategy(graphDatabaseService, indexProvider);
     }
     
     public void setIndexProvider(IndexProvider indexProvider) {
@@ -94,7 +94,7 @@ public class TypeRepresentationStrategyFactory {
             }
 
             @Override
-            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService) {
+            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService, IndexProvider indexProvider) {
                 return new NoopRelationshipTypeRepresentationStrategy();
             }
         },
@@ -105,8 +105,8 @@ public class TypeRepresentationStrategyFactory {
             }
 
             @Override
-            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService) {
-                return new IndexingRelationshipTypeRepresentationStrategy(graphDatabaseService);
+            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService, IndexProvider indexProvider) {
+                return new IndexingRelationshipTypeRepresentationStrategy(graphDatabaseService, indexProvider);
             }
         },
         Noop {
@@ -116,13 +116,13 @@ public class TypeRepresentationStrategyFactory {
             }
 
             @Override
-            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService) {
+            public RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService, IndexProvider indexProvider) {
                 return new NoopRelationshipTypeRepresentationStrategy();
             }
         };
 
         public abstract NodeTypeRepresentationStrategy getNodeTypeRepresentationStrategy(GraphDatabase graphDatabaseService, IndexProvider indexProvider);
 
-        public abstract RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService);
+        public abstract RelationshipTypeRepresentationStrategy getRelationshipTypeRepresentationStrategy(GraphDatabase graphDatabaseService, IndexProvider indexProvider);
     }
 }


### PR DESCRIPTION
- Made a IndexProvider.customizeIndexName(String indexName, Class<?>
  type). If you override the default implementation you can do something
  with the name for the hi level indices. With this change you are
  independent for the most part from upcoming changes.
- Added indexProvider related naming logic for relationships (compare
  with pull request #20 branch junisphere_unleash_IndexProvider features
  for node types)
  
  @Micha: Are you interessted in coding generic classes for IndexingNodeTypeRepresentationStrategy and IndexingRelationshipTypeRepresentationStrategy? (mostly same functionality)
