### PR TITLE
Call close() on all (obvious) IndexHits instances to avoid potential resource leaks

### DIFF
--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexingNodeTypeRepresentationStrategyTest.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexingNodeTypeRepresentationStrategyTest.java
@@ -81,6 +81,8 @@ public class IndexingNodeTypeRepresentationStrategyTest extends EntityTestBase {
 		assertEquals(node(subThing), subThingHits.getSingle());
 		assertEquals(thing.getClass().getName(), node(thing).getProperty(IndexingNodeTypeRepresentationStrategy.TYPE_PROPERTY_NAME));
 		assertEquals(subThing.getClass().getName(), node(subThing).getProperty(IndexingNodeTypeRepresentationStrategy.TYPE_PROPERTY_NAME));
+		thingHits.close();
+		subThingHits.close();
 	}
 
 	@Test

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexingRelationshipTypeRepresentationStrategyTest.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexingRelationshipTypeRepresentationStrategyTest.java
@@ -83,6 +83,7 @@ public class IndexingRelationshipTypeRepresentationStrategyTest extends EntityTe
         Relationship rel = linkHits.getSingle();
         assertEquals(rel(link), rel);
 		assertEquals(link.getClass().getName(), rel.getProperty("__type__"));
+		linkHits.close();
 	}
 
 	@Test
@@ -104,6 +105,7 @@ public class IndexingRelationshipTypeRepresentationStrategyTest extends EntityTe
 
         IndexHits<Relationship> linkHits = typesIndex.get(IndexingNodeTypeRepresentationStrategy.INDEX_KEY, link.getClass().getName());
         assertNull(linkHits.getSingle());
+        linkHits.close();
 	}
 
 	@Test

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityState.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityState.java
@@ -64,6 +64,7 @@ public class CrossStoreNodeEntityState<ENTITY extends NodeBacked> extends Defaul
             final String foreignId = createForeignId(id);
             IndexHits<Node> indexHits = getForeignIdIndex().get(FOREIGN_ID, foreignId);
             Node node = indexHits.hasNext() ? indexHits.next() : null;
+            indexHits.close();
             if (node == null) {
                 node = template.createNode();
                 persistForeignId(node, id);

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestIndexTest.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestIndexTest.java
@@ -37,6 +37,7 @@ public class RestIndexTest extends RestTestBase {
         IndexHits<Node> hits = nodeIndex().get("name", "test");
         Assert.assertEquals("index results", true, hits.hasNext());
         Assert.assertEquals(node(), hits.next());
+        hits.close();
     }
 
     @Test
@@ -45,6 +46,7 @@ public class RestIndexTest extends RestTestBase {
         IndexHits<Node> hits = nodeIndex().query("name", "tes*");
         Assert.assertEquals("index results", true, hits.hasNext());
         Assert.assertEquals(node(), hits.next());
+        hits.close();
     }
 
         @Test
@@ -53,12 +55,14 @@ public class RestIndexTest extends RestTestBase {
         IndexHits<Node> hits = nodeIndex().query("age", "age:[30 TO 40]");
         Assert.assertEquals("index results", true, hits.hasNext());
         Assert.assertEquals(node(), hits.next());
+        hits.close();
     }
 
     @Test
     public void testNotFoundInNodeIndex() {
         IndexHits<Node> hits = nodeIndex().get("foo", "bar");
         Assert.assertEquals("no index results", false, hits.hasNext());
+        hits.close();
     }
 
     @Test
@@ -68,12 +72,14 @@ public class RestIndexTest extends RestTestBase {
         IndexHits<Relationship> hits = relationshipIndex().get("name", value);
         Assert.assertEquals("index results", true, hits.hasNext());
         Assert.assertEquals(relationship(), hits.next());
+        hits.close();
     }
 
     @Test
     public void testNotFoundInRelationshipIndex() {
         IndexHits<Relationship> hits = relationshipIndex().get("foo", "bar");
         Assert.assertEquals("no index results", false, hits.hasNext());
+        hits.close();
     }
 
     @Test
@@ -86,6 +92,8 @@ public class RestIndexTest extends RestTestBase {
         nodeIndex().remove(node(), "time", value);
         IndexHits<Node> hitsAfterRemove = nodeIndex().get("time", value);
         Assert.assertEquals("not found in index results", false, hitsAfterRemove.hasNext());
+        hits.close();
+        hitsAfterRemove.close();
     }
 
     @Test
@@ -98,6 +106,8 @@ public class RestIndexTest extends RestTestBase {
         relationshipIndex().remove(relationship(), "time", value);
         IndexHits<Relationship> hitsAfterRemove = relationshipIndex().get("time", value);
         Assert.assertEquals("not found in index results", false, hitsAfterRemove.hasNext());
+        hits.close();
+        hitsAfterRemove.close();
     }
 
     private Index<Node> nodeIndex() {


### PR DESCRIPTION
Not sure if all those calls to close() are really needed, but set a good example...
