### PR TITLE
Exclude transient fields from the field accessor pointcuts

### DIFF
--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/node/Neo4jNodeBacking.aj
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/node/Neo4jNodeBacking.aj
@@ -87,13 +87,13 @@ public privileged aspect Neo4jNodeBacking { // extends AbstractTypeAnnotatingMix
 
 
     protected pointcut entityFieldGet(NodeBacked entity) :
-            get(* NodeBacked+.*) &&
+            get(!transient * NodeBacked+.*) &&
             this(entity) &&
             !get(* NodeBacked.*);
 
 
     protected pointcut entityFieldSet(NodeBacked entity, Object newVal) :
-            set(* NodeBacked+.*) &&
+            set(!transient * NodeBacked+.*) &&
             this(entity) &&
             args(newVal) &&
             !set(* NodeBacked.*);


### PR DESCRIPTION
Exclude transient fields from the field accessor pointcuts. Setting a transient field marked the entity as "dirty", without having a way to set it "undirty" again.
