### PR TITLE
Exclude transient fields

### DIFF
--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/relationship/Neo4jRelationshipBacking.aj
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/relationship/Neo4jRelationshipBacking.aj
@@ -72,13 +72,13 @@ public aspect Neo4jRelationshipBacking {
 
 
     protected pointcut entityFieldGet(RelationshipBacked entity) :
-            get(* RelationshipBacked+.*) &&
+            get(!transient * RelationshipBacked+.*) &&
             this(entity) &&
             !get(* RelationshipBacked.*);
 
 
     protected pointcut entityFieldSet(RelationshipBacked entity, Object newVal) :
-            set(* RelationshipBacked+.*) &&
+            set(!transient * RelationshipBacked+.*) &&
             this(entity) &&
             args(newVal) &&
             !set(* RelationshipBacked.*);


### PR DESCRIPTION
Exclude transient fields from the field accessor pointcuts in the Neo4jRelationshipBacking aspect as well
