### PR TITLE
DATAGRAPH-190: fixed pagination for findAll()

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
@@ -387,8 +387,10 @@ public abstract class AbstractGraphRepository<S extends PropertyContainer, T> im
 
     private PageImpl<T> extractPage(Pageable pageable, int count, int offset, Iterator<T> iterator) {
         final List<T> result = new ArrayList<T>(count);
-        int total=subList(offset, count, iterator, result);
-        if (iterator.hasNext()) total++;
+        int total = subList(offset, count, iterator, result);
+        for (; iterator.hasNext(); ++total) {
+        	iterator.next();
+        }
         return new PageImpl<T>(result, pageable, total);
     }
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/GraphRepositoryTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/GraphRepositoryTest.java
@@ -203,6 +203,13 @@ public class GraphRepositoryTest {
         Iterable<Person> teamMembers = personRepository.findSomeTeamMembers(testTeam.sdg.getName(), 0, limit, depth);
         assertThat(asCollection(teamMembers), hasItems(testTeam.michael, testTeam.david));
     }
+    
+    @Test @Transactional
+    public void testFindAllPaged() {
+    	final PageRequest page = new PageRequest(0, 1, Sort.Direction.ASC, "member.name","member.age");
+    	Page<Person> teamMemberPage1 = personRepository.findAll(page);
+    	assertEquals(3, teamMemberPage1.getTotalPages());
+    }
 
     @Test @Transactional 
     public void testFindPaged() {


### PR DESCRIPTION
The fix only works for findAll(). This doesn't do anything to both Cypher and Gremlin query engines, so tests like GraphRepositoryTest::testFindPaged() are slightly misleading: number of pages is always wrong there and this is not checked.