### PR TITLE
Update for compatibility with Cypher-DSL 1.8

### DIFF
--- a/spring-data-neo4j-parent/pom.xml
+++ b/spring-data-neo4j-parent/pom.xml
@@ -471,7 +471,7 @@
       <dependency>
           <groupId>org.neo4j</groupId>
           <artifactId>neo4j-cypher-dsl</artifactId>
-          <version>1.7</version> <!-- TODO -->
+          <version>1.8-SNAPSHOT</version> <!-- TODO -->
           <!--optional>true</optional-->
       </dependency>
       <dependency>

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
@@ -17,8 +17,8 @@
 package org.springframework.data.neo4j.repository;
 
 import org.apache.lucene.search.NumericRangeQuery;
-import org.neo4j.cypherdsl.Execute;
-import org.neo4j.cypherdsl.Skip;
+import org.neo4j.cypherdsl.grammar.Execute;
+import org.neo4j.cypherdsl.grammar.Skip;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.index.IndexHits;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CypherDslRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CypherDslRepository.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.neo4j.repository;
 
-import org.neo4j.cypherdsl.Execute;
+import org.neo4j.cypherdsl.grammar.Execute;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.neo4j.conversion.EndResult;

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/CypherDslRepositoryTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/CypherDslRepositoryTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 
 import static org.neo4j.cypherdsl.CypherQuery.*;
 import static org.neo4j.cypherdsl.querydsl.CypherQueryDSL.*;
-import org.neo4j.cypherdsl.Execute;
+import org.neo4j.cypherdsl.grammar.Execute;
 import org.neo4j.cypherdsl.querydsl.CypherQueryDSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -59,9 +59,9 @@ public class CypherDslRepositoryTest {
     @Autowired Neo4jOperations template;
     private TestTeam team;
     private Map<String,Object> peopleParams;
-    private Execute query = start(node("n", "people")).returns(identifier("n"));
-    private Execute query2 = CypherQueryDSL.start(CypherQueryDSL.node(QPerson.person, "people")).
-                                            where(QPerson.person.name.eq("Michael")).
+    private Execute query = start(nodeByParameter("n", "people")).returns(identifier("n"));
+    private Execute query2 = CypherQueryDSL.start(CypherQueryDSL.nodeByParameter(identifier(QPerson.person), "people")).
+                                            where(toBooleanExpression(QPerson.person.name.eq("Michael"))).
                                             returns(identifier(QPerson.person));
 
     @Before


### PR DESCRIPTION
This allows to use Cypher-DSL 1.8 (currently only available as -SNAPSHOT) with SDN. The failing testcases need to use Neo4J 1.8, and would work with it (as tested in another branch, which isn't ready for a pull request yet). 
