### PR TITLE
DATAGRAPH-285 adding application events for save and delete

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterSaveEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterSaveEvent.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.springframework.context.ApplicationEvent;
+
+public class AfterSaveEvent<T> extends ApplicationEvent {
+    private final T entity;
+
+    /**
+     * Create a new ApplicationEvent.
+     *
+     * @param source the component that published the event (never <code>null</code>)
+     * @param entity
+     */
+    public AfterSaveEvent(Object source, T entity) {
+        super(source);
+
+        this.entity = entity;
+    }
+
+    public T getEntity() {
+        return entity;
+    }
+}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEvent.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.springframework.context.ApplicationEvent;
+
+public class BeforeSaveEvent<T> extends ApplicationEvent {
+    private final T entity;
+
+    /**
+     * @param source the component that published the event (never <code>null</code>)
+     * @param entity the entity that is about to be saved
+     */
+    public BeforeSaveEvent(Object source, T entity) {
+        super(source);
+
+        this.entity = entity;
+    }
+
+    public T getEntity() {
+        return entity;
+    }
+}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/DeleteEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/DeleteEvent.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.springframework.context.ApplicationEvent;
+
+public class DeleteEvent<T> extends ApplicationEvent {
+    private final T entity;
+
+    public DeleteEvent(Object source, T entity) {
+        super(source);
+
+        this.entity = entity;
+    }
+
+    public T getEntity() {
+        return entity;
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterSaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterSaveEventTests.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.ImpermanentGraphDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+@NodeEntity
+class Bar {
+    @GraphId
+    Long id;
+
+    String generatedId = "no event";
+}
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@Transactional
+public class AfterSaveEventTests {
+    @Configuration
+    @EnableNeo4jRepositories
+    static class TestConfig extends Neo4jConfiguration {
+        @Bean
+        GraphDatabaseService graphDatabaseService() {
+            return new ImpermanentGraphDatabase();
+        }
+
+        @Bean
+        ApplicationListener<AfterSaveEvent> beforeSaveEventApplicationListener() {
+            return new ApplicationListener<AfterSaveEvent>() {
+                @Override
+                public void onApplicationEvent(AfterSaveEvent event) {
+                    Bar bar = (Bar) event.getEntity();
+                    bar.generatedId = "after event";
+                }
+            };
+        }
+    }
+
+    @Autowired
+    private Neo4jTemplate template;
+
+    @Test
+    public void shouldFireAfterEntityIsSaved() throws Exception {
+        Bar entity = new Bar();
+        assertThat(template.save(entity).generatedId, is("no event"));
+        assertThat(entity.generatedId, is("after event"));
+        assertThat(single(template.findAll(Bar.class)).generatedId, is("no event"));
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEventTests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.ImpermanentGraphDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+@NodeEntity
+class Foo {
+    @GraphId
+    Long id;
+
+    String generatedId = "no event";
+}
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@Transactional
+public class BeforeSaveEventTests {
+    @Configuration
+    @EnableNeo4jRepositories
+    static class TestConfig extends Neo4jConfiguration {
+        @Bean
+        GraphDatabaseService graphDatabaseService() {
+            return new ImpermanentGraphDatabase();
+        }
+
+        @Bean
+        ApplicationListener<BeforeSaveEvent> beforeSaveEventApplicationListener() {
+            return new ApplicationListener<BeforeSaveEvent>() {
+                @Override
+                public void onApplicationEvent(BeforeSaveEvent event) {
+                    Foo foo = (Foo) event.getEntity();
+                    foo.generatedId = "before event";
+                }
+            };
+        }
+    }
+
+    @Autowired
+    private Neo4jTemplate template;
+
+    @Test
+    public void shouldFireBeforeEntityIsSaved() throws Exception {
+        assertThat(template.save(new Foo()).generatedId, is("before event"));
+        assertThat(single(template.findAll(Foo.class)).generatedId, is("before event"));
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/DeleteEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/DeleteEventTests.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.ImpermanentGraphDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.data.neo4j.support.node.Neo4jHelper;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.hasItem;
+
+@NodeEntity
+class Program {
+    @GraphId
+    Long id;
+
+    String name;
+
+    Program() {
+    }
+
+    public Program(String name) {
+        this.name = name;
+    }
+}
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@Transactional
+public class DeleteEventTests {
+    @Configuration
+    @EnableNeo4jRepositories
+    static class TestConfig extends Neo4jConfiguration {
+        @Bean
+        GraphDatabaseService graphDatabaseService() {
+            return new ImpermanentGraphDatabase();
+        }
+
+        @Bean
+        ApplicationListener<DeleteEvent<Program>> deleteEventApplicationListener() {
+            return new ApplicationListener<DeleteEvent<Program>>() {
+                @Override
+                public void onApplicationEvent(DeleteEvent<Program> event) {
+                    deletions.add(event.getEntity());
+                }
+            };
+        }
+    }
+
+    @Autowired
+    Neo4jTemplate template;
+
+    @Autowired
+    GraphDatabaseService graphDatabaseService;
+
+    static final LinkedList<Program> deletions = new LinkedList<Program>();
+
+    @BeforeTransaction
+    public void beforeTransaction() {
+        Neo4jHelper.cleanDb(template);
+    }
+
+    @Before
+    public void before() {
+        deletions.clear();
+    }
+
+    @Test
+    public void shouldFireEventOnNodeDeletion() throws Exception {
+        Program sark = template.save(new Program("Sark"));
+
+        template.delete(sark);
+
+        assertThat(deletions, hasItem(sark));
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/SaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/SaveEventTests.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.lifecycle;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.ImpermanentGraphDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.annotation.*;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.data.neo4j.support.node.Neo4jHelper;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.matchers.JUnitMatchers.either;
+import static org.springframework.data.neo4j.SetHelper.asSet;
+
+@RelationshipEntity(type = "slew")
+class Slaying {
+    @GraphId
+    Long id;
+
+    @StartNode
+    FictionalCharacter slayor;
+
+    @EndNode
+    FictionalCharacter slayee;
+
+    String battle;
+
+    Slaying() {
+    }
+
+    Slaying(FictionalCharacter slayor, FictionalCharacter slayee, String battle) {
+        this.slayor = slayor;
+        this.slayee = slayee;
+        this.battle = battle;
+    }
+}
+
+
+@NodeEntity
+class FictionalCharacter {
+    @GraphId
+    Long id;
+
+    String name;
+
+    @RelatedToVia
+    Slaying slew;
+
+    @RelatedToVia(type = "slayered")
+    Set<Slaying> slayings;
+
+    FictionalCharacter() {
+    }
+
+    FictionalCharacter(String name) {
+
+        this.name = name;
+    }
+
+    void slew(FictionalCharacter fictionalCharacter, String battle) {
+        slew = new Slaying(this, fictionalCharacter, battle);
+    }
+
+    void slew(FictionalCharacter... victims) {
+        slayings = new HashSet<Slaying>();
+
+        for (FictionalCharacter victim : victims) {
+            slayings.add(new Slaying(this, victim, null));
+        }
+    }
+}
+
+@NodeEntity
+class Parent {
+    @GraphId
+    Long id;
+
+    String name;
+
+    @Fetch
+    Child eldest;
+
+    @Fetch
+    Set<Child> youngsters;
+
+    Parent() {
+
+    }
+
+    Parent(Child eldest) {
+        this.eldest = eldest;
+    }
+
+    public Parent(String name) {
+        this.name = name;
+    }
+
+    public Parent(Set<Child> youngsters) {
+        this.youngsters = youngsters;
+    }
+}
+
+@NodeEntity
+class Child {
+    @GraphId
+    Long id;
+
+    String name;
+
+    Child() {
+    }
+
+    Child(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Child child = (Child) o;
+
+        if (id != null ? !id.equals(child.id) : child.id != null) return false;
+        if (name != null ? !name.equals(child.name) : child.name != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
+}
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@Transactional
+public class SaveEventTests {
+    @Configuration
+    @EnableNeo4jRepositories
+    static class TestConfig extends Neo4jConfiguration {
+        @Bean
+        GraphDatabaseService graphDatabaseService() {
+            return new ImpermanentGraphDatabase();
+        }
+
+        @Bean
+        ApplicationListener<BeforeSaveEvent> beforeSaveEventApplicationListener() {
+            return new ApplicationListener<BeforeSaveEvent>() {
+                @Override
+                public void onApplicationEvent(BeforeSaveEvent event) {
+                    entities.add(event.getEntity());
+                }
+            };
+        }
+    }
+
+    @Autowired
+    Neo4jTemplate template;
+
+    static final LinkedList<Object> entities = new LinkedList<Object>();
+
+    @BeforeTransaction
+    public void beforeTransaction() {
+        Neo4jHelper.cleanDb(template);
+    }
+
+    @Before
+    public void before() {
+        entities.clear();
+    }
+
+    @Test
+    public void shouldFireEventForNodeEntity() throws Exception {
+        Child child = new Child();
+        template.save(child);
+
+        assertThat(entities.size(), is(1));
+        assertThat((Child) entities.get(0), is(child));
+    }
+
+    @Test
+    public void shouldFireEventForRelationshipEntity() throws Exception {
+        FictionalCharacter fingolfin = template.save(new FictionalCharacter("Fingolfin"));
+        FictionalCharacter morgoth = template.save(new FictionalCharacter("Morgoth"));
+        entities.clear();
+        Slaying slaying = new Slaying(morgoth, fingolfin, "Dagor Bragollach");
+
+        template.save(slaying);
+
+        assertThat(entities.size(), is(1));
+        assertThat(((Slaying) entities.get(0)).battle, is(equalTo("Dagor Bragollach")));
+    }
+
+    @Test
+    public void shouldFireEventForNodeEntities() throws Exception {
+        Child child1 = new Child("Huey");
+        Child child2 = new Child("Louie");
+        Child child3 = new Child("Dewey");
+        Parent parent = new Parent(asSet(child1, child2, child3));
+        template.save(parent);
+
+        assertThat(entities.size(), is(4));
+        assertThat((Parent) entities.get(0), is(parent));
+        assertThat((Child) entities.get(1), is(child1));
+        assertThat((Child) entities.get(2), is(child2));
+        assertThat((Child) entities.get(3), is(child3));
+    }
+
+    @Test
+    public void shouldFireEventForRelationshipEntities() throws Exception {
+        FictionalCharacter beleg = template.save(new FictionalCharacter("Beleg"));
+        FictionalCharacter brandir = template.save(new FictionalCharacter("Brandir"));
+        entities.clear();
+        FictionalCharacter turin = new FictionalCharacter("Túrin");
+        turin.slew(beleg, brandir);
+
+        template.save(turin);
+
+        assertThat(entities.size(), is(3));
+        assertThat(((FictionalCharacter) entities.get(0)).id, is(turin.id));
+        assertThat(((Slaying) entities.get(1)).slayee.id, is(either(equalTo(beleg.id)).or(equalTo(brandir.id))));
+        assertThat(((Slaying) entities.get(2)).slayee.id, is(either(equalTo(beleg.id)).or(equalTo(brandir.id))));
+    }
+
+    @Test
+    public void shouldFireEventForNodeEntityWhenItIsSavedIndirectly() throws Exception {
+        Child child = new Child();
+        Parent parent = new Parent(child);
+        template.save(parent);
+
+        assertThat(entities.size(), is(2));
+        assertThat((Parent) entities.get(0), is(parent));
+        assertThat((Child) entities.get(1), is(child));
+    }
+
+    @Test
+    public void shouldFireEventForRelationshipEntityWhenItIsSavedIndirectly() throws Exception {
+        FictionalCharacter fingolfin = template.save(new FictionalCharacter("Fingolfin"));
+        entities.clear();
+        FictionalCharacter morgoth = new FictionalCharacter("Morgoth");
+        morgoth.slew(fingolfin, "Dagor Bragollach");
+
+        template.save(morgoth);
+
+        assertThat(entities.size(), is(2));
+        assertThat(((FictionalCharacter) entities.get(0)).id, is(morgoth.id));
+        assertThat(((Slaying) entities.get(1)).battle, is(equalTo("Dagor Bragollach")));
+    }
+
+    @Test
+    public void shouldFireEventForUpdatedEntities() throws Exception {
+        Parent parent = template.save(new Parent("Donald Duck"));
+        entities.clear();
+        parent = template.findOne(parent.id, Parent.class);
+        parent.name = "Mickey Mouse";
+
+        template.save(parent);
+
+        assertThat(entities.size(), is(1));
+        assertThat((Parent) entities.get(0), is(parent));
+    }
+
+    @Test
+    public void shouldFireEventEvenIfEntityHasNotBeenUpdated() throws Exception {
+        Parent parent = template.save(new Parent("Uncle Scrooge"));
+        entities.clear();
+        parent = template.findOne(parent.id, Parent.class);
+
+        template.save(parent);
+
+        assertThat(entities.size(), is(1));
+        assertThat((Parent) entities.get(0), is(parent));
+    }
+
+    /**
+     * because we do not save recursively, the child entity isn't saved and thus no event is fired
+     * <p/>
+     * so this is basically saying, "we do not save recursively"
+     * <p/>
+     * is that different in the advanced mapping mode case?
+     */
+    @Test
+    public void shouldNotFireEventForUpdatedRelatedEntities() throws Exception {
+        Parent parent = template.save(new Parent(new Child("Daisy Duck")));
+        entities.clear();
+        parent = template.findOne(parent.id, Parent.class);
+        parent.eldest.name = "Minnie Mouse";
+
+        template.save(parent);
+
+        assertThat(entities.size(), is(1));
+        assertThat((Parent) entities.get(0), is(parent));
+    }
+}

--- a/src/docbkx/reference/programming-model/template.xml
+++ b/src/docbkx/reference/programming-model/template.xml
@@ -107,4 +107,35 @@
 	        via the graph database.  
 	    </para>
     </section>
+    <section>
+        <title>Lifecycle Events</title>
+        <para>Neo4j Template offers basic lifecycle events via Spring's event mechanism using ApplicationListener and ApplicationEvent. The following hooks are available in the form of types of application event:</para>
+        <itemizedlist>
+            <listitem><para>BeforeSaveEvent</para></listitem>
+            <listitem><para>AfterSaveEvent</para></listitem>
+            <listitem><para>DeleteEvent - after the event has been deleted</para></listitem>
+        </itemizedlist>
+        <para>The following example demostrates how to register a listener and perform behaviour across types of entities</para>
+        <example>
+            <title>Timestamping Entities</title>
+            <programlisting language="java">
+                <![CDATA[@Configuration
+    @EnableNeo4jRepositories
+    public class ApplicationConfig extends Neo4jConfiguration {
+        ...
+        @Bean
+        ApplicationListener<BeforeSaveEvent> beforeSaveEventApplicationListener() {
+            return new ApplicationListener<BeforeSaveEvent>() {
+                @Override
+                public void onApplicationEvent(BeforeSaveEvent event) {
+                    Auditable entity = (Auditable) event.getEntity();
+                    entity.setLastUpdated(new Date());
+                }
+            };
+        }
+        ...]]>
+            </programlisting>
+        </example>
+        <para>Changes made to entities in the before-save event handler are reflected in the stored entity - after-save ones are not.</para>
+    </section>
 </section>


### PR DESCRIPTION
This offers application events for the entity-lifecycle. 3 events: before save, after save, and after delete. This should match 2 use cases: 1) generating user-defined ids for entities in a cross-cutting manner, and 2) auditing create/update/delete of entities - see https://jira.springsource.org/browse/DATAGRAPH-285
