### PR TITLE
Fix for DATAGRAPH-299 - Inconsistent Neo4j REST version

### DIFF
--- a/spring-data-neo4j-rest/pom.xml
+++ b/spring-data-neo4j-rest/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-rest-graphdb</artifactId>
-            <version>1.8.RC2</version>
+            <version>1.8.RC1</version>
             <exclusions>
                <exclusion>
                    <groupId>org.neo4j</groupId>


### PR DESCRIPTION
This addresses Issue #85 (DATAGRAPH-299 - Inconsistent Neo4j REST version).
https://jira.springsource.org/browse/DATAGRAPH-299
## 

Fixed pom.xml for spring-data-neo4j-rest package to point to correct neo4j version
