### PR TITLE
Javadoc improvements

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphId.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphId.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation fot the field that virtually provides the Id of the graph entity (node or relationship), type of the field should be long
+ * Annotation for the field that virtually provides the Id of the graph entity (node or relationship), type of the field should be long
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD,ElementType.METHOD})

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/NodeEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/NodeEntity.java
@@ -21,7 +21,7 @@ import org.springframework.data.annotation.Persistent;
 import java.lang.annotation.*;
 
 /**
- * Annotation to declare an Pojo-Entity as graph backed.
+ * Annotation to declare an POJO-entity as graph-backed.
  * 
  * @author Michael Hunger
  * @since 27.08.2010

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedTo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedTo.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation for {@link org.springframework.data.neo4j.annotation.NodeEntity} fields that relate to other entities via
  * relationships. Works for one-to-one and one-to-many relationships. It is optionally possible to define the relationship type,
- * relationship direction and target class (required for one-many-relationships).
+ * relationship direction and target class (required for one-to-many relationships).
  *
  * Collection based one-to-many relationships return managed collections that reflect addition and removal to the underlying relationships.
  *

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedToVia.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedToVia.java
@@ -26,9 +26,10 @@ import org.springframework.data.annotation.Reference;
 
 
 /**
- * Annotation for {@link org.springframework.data.neo4j.annotation.NodeEntity} fields that relate to other entities via
- * relationships. The fields represent read only iterators that provide the relationship-entities
- * {@link RelationshipEntity} of the relationships. The iterator reflects the underlying relationships.
+ * Annotation for {@link org.springframework.data.neo4j.annotation.RelationshipEntity} fields
+ * by which this entity relates to other entites. The fields represent read-only iterators that
+ * provide the relationship-entities {@link RelationshipEntity} of the relationships.
+ * The iterator reflects the underlying relationships.
  *
  * <pre>
  * &#64;RelatedToVia([type=&quot;roles&quot;], elementClass=Role.class)

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipEntity.java
@@ -21,10 +21,10 @@ import org.springframework.data.annotation.Persistent;
 import java.lang.annotation.*;
 
 /**
- * Annotation to declare a Pojo-Entity as graph backed relationship entity.
+ * Annotation to declare a POJO-entity as graph-backed relationship entity.
  * It is used by the Neo4jRelationshipBacking aspect to add field advices as well as the RelationshipBacked interface.
  *
- * Relationship entities cannot be instantiated directly. The will be provided by relationship fields and the
+ * Relationship entities cannot be instantiated directly. They will be provided by relationship fields and the
  * methods relatedTo and getRelationshipTo introduced to the node entities.
  *
  * @author Michael Hunger


### PR DESCRIPTION
I gotta admit at first I struggled a bit to understand what the _Via_ in _@RelatedToVia_ stood for.  The javadoc for _@RelatedTo_ and _@RelatedToVia_ read a lot alike. 
Maybe rephrasing _@RelatedToVia_ could make it clearer, e.g. instead of

_Annotation for {@link org.springframework.data.neo4j.annotation.RelationshipEntity} fields that relate to other entities via  relationships._

have it say

_Annotation for {@link org.springframework.data.neo4j.annotation.RelationshipEntity} fields by which this entity relates to other entities._

Edit: squashed all commits into one and added the suggested rewording.
