### PR TITLE
DATAGRAPH-323 total elements count fix

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
@@ -440,7 +440,7 @@ public abstract class AbstractGraphRepository<S extends PropertyContainer, T> im
         final Execute limitedQuery = ((Skip)query).skip(page.getOffset()).limit(page.getPageSize());
         QueryEngine<Object> engine = template.queryEngineFor(QueryType.Cypher);
         Page result = engine.query(limitedQuery.toString(), params).to(clazz).as(Page.class);
-        if (countQuery==null || result.getNumberOfElements() < page.getPageSize()) {
+        if (countQuery == null) {
             return result; 
         }
         Long count = engine.query(countQuery.toString(), params).to(Long.class).singleOrNull();


### PR DESCRIPTION
The count query should always be executed, even when the returned element number is smaller than the page size.

E.g. imagine 3 results when the page size is 2
- The first page would return 2 elements and a total element count of 3 => OK
- The second page would return 1 element and a total element count of 1 => should also be 3!

Does this seem correct or am I missing something conceptually?
