### PR TITLE
Adds a call to `setMappingContext` so that `spring-data-rest` doesn't explode when asking the metadata classes for a `PersistentEntity` instance.

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactoryBean.java
@@ -64,6 +64,7 @@ TransactionalRepositoryFactoryBeanSupport<R, T, Long> {
             context.initialize();
             this.neo4jMappingContext = context;
         }
+	      setMappingContext(neo4jMappingContext);
 
         super.afterPropertiesSet();
     }


### PR DESCRIPTION
#103 Adds a call to `setMappingContext` so that `spring-data-rest` doesn't explode when asking the metadata classes for a `PersistentEntity` instance.
