### PR TITLE
DynamicProperties to be serializable.

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicProperties.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.neo4j.fieldaccess;
 
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Map;
 
@@ -44,7 +45,7 @@ import org.springframework.data.neo4j.fieldaccess.DynamicPropertiesFieldAccessor
  * "personalProperties-City" => "Zuerich"
  * </pre>
  */
-public interface DynamicProperties {
+public interface DynamicProperties extends Serializable {
 
     /**
      * @param key

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesContainer.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesContainer.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 public class DynamicPropertiesContainer implements DynamicProperties {
 
+	private static final long serialVersionUID = -1096894554562186463L;
+	
 	private final Map<String, Object> map = new HashMap<String, Object>();
 	
 	public DynamicPropertiesContainer() {

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedPrefixedDynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedPrefixedDynamicProperties.java
@@ -29,7 +29,10 @@ import java.util.Map;
  * deleted.
  */
 public class ManagedPrefixedDynamicProperties extends PrefixedDynamicProperties {
-    private final Object entity;
+	
+	private static final long serialVersionUID = -2624815323448599814L;
+	
+	private final Object entity;
     private final Neo4jTemplate template;
     private final FieldAccessor fieldAccessor;
     private final Neo4jPersistentProperty property;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicProperties.java
@@ -28,7 +28,10 @@ import java.util.Set;
  * The methods *PrefixedProperty() allow to access the prefixed property key/values pairs directly.
  */
 public class PrefixedDynamicProperties implements DynamicProperties {
-    private final Map<String, Object> map;
+	
+	private static final long serialVersionUID = 2957585039599536816L;
+	
+	private final Map<String, Object> map;
     protected final String prefix;
 
     /**


### PR DESCRIPTION
DynamicProperties are in general properties of NodeEntities or -relationships, which are supposed to be serializable(?!). Using DynamicProperties makes a NodeElement having a field which itself is not serializable. This patch fixes this issue.

I have recognized this suggestion for improvement because of findbugs integration in my project (which uses spring-data-neo4j) ([ef] is of type DynamicProperties):

  Class [ab.cd] defines non-transient non-serializable instance field [ef]

  This Serializable class defines a non-primitive instance field which is neither transient, Serializable, or java.lang.Object, and does not appear to implement the Externalizable interface or the readObject() and writeObject() methods.  Objects of this class will not be deserialized correctly if a non-Serializable object is stored in this field.
