### PR TITLE
DATAGRAPH-399 - Add support for nested repositories.

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jRepositories.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2011 the original author or authors.
+ * Copyright 2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
  * Annotation to enable Neo4j repositories.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -103,4 +104,10 @@ public @interface EnableNeo4jRepositories {
 	 * {@link Neo4jRepositoryConfigurationExtension#DEFAULT_NEO4J_TEMPLATE_REF}.
 	 */
 	String neo4jTemplateRef() default Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_REF;
+
+	/**
+	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the
+	 * repositories infrastructure.
+	 */
+	boolean considerNestedRepositories() default false;
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesJavaConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesJavaConfigTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.repository.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.data.neo4j.repository.PersonRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for JavaConfig configuration with nested repositories.
+ * 
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class NestedNeo4jRepositoriesJavaConfigTests {
+
+	@Configuration
+	@EnableNeo4jRepositories(basePackageClasses = PersonRepository.class, considerNestedRepositories = true)
+	static class Config extends Neo4jConfiguration {
+
+		@Bean
+		public GraphDatabaseService graphDatabaseService() {
+			return new TestGraphDatabaseFactory().newImpermanentDatabase();
+		}
+	}
+
+	@Autowired NestedUserRepository nestedUserRepository;
+
+	/**
+	 * @see DATAGRAPH-399
+	 */
+	@Test
+	public void shouldSupportNestedRepositories() {
+		assertThat(nestedUserRepository, is(notNullValue()));
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesNamspaceConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesNamspaceConfigTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.repository.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for repository namespace configuration with nested repositories.
+ * 
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "DataGraphNamespaceHandlerTests-nested-repositories-context.xml")
+public class NestedNeo4jRepositoriesNamspaceConfigTests {
+
+	@Autowired NestedUserRepository fooRepository;
+
+	/**
+	 * @see DATAGRAPH-399
+	 */
+	@Test
+	public void shouldFindNestedRepository() {
+		assertThat(fooRepository, is(notNullValue()));
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ClassWithNestedRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ClassWithNestedRepository.java
@@ -1,0 +1,13 @@
+package org.springframework.data.neo4j.repository;
+
+import org.springframework.data.neo4j.model.Person;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @see DATAGRAPH-399
+ * @author Thomas Darimont
+ */
+public class ClassWithNestedRepository {
+
+	public static interface NestedUserRepository extends Repository<Person, Integer> {}
+}

--- a/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerTests-nested-repositories-context.xml
+++ b/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerTests-nested-repositories-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+
+    <context:annotation-config/>
+    <neo4j:config storeDirectory="target/config-test"/>
+    <bean id="config" class="org.springframework.data.neo4j.config.DataGraphNamespaceHandlerTests$Config"/>
+
+    <neo4j:repositories base-package="org.springframework.data.neo4j.repository" consider-nested-repositories="true"/>
+</beans>


### PR DESCRIPTION
Support for considering nested repository interfaces can now be configured on the EnableNeo4jRepositories annotation via the considerNestedRepositories property. Previously nested repository definitions were ignored by the repositories infrastructure.

This depends on DATACMNS-90.
