### PR TITLE
DATAGRAPH-413: ConcurrentModificationException with Advanced Mode and implicit tx

### DIFF
--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ModificationOutsideOfTransactionTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ModificationOutsideOfTransactionTests.java
@@ -179,6 +179,27 @@ public class ModificationOutsideOfTransactionTests extends EntityTestBase {
     }
 
     @Test
+    public void testSetPropertyOutsideTransactionCanBePersistedThereafter()
+    {
+        Person p = persistedPerson( "Michael", 35 );
+        p.setAge( 25 );
+        assertEquals(25, p.getAge());
+
+        try (Transaction tx = neo4jTemplate.getGraphDatabase().beginTx()) {
+            assertEquals( 35, nodeFor( p ).getProperty("age") );
+            tx.success();
+        }
+
+        p.persist();
+
+        try (Transaction tx = neo4jTemplate.getGraphDatabase().beginTx()) {
+            assertEquals( 25, nodeFor( p ).getProperty("age") );
+            tx.success();
+        }
+
+    }
+
+    @Test
     public void shouldWorkWithUninitializedCollectionFieldWithoutUnderlyingState() {
         Group group = new Group();
         Collection<Person> people = group.getPersons();


### PR DESCRIPTION
@jexp Came across this issue whilst looking into something else and have a fix which works via this PR. This fix is specifically for the Advanced mapping mode (AspectJ), however want to check if there are any implications for creating a Transaction on the fly within the detached entity on the simple mode which I am unaware of? All tests still pass.
