### PR TITLE
DATAGRAPH-445: Added failOnDuplicate property to @Indexed(unique=true)

### DIFF
--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Account1Repository.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Account1Repository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.neo4j.aspects;
+
+import org.springframework.data.neo4j.aspects.support.domain.Account1;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+/**
+ * @author Nicki Watt
+ * @since 06-04-2014
+ */
+public interface Account1Repository extends GraphRepository<Account1> {
+}

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Account2Repository.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Account2Repository.java
@@ -1,0 +1,12 @@
+package org.springframework.data.neo4j.aspects;
+
+
+import org.springframework.data.neo4j.aspects.support.domain.Account2;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+/**
+ * @author Nicki Watt
+ * @since 06-04-2014
+ */
+public interface Account2Repository extends GraphRepository<Account2> {
+}

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityTestBase.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityTestBase.java
@@ -24,9 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.data.neo4j.aspects.FriendshipRepository;
-import org.springframework.data.neo4j.aspects.GroupRepository;
-import org.springframework.data.neo4j.aspects.PersonRepository;
+import org.springframework.data.neo4j.aspects.*;
 import org.springframework.data.neo4j.support.Neo4jTemplate;
 import org.springframework.data.neo4j.support.mapping.StoredEntityType;
 import org.springframework.data.neo4j.support.node.Neo4jHelper;
@@ -48,6 +46,8 @@ public class EntityTestBase {
 
     @Autowired protected GraphDatabaseService graphDatabaseService;
 
+    @Autowired protected Account1Repository account1Repository;
+    @Autowired protected Account2Repository account2Repository;
     @Autowired protected PersonRepository personRepository;
     @Autowired protected GroupRepository groupRepository;
     @Autowired protected FriendshipRepository friendshipRepository;

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account1.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account1.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.aspects.support.domain;
+
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.Indexed;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+
+
+@NodeEntity
+public class Account1 {
+
+    private static final long serialVersionUID = 1L;
+
+    @Indexed(unique = true, failOnDuplicate = false)
+	private String accountNumber;
+
+    private String name;
+
+    public Account1() {
+    }
+
+    public Account1(String accountNumber, String name) {
+        this.accountNumber = accountNumber;
+        this.name = name;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account2.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account2.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.aspects.support.domain;
+
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.Indexed;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+
+
+@NodeEntity
+public class Account2 {
+
+    private static final long serialVersionUID = 1L;
+
+    @GraphId
+	private Long graphId;
+
+    @Indexed(unique = true, failOnDuplicate = true)
+	private String accountNumber;
+
+    private String name;
+
+    public Account2() {
+    }
+
+    public Account2(String accountNumber, String name) {
+        this.accountNumber = accountNumber;
+        this.name = name;
+    }
+
+    public Long getGraphId() {
+        return graphId;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Account2 person = (Account2) o;
+        if (graphId == null) return super.equals(o);
+        return graphId.equals(person.graphId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return graphId != null ? graphId.hashCode() : super.hashCode();
+    }
+
+}

--- a/spring-data-neo4j-aspects/src/test/resources/org/springframework/data/neo4j/aspects/support/Neo4jGraphPersistenceTests-context.xml
+++ b/spring-data-neo4j-aspects/src/test/resources/org/springframework/data/neo4j/aspects/support/Neo4jGraphPersistenceTests-context.xml
@@ -115,6 +115,8 @@
     <bean id="mappingContext" class="org.springframework.data.neo4j.support.mapping.Neo4jMappingContext">
         <property name="initialEntitySet">
             <set>
+                <value>org.springframework.data.neo4j.aspects.support.domain.Account1</value>
+                <value>org.springframework.data.neo4j.aspects.support.domain.Account2</value>
                 <value>org.springframework.data.neo4j.aspects.Developer</value>
                 <value>org.springframework.data.neo4j.aspects.Person</value>
                 <value>org.springframework.data.neo4j.aspects.Group</value>
@@ -167,6 +169,14 @@
                 </constructor-arg>
             </bean>
         </property>
+    </bean>
+    <bean id="account2Repository" class="org.springframework.data.neo4j.repository.GraphRepositoryFactoryBean">
+        <property name="repositoryInterface" value="org.springframework.data.neo4j.aspects.Account2Repository" />
+        <property name="neo4jTemplate" ref="template"/>
+    </bean>
+    <bean id="account1Repository" class="org.springframework.data.neo4j.repository.GraphRepositoryFactoryBean">
+        <property name="repositoryInterface" value="org.springframework.data.neo4j.aspects.Account1Repository" />
+        <property name="neo4jTemplate" ref="template"/>
     </bean>
     <bean id="groupRepository" class="org.springframework.data.neo4j.repository.GraphRepositoryFactoryBean">
         <property name="repositoryInterface" value="org.springframework.data.neo4j.aspects.GroupRepository" />

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestGraphRepositoryTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestGraphRepositoryTests.java
@@ -17,12 +17,11 @@
 package org.springframework.data.neo4j.rest.integration;
 
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.data.neo4j.aspects.support.GraphRepositoryTests;
 import org.springframework.data.neo4j.rest.support.RestTestBase;
-import org.springframework.data.neo4j.support.node.Neo4jHelper;
 import org.springframework.test.context.CleanContextCacheTestExecutionListener;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -53,7 +52,13 @@ public class RestGraphRepositoryTests extends GraphRepositoryTests {
     @AfterClass
     public static void shutdownDb() {
         RestTestBase.shutdownDb();
+    }
 
+    // TODO - Change REST to have a better (more descriptive)
+    //        exception thrown when duplicate violations occur
+    @Test(expected = IllegalStateException.class)
+    public void testSaveWhenFailOnDuplicateSetToTrue() {
+          super.testSaveWhenFailOnDuplicateSetToTrue();
     }
 
 }

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityTests.java
@@ -16,11 +16,9 @@
 
 package org.springframework.data.neo4j.rest.integration;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.*;
 import org.junit.runner.RunWith;
+import org.neo4j.graphdb.ConstraintViolationException;
 import org.springframework.data.neo4j.aspects.support.NodeEntityTests;
 import org.springframework.data.neo4j.rest.support.RestTestBase;
 import org.springframework.test.context.CleanContextCacheTestExecutionListener;
@@ -59,5 +57,12 @@ public class RestNodeEntityTests extends NodeEntityTests {
     @Ignore
     public void testSetShortProperty() {
         // super.testSetShortProperty();
+    }
+
+    // TODO - Change REST to have a better (more descriptive)
+    //        exception thrown when duplicate violations occur
+    @Test(expected = IllegalStateException.class)
+    public void testDefaultFailOnDuplicateSetToTrueCausesExceptionWhenAnotherDuplicateEntityCreated() {
+        super.testDefaultFailOnDuplicateSetToTrueCausesExceptionWhenAnotherDuplicateEntityCreated();
     }
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Indexed.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Indexed.java
@@ -39,9 +39,21 @@ public @interface Indexed {
 
     String fieldName() default "";
 
+    /**
+     * Indicates whether to apply a unique constraint on this property, defaults to false.
+     */
     boolean unique() default false;
 
     boolean numeric() default false;
+
+    /**
+     * Only applicable when indexType is LABEL and unique=true, indicates how to handle attempts to save
+     * entities where this unique property already exists, defaults to false. When set to false, default entity
+     * saving behaviour resorts to merge type behaviour whilst when set to true, results in an exception being
+     * thrown when attempting to save another entity where the same unique indexed property already exists under
+     * a different node id.
+     */
+    boolean failOnDuplicate() default false;
 
     // FQN is a fix for javac compiler bug http://bugs.sun.com/view_bug.do?bug_id=6512707
     org.springframework.data.neo4j.annotation.Indexed.Level level() default org.springframework.data.neo4j.annotation.Indexed.Level.CLASS;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/IndexInfo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/IndexInfo.java
@@ -31,6 +31,7 @@ public class IndexInfo {
     private final Indexed.Level level;
     private String indexKey;
     private final boolean unique;
+    private final boolean failOnDuplicate;
     private boolean numeric;
     private Indexed annotation;
     private Neo4jPersistentProperty property;
@@ -43,6 +44,7 @@ public class IndexInfo {
         fieldName = annotation.fieldName();
         this.indexKey = fieldName.isEmpty() ? property.getNeo4jPropertyName() : fieldName;
         unique = annotation.unique();
+        failOnDuplicate = annotation.failOnDuplicate();
         level = annotation.level();
         numeric = annotation.numeric();
     }
@@ -112,6 +114,10 @@ public class IndexInfo {
 
     public boolean isUnique() {
         return unique;
+    }
+
+    public boolean isFailOnDuplicate() {
+        return failOnDuplicate;
     }
 
     public boolean isNumeric() {

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SchemaIndexRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SchemaIndexRepository.java
@@ -26,9 +26,22 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface SchemaIndexRepository<T> {
 
+    /**
+     * Finds an entity based on the provided schema indexed property value if one exists.
+     * @param property The name of the schema indexed property
+     * @param value The value of the schema indexed property
+     * @return The single entity associated with this property value setting, or
+     *         null if one does not exist.
+     */
     @Transactional
     T findBySchemaPropertyValue(String property, Object value);
 
+    /**
+     * Finds all entities which have a schema indexed property set to specified value.
+     * @param property The name of the schema indexed property
+     * @param value The value of the schema indexed property
+     * @return A result of all entities which match indexed property value.
+     */
     @Transactional
     Result<T> findAllBySchemaPropertyValue(String property, Object value);
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityStateHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityStateHandler.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.neo4j.helpers.collection.MapUtil.map;
+
 /**
  * @author mh
  * @since 02.10.11
@@ -151,7 +153,9 @@ public class EntityStateHandler {
         final Object value = uniqueProperty.getValueFromEntity(entity, MappingPolicy.MAP_FIELD_DIRECT_POLICY);
         if (value==null) throw new MappingException("Error creating "+uniqueProperty.getOwner().getName()+" with "+entity+" unique property "+uniqueProperty.getName()+" has null value");
         if (indexInfo.isLabelBased()) {
-            return graphDatabase.merge(indexInfo.getIndexName(), indexInfo.getIndexKey(), value, Collections.<String,Object>emptyMap(), persistentEntity.getAllLabels());
+            return (indexInfo.isFailOnDuplicate())
+                    ? graphDatabase.createNode(map(uniqueProperty.getName(),value),persistentEntity.getAllLabels())
+                    : graphDatabase.merge(indexInfo.getIndexName(), indexInfo.getIndexKey(), value, Collections.<String,Object>emptyMap(), persistentEntity.getAllLabels());
         } else {
             return graphDatabase.getOrCreateNode(indexInfo.getIndexName(), indexInfo.getIndexKey(), value, Collections.<String,Object>emptyMap(),persistentEntity.getAllLabels());
         }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account1.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account1.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.model;
+
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.Indexed;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+
+
+@NodeEntity
+public class Account1 {
+
+    private static final long serialVersionUID = 1L;
+
+    @GraphId
+	private Long graphId;
+
+    @Indexed(unique = true, failOnDuplicate = false)
+	private String accountNumber;
+
+    private String name;
+
+    public Account1() {
+    }
+
+    public Account1(String accountNumber, String name) {
+        this.accountNumber = accountNumber;
+        this.name = name;
+    }
+
+    public Long getGraphId() {
+        return graphId;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Account1 person = (Account1) o;
+        if (graphId == null) return super.equals(o);
+        return graphId.equals(person.graphId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return graphId != null ? graphId.hashCode() : super.hashCode();
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account2.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account2.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.model;
+
+import org.springframework.data.neo4j.annotation.GraphId;
+import org.springframework.data.neo4j.annotation.Indexed;
+import org.springframework.data.neo4j.annotation.NodeEntity;
+
+
+@NodeEntity
+public class Account2 {
+
+    private static final long serialVersionUID = 1L;
+
+    @GraphId
+	private Long graphId;
+
+    @Indexed(unique = true, failOnDuplicate = true)
+	private String accountNumber;
+
+    private String name;
+
+    public Account2() {
+    }
+
+    public Account2(String accountNumber, String name) {
+        this.accountNumber = accountNumber;
+        this.name = name;
+    }
+
+    public Long getGraphId() {
+        return graphId;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Account2 person = (Account2) o;
+        if (graphId == null) return super.equals(o);
+        return graphId.equals(person.graphId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return graphId != null ? graphId.hashCode() : super.hashCode();
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/Account1Repository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/Account1Repository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.neo4j.repositories;
+
+import org.springframework.data.neo4j.model.Account1;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+/**
+ * @author Nicki Watt
+ * @since 06-04-2014
+ */
+public interface Account1Repository extends GraphRepository<Account1> {
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/Account2Repository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/Account2Repository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.neo4j.repositories;
+
+import org.springframework.data.neo4j.model.Account2;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+/**
+ * @author Nicki Watt
+ * @since 06-04-2014
+ */
+public interface Account2Repository extends GraphRepository<Account2> {
+}


### PR DESCRIPTION
@jexp addition of failOnDuplicate to @Indexed. At present, this allows the raw ConstraintViolationException to propagate up, do we want to change this to throw something more friendly? Also the Rest based calls work slightly differently and land up using an IllegalStateException to indicate duplicate errors. Let me know if you want me to change these. 
