### PR TITLE
DATAGRAPH-458 & DATAGRAPH-460 : Changes for Spring 4.X compatibility

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/Neo4jConversionServiceFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/Neo4jConversionServiceFactoryBean.java
@@ -26,6 +26,7 @@ import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Shape;
 import org.springframework.data.neo4j.repository.GeoConverter;
+import org.springframework.data.neo4j.support.conversion.*;
 
 import java.util.Date;
 
@@ -52,6 +53,11 @@ public class Neo4jConversionServiceFactoryBean implements FactoryBean<Conversion
             registry.addConverter(new PointToStringConverter());
             registry.addConverter(new StringToPointConverter());
             registry.addConverterFactory(new StringToEnumConverterFactory());
+
+            // By default add in an older version of the ObjectToObjectConverter
+            // which provides backwards compatibility for Spring 4.X users
+            // DATAGRAPH-458
+            registry.addConverter(new Spring3ObjectToObjectConverter());
         } else {
             throw new IllegalArgumentException("conversionservice is no ConverterRegistry:" + service);
         }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/Spring3ObjectToObjectConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/Spring3ObjectToObjectConverter.java
@@ -1,0 +1,102 @@
+package org.springframework.data.neo4j.support.conversion;
+
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * This class exists (possibly only as an interim measure) to re-introduce some
+ * previously lost functionality as a result of moving from Spring 3.2.X - > 4.X,
+ * specifically providing the ability to be backwards compatible with regards
+ * to the Object -> String conversion scenario. This functionality changed in
+ * Spring 4.X and there is current debate as to whether this is a regression
+ * or intended behaviour. For more information, please
+ * see https://jira.spring.io/browse/SPR-11693, however in the interim this
+ * class will provide the original functionality so that when used in a Spring4
+ * context, the functionality should still work.
+ *
+ * This is basically a copy of the older Spring 3.2.8
+ * {@link org.springframework.core.convert.support.ObjectToObjectConverter} class.
+ *
+ */
+public final class Spring3ObjectToObjectConverter implements ConditionalGenericConverter {
+
+    public Set<ConvertiblePair> getConvertibleTypes() {
+        return Collections.singleton(new ConvertiblePair(Object.class, Object.class));
+    }
+
+    public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+        if (sourceType.getType().equals(targetType.getType())) {
+            // no conversion required
+            return false;
+        }
+        return hasValueOfMethodOrConstructor(targetType.getType(), sourceType.getType());
+    }
+
+    public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+        if (source == null) {
+            return null;
+        }
+        Class<?> sourceClass = sourceType.getType();
+        Class<?> targetClass = targetType.getType();
+        Method method = getValueOfMethodOn(targetClass, sourceClass);
+        try {
+            if (method != null) {
+                ReflectionUtils.makeAccessible(method);
+                return method.invoke(null, source);
+            }
+            else {
+                Constructor<?> constructor = getConstructor(targetClass, sourceClass);
+                if (constructor != null) {
+                    return constructor.newInstance(source);
+                }
+            }
+        }
+        catch (InvocationTargetException ex) {
+            throw new ConversionFailedException(sourceType, targetType, source, ex.getTargetException());
+        }
+        catch (Throwable ex) {
+            throw new ConversionFailedException(sourceType, targetType, source, ex);
+        }
+        throw new IllegalStateException("No static valueOf(" + sourceClass.getName() +
+                ") method or Constructor(" + sourceClass.getName() + ") exists on " + targetClass.getName());
+    }
+
+    static boolean hasValueOfMethodOrConstructor(Class<?> clazz, Class<?> sourceParameterType) {
+        return getValueOfMethodOn(clazz, sourceParameterType) != null || getConstructor(clazz, sourceParameterType) != null;
+    }
+
+    private static Method getValueOfMethodOn(Class<?> clazz, Class<?> sourceParameterType) {
+        return ClassUtils.getStaticMethod(clazz, "valueOf", sourceParameterType);
+    }
+
+    private static Constructor<?> getConstructor(Class<?> clazz, Class<?> sourceParameterType) {
+        return ClassUtils.getConstructorIfAvailable(clazz, sourceParameterType);
+    }
+
+}
+

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/AuditingIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/AuditingIntegrationTests.java
@@ -15,20 +15,18 @@
  */
 package org.springframework.data.neo4j.config;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-
 import org.joda.time.DateTime;
 import org.junit.Test;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.neo4j.annotation.GraphId;
 import org.springframework.data.neo4j.annotation.NodeEntity;
 import org.springframework.data.neo4j.lifecycle.BeforeSaveEvent;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * Integration tests for Neo4j auditing.

--- a/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/auditing-bean.xml
+++ b/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/auditing-bean.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
+	   xsi:schemaLocation="
+	    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j-3.0.xsd">
+
+    <context:annotation-config/>
 
 	<neo4j:config graphDatabaseService="graphDatabaseService"
 		base-package="org.springframework.data.neo4j.config" />

--- a/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/auditing.xml
+++ b/spring-data-neo4j/src/test/resources/org/springframework/data/neo4j/config/auditing.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   	   xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
+	   xsi:schemaLocation="
+	    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j-3.0.xsd">
+
+    <context:annotation-config/>
 
     <neo4j:config graphDatabaseService="graphDatabaseService" base-package="org.springframework.data.neo4j.config" />
 


### PR DESCRIPTION
@jexp Changes to make SDN Spring 4.0 compatible. Note, as the Jira regarding the regression introduced in Spring 4 via the ObjectToObjectConverter and FallbackObjectToSpringConverter is still outstanding (https://jira.spring.io/browse/SPR-11693), I added the Spring 3.2 version of the functionality back in (in addition to Spring 4 version) via the class Spring3ObjectToObjectConverter. Should Spring get updated we can remove this but for now this will allow both Spring 3 and 4 functionality to co-exist in a backwards compatible manner. 
