### PR TITLE
Update DelegatingGraphDatabase.java

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DelegatingGraphDatabase.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DelegatingGraphDatabase.java
@@ -63,6 +63,9 @@ public class DelegatingGraphDatabase implements GraphDatabase {
     private ResultConverter resultConverter;
     private volatile CypherQueryEngineImpl cypherQueryEngine;
 
+    public DelegatingGraphDatabase() {
+    }
+    
     public DelegatingGraphDatabase(final GraphDatabaseService delegate) {
         this(delegate,null);
     }


### PR DESCRIPTION
Empty constructor needed by Java EE CDI to treat this class as a bean
