### PR TITLE
#199: Made springdataneo4j.gradle compatible to Gradle 2.x

### DIFF
--- a/build/gradle/springdataneo4j.gradle
+++ b/build/gradle/springdataneo4j.gradle
@@ -15,18 +15,18 @@ dependencies{
 
 task compileJava(overwrite: true, description: 'Compiles AspectJ Source', type: Ajc) {
     dependsOn processResources
-    sourceSet = sourceSets.main
+    def sourceSet = sourceSets.main
     inputs.files(sourceSets.main.java.srcDirs)
-    outputs.dir(sourceSet.classesDir)
-    aspectPath = configurations.aspectpath
+    outputs.dir(sourceSet.output)
+    def aspectPath = configurations.aspectpath
 }
 
 task compileTestJava(overwrite: true, description: 'Compiles AspectJ Test Source', type: Ajc) {
     dependsOn processTestResources, compileJava, jar
-    sourceSet = sourceSets.test
+    def sourceSet = sourceSets.test
     inputs.files(sourceSets.test.java.srcDirs)
-    outputs.dir(sourceSet.classesDir)
-    aspectPath = files(configurations.aspectpath, jar.archivePath)
+    outputs.dir(sourceSet.output)
+    def aspectPath = files(configurations.aspectpath, jar.archivePath)
 }
 
 class Ajc extends DefaultTask {


### PR DESCRIPTION
Property "classesDir" was deprecated and has been removed from gradle. Replaced it with "output".
New definitions need to be prepended by "def".
