### PR TITLE
DATAGRAPH-577 - Support @NodeEntity and @Transient on interfaces.

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/entityaccess/EntityFactory.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/entityaccess/EntityFactory.java
@@ -86,7 +86,7 @@ public class EntityFactory {
             if (classInfo != null) {
                 taxaLeafClass.put(Arrays.toString(taxa), fqn=classInfo.name());
             } else {
-                throw new MappingException("Could not resolve a single base class from " + taxa);
+                throw new MappingException("Could not resolve a single base class from " + Arrays.toString(taxa));
             }
         }
         return fqn;

--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/MappingContext.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/MappingContext.java
@@ -83,6 +83,14 @@ public class MappingContext {
                 && !type.getSuperclass().getName().equals("java.lang.Object")) {
             registerTypes(type.getSuperclass(), entity);
         }
+        if(type.getInterfaces() != null
+                && metaData!=null) {
+            for(Class interfaceClass : type.getInterfaces()) {
+                if(metaData.classInfo(interfaceClass.getName())!=null) {
+                    registerTypes(interfaceClass,entity);
+                }
+            }
+        }
     }
 
     private void deregisterTypes(Class type, Object entity) {

--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/MetaData.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/MetaData.java
@@ -53,7 +53,11 @@ public class MetaData {
         if (classInfo != null) {
             return classInfo;
         }
-        return domainInfo.getClassSimpleName(name);
+        classInfo = domainInfo.getClassSimpleName(name);
+        if (classInfo != null) {
+            return classInfo;
+        }
+        return domainInfo.getClassInfoForInterface(name);
     }
 
 
@@ -111,6 +115,13 @@ public class MetaData {
                             // taxon class now.
                             baseClasses.add(taxonClassInfo);
                         }
+                        else {
+                            //try to find a single implementing class if this is an interface
+                            ClassInfo singleImplementor = findSingleImplementor(taxon);
+                            if(singleImplementor!=null) {
+                                baseClasses.add(singleImplementor);
+                            }
+                        }
                     }
                 } // not found, try again
             }
@@ -127,6 +138,9 @@ public class MetaData {
 
     private ClassInfo findSingleBaseClass(ClassInfo fqn, List<ClassInfo> classInfoList) {
         if (classInfoList.isEmpty()) {
+            if(fqn.isInterface()) {
+                return null;
+            }
             return fqn;
         }
         if (classInfoList.size() > 1) {
@@ -144,6 +158,14 @@ public class MetaData {
             return false;
         }
         return null != classInfo.annotationsInfo().get(RelationshipEntity.CLASS);
+    }
+
+    private ClassInfo findSingleImplementor(String taxon) {
+        ClassInfo interfaceInfo = domainInfo.getClassInfoForInterface(taxon);
+        if(interfaceInfo!=null && interfaceInfo.directImplementingClasses()!=null && interfaceInfo.directImplementingClasses().size()==1) {
+            return interfaceInfo.directImplementingClasses().get(0);
+        }
+        return null;
     }
 
 

--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/info/ClassInfo.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/info/ClassInfo.java
@@ -61,6 +61,8 @@ public class ClassInfo {
 
     private ClassInfo directSuperclass;
     private final List<ClassInfo> directSubclasses = new ArrayList<>();
+    private final List<ClassInfo> directInterfaces = new ArrayList<>();
+    private final List<ClassInfo> directImplementingClasses = new ArrayList<>();
 
     // ??
     private final Set<InterfaceInfo> interfaces = new HashSet<>();
@@ -179,6 +181,9 @@ public class ClassInfo {
         if (directSuperclass != null && !"java.lang.Object".equals(directSuperclass.className)) {
             directSuperclass.collectLabels(labelNames);
         }
+        for(ClassInfo interfaceInfo : directInterfaces()) {
+            interfaceInfo.collectLabels(labelNames);
+        }
         return labelNames;
     }
 
@@ -186,8 +191,20 @@ public class ClassInfo {
         return directSubclasses;
     }
 
+    public List<ClassInfo> directImplementingClasses() {
+        return directImplementingClasses;
+    }
+
+    public List<ClassInfo> directInterfaces() {
+        return directInterfaces;
+    }
+
     Set<InterfaceInfo> interfaces() {
         return interfaces;
+    }
+
+    public InterfacesInfo interfacesInfo() {
+        return interfacesInfo;
     }
 
     public Collection<AnnotationInfo> annotations() {

--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/info/InterfaceInfo.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/metadata/info/InterfaceInfo.java
@@ -12,9 +12,6 @@
 
 package org.neo4j.ogm.metadata.info;
 
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Direct and ancestral interfaces of a given interface.
  *
@@ -23,21 +20,9 @@ import java.util.Set;
 class InterfaceInfo {
 
     private final String interfaceName;
-    private final Set<InterfaceInfo> superInterfaces = new HashSet<>();
-
-    // what's this for?
-    private final Set<InterfaceInfo> allSuperInterfaces = new HashSet<>();
 
     public InterfaceInfo(String name) {
         this.interfaceName = name;
-    }
-
-    public Set<InterfaceInfo> superInterfaces() {
-        return superInterfaces;
-    }
-
-    public Set<InterfaceInfo> allSuperInterfaces() {
-        return allSuperInterfaces;
     }
 
     String name() {

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
@@ -17,9 +17,34 @@ import org.junit.Test;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.ogm.integration.hierarchy.domain.annotated.*;
-import org.neo4j.ogm.integration.hierarchy.domain.people.*;
-import org.neo4j.ogm.integration.hierarchy.domain.plain.*;
-import org.neo4j.ogm.integration.hierarchy.domain.trans.*;
+import org.neo4j.ogm.integration.hierarchy.domain.people.Bloke;
+import org.neo4j.ogm.integration.hierarchy.domain.people.Entity;
+import org.neo4j.ogm.integration.hierarchy.domain.people.Female;
+import org.neo4j.ogm.integration.hierarchy.domain.people.Male;
+import org.neo4j.ogm.integration.hierarchy.domain.people.Person;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainAbstractWithAnnotatedParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAbstractParentAndAnnotatedSuperclass;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedAbstractNamedParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedAbstractParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedConcreteNamedParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedConcreteParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedConcreteSuperclass;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedInterfaceParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedNamedInterfaceParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithAnnotatedSuperInterface;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithPlainAbstractParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithPlainConcreteParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithPlainConcreteParentImplementingInterface;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithPlainInterfaceChild;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainChildWithPlainInterfaceParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainConcreteParent;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainSingleClass;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.PlainChildOfTransientInterface;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.PlainChildOfTransientParent;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.PlainClassWithTransientFields;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.TransientChildWithPlainConcreteParent;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.TransientSingleClass;
+import org.neo4j.ogm.integration.hierarchy.domain.trans.TransientSingleClassWithId;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.WrappingServerIntegrationTest;
@@ -29,8 +54,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.neo4j.ogm.testutil.GraphTestUtils.assertSameGraph;
 import static org.junit.Assert.*;
+import static org.neo4j.ogm.testutil.GraphTestUtils.*;
 
 /**
  * Integration test for label-based mapping of class hierarchies.
@@ -39,12 +64,14 @@ import static org.junit.Assert.*;
  * <ul>
  * <li>any plain concrete class in the hierarchy generates a label by default</li>
  * <li>plain abstract class does not generate a label by default</li>
+ * <li>plain interface does not generate a label by default</li>
  * <li>any class annotated with @NodeEntity or @NodeEntity(label="something") generates a label</li>
  * <li>empty or null labels must not be allowed</li>
  * <li>classes / hierarchies that are not to be persisted must be annotated with @Transient</li>
  * </ul>
  *
  * @author Michal Bachman
+ * @author Luanne Misquitta
  */
 public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTest {
 
@@ -71,12 +98,31 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     }
 
     @Test
+    public void annotatedChildWithAnnotatedNamedInterfaceParent() {
+        session.save(new AnnotatedChildWithAnnotatedNamedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithAnnotatedNamedInterfaceParent:Parent)");
+
+        assertNotNull(session.load(AnnotatedChildWithAnnotatedNamedInterfaceParent.class, 0L));
+    }
+
+
+    @Test
     public void annotatedChildWithAnnotatedAbstractParent() {
         session.save(new AnnotatedChildWithAnnotatedAbstractParent());
 
         assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithAnnotatedAbstractParent:AnnotatedAbstractParent)");
 
         assertNotNull(session.load(AnnotatedChildWithAnnotatedAbstractParent.class, 0L));
+    }
+
+    @Test
+    public void annotatedChildWithAnnotatedInterfaceParent() {
+        session.save(new AnnotatedChildWithAnnotatedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithAnnotatedInterfaceParent:AnnotatedInterface)");
+
+        assertNotNull(session.load(AnnotatedChildWithAnnotatedInterfaceParent.class, 0L));
     }
 
     @Test
@@ -107,6 +153,15 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     }
 
     @Test
+    public void annotatedChildWithPlainInterfaceParent() {
+        session.save(new AnnotatedChildWithPlainInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithPlainInterfaceParent)");
+
+        assertNotNull(session.load(AnnotatedChildWithPlainInterfaceParent.class, 0L));
+    }
+
+    @Test
     public void annotatedChildWithPlainConcreteParent() {
         session.save(new AnnotatedChildWithPlainConcreteParent());
 
@@ -125,12 +180,30 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     }
 
     @Test
+    public void annotatedNamedChildWithAnnotatedNamedInterface() {
+        session.save(new AnnotatedNamedChildWithAnnotatedNamedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:Child:Parent)");
+
+        assertNotNull(session.load(AnnotatedNamedChildWithAnnotatedNamedInterfaceParent.class, 0L));
+    }
+
+    @Test
     public void annotatedNamedChildWithAnnotatedAbstractParent() {
         session.save(new AnnotatedNamedChildWithAnnotatedAbstractParent());
 
         assertSameGraph(getDatabase(), "CREATE (:Child:AnnotatedAbstractParent)");
 
         assertNotNull(session.load(AnnotatedNamedChildWithAnnotatedAbstractParent.class, 0L));
+    }
+
+    @Test
+    public void annotatedNamedChildWithAnnotatedInterfaceParent() {
+        session.save(new AnnotatedNamedChildWithAnnotatedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:Child:AnnotatedInterface)");
+
+        assertNotNull(session.load(AnnotatedNamedChildWithAnnotatedInterfaceParent.class, 0L));
     }
 
     @Test
@@ -158,6 +231,15 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertSameGraph(getDatabase(), "CREATE (:Child)");
 
         assertNotNull(session.load(AnnotatedNamedChildWithPlainAbstractParent.class, 0L));
+    }
+
+    @Test
+    public void annotatedNamedChildWithPlainInterfaceParent() {
+        session.save(new AnnotatedNamedChildWithPlainInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:Child)");
+
+        assertNotNull(session.load(AnnotatedNamedChildWithPlainInterfaceParent.class, 0L));
     }
 
     @Test
@@ -197,12 +279,30 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     }
 
     @Test
+    public void plainChildWithAnnotatedNamedInterfaceParent() {
+        session.save(new PlainChildWithAnnotatedNamedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAnnotatedNamedInterfaceParent:Parent)");
+
+        assertNotNull(session.load(PlainChildWithAnnotatedNamedInterfaceParent.class, 0L));
+    }
+
+    @Test
     public void plainChildWithAnnotatedAbstractParent() {
         session.save(new PlainChildWithAnnotatedAbstractParent());
 
         assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAnnotatedAbstractParent:AnnotatedAbstractParent)");
 
         assertNotNull(session.load(PlainChildWithAnnotatedAbstractParent.class, 0L));
+    }
+
+    @Test
+    public void plainChildWithAnnotatedInterfaceParent() {
+        session.save(new PlainChildWithAnnotatedInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAnnotatedInterfaceParent:AnnotatedInterface)");
+
+        assertNotNull(session.load(PlainChildWithAnnotatedInterfaceParent.class, 0L));
     }
 
     @Test
@@ -233,6 +333,16 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     }
 
     @Test
+    public void plainChildWithPlainInterfaceParent() {
+        session.save(new PlainChildWithPlainInterfaceParent());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithPlainInterfaceParent)");
+
+        assertNotNull(session.load(PlainChildWithPlainInterfaceParent.class, 0L));
+    }
+
+
+    @Test
     public void plainChildWithPlainConcreteParent() {
         session.save(new PlainChildWithPlainConcreteParent());
 
@@ -241,6 +351,82 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithPlainConcreteParent.class, 0L));
     }
 
+    @Test
+    public void plainChildWithPlainConcreteParentImplementingInterface() {
+        session.save(new PlainChildWithPlainConcreteParentImplementingInterface());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithPlainConcreteParentImplementingInterface:PlainConcreteParent)");
+
+        assertNotNull(session.load(PlainChildWithPlainConcreteParentImplementingInterface.class, 0L));
+        assertNotNull(session.load(PlainConcreteParent.class, 0L));
+    }
+
+    @Test
+    public void plainChildWithPlainInterfaceChild() {
+        session.save(new PlainChildWithPlainInterfaceChild());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithPlainInterfaceChild)");
+
+        assertNotNull(session.load(PlainChildWithPlainInterfaceChild.class, 0L));
+    }
+
+    @Test
+    public void plainChildWithAnnotatedSuperInterface() {
+        /*
+        PlainChildWithAnnotatedSuperInterface->PlainInterfaceChildWithAnnotatedParentInterface->AnnotatedInterface
+         */
+        session.save(new PlainChildWithAnnotatedSuperInterface());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAnnotatedSuperInterface:AnnotatedInterface)");
+        assertNotNull(session.load(PlainChildWithAnnotatedSuperInterface.class, 0L));
+    }
+
+    @Test
+    public void annotatedChildWithAnnotatedInterface() {
+        /*
+        AnnotatedChildWithAnnotatedInterface->AnnotatedInterfaceWithSingleImpl
+         */
+        session.save(new AnnotatedChildWithAnnotatedInterface());
+
+        assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithAnnotatedInterface:AnnotatedInterfaceWithSingleImpl)");
+        assertNotNull(session.load(AnnotatedChildWithAnnotatedInterface.class, 0L));
+        assertNotNull(session.load(AnnotatedInterfaceWithSingleImpl.class, 0L)); //AnnotatedInterfaceWithSingleImpl has a single implementation so we should be able to load it
+        assertEquals("org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedChildWithAnnotatedInterface",session.load(AnnotatedInterfaceWithSingleImpl.class, 0L).getClass().getName());
+    }
+
+
+    @Test
+    public void plainChildWithAnnotatedSuperclass() {
+        /*
+           PlainChildWithAnnotatedConcreteSuperclass->PlainChildWithAnnotatedConcreteParent->AnnotatedConcreteParent
+         */
+        session.save(new PlainChildWithAnnotatedConcreteSuperclass());
+
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAnnotatedConcreteSuperclass:PlainChildWithAnnotatedConcreteParent:AnnotatedConcreteParent)");
+        assertNotNull(session.load(PlainChildWithAnnotatedConcreteSuperclass.class, 0L));
+        assertNotNull(session.load(PlainChildWithAnnotatedConcreteParent.class, 0L));
+        assertNotNull(session.load(AnnotatedConcreteParent.class, 0L));
+    }
+
+    @Test
+    public void plainChildWithAbstractParentAndAnnotatedSuperclass() {
+        /*
+           PlainChildWithAbstractParentAndAnnotatedSuperclass->PlainAbstractWithAnnotatedParent->AnnotatedSingleClass
+         */
+        session.save(new PlainChildWithAbstractParentAndAnnotatedSuperclass());
+        assertSameGraph(getDatabase(), "CREATE (:PlainChildWithAbstractParentAndAnnotatedSuperclass:AnnotatedSingleClass)");
+        assertNotNull(session.load(PlainChildWithAbstractParentAndAnnotatedSuperclass.class, 0L));
+        assertNotNull(session.load(PlainAbstractWithAnnotatedParent.class, 0L));
+        assertNotNull(session.load(AnnotatedSingleClass.class, 0L));
+    }
+
+    @Test
+    public void annotatedChildWithMultipleAnnotatedInterfaces() {
+        session.save(new AnnotatedChildWithMultipleAnnotatedInterfaces());
+
+        assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithMultipleAnnotatedInterfaces:AnnotatedInterface:Parent)");
+        assertNotNull(session.load(AnnotatedChildWithMultipleAnnotatedInterfaces.class, 0L));
+    }
     @Test
     public void plainSingleClass() {
         session.save(new PlainSingleClass());
@@ -254,6 +440,15 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
     public void plainChildOfTransientParent() {
         session.save(new PlainChildOfTransientParent());
 
+        try (Transaction tx = getDatabase().beginTx()) {
+            assertFalse(GlobalGraphOperations.at(getDatabase()).getAllNodes().iterator().hasNext());
+            tx.success();
+        }
+    }
+
+    @Test
+    public void plainChildOfTransientInterface() {
+        session.save(new PlainChildOfTransientInterface());
         try (Transaction tx = getDatabase().beginTx()) {
             assertFalse(GlobalGraphOperations.at(getDatabase()).getAllNodes().iterator().hasNext());
             tx.success();
@@ -507,8 +702,4 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
 
         session.loadAll(Person.class);
     }
-
-    //todo interfaces in domain objects
-
-
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
@@ -473,7 +473,10 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
 
         assertSameGraph(getDatabase(), "CREATE (:AnnotatedChildWithMultipleAnnotatedInterfaces:AnnotatedInterface:Parent)");
         assertNotNull(session.load(AnnotatedChildWithMultipleAnnotatedInterfaces.class, 0L));
+        assertEquals(1,session.loadAll(AnnotatedInterface.class).size());
+        assertEquals(1,session.loadAll(AnnotatedNamedInterfaceParent.class).size());
     }
+
     @Test
     public void plainSingleClass() {
         session.save(new PlainSingleClass());

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/ClassHierarchiesIntegrationTest.java
@@ -97,6 +97,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedChildWithAnnotatedAbstractNamedParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedChildWithAnnotatedNamedInterfaceParent() {
         session.save(new AnnotatedChildWithAnnotatedNamedInterfaceParent());
@@ -116,6 +119,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedChildWithAnnotatedAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedChildWithAnnotatedInterfaceParent() {
         session.save(new AnnotatedChildWithAnnotatedInterfaceParent());
@@ -152,6 +158,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedChildWithPlainAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedChildWithPlainInterfaceParent() {
         session.save(new AnnotatedChildWithPlainInterfaceParent());
@@ -179,6 +188,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedNamedChildWithAnnotatedAbstractNamedParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedNamedChildWithAnnotatedNamedInterface() {
         session.save(new AnnotatedNamedChildWithAnnotatedNamedInterfaceParent());
@@ -197,6 +209,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedNamedChildWithAnnotatedAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedNamedChildWithAnnotatedInterfaceParent() {
         session.save(new AnnotatedNamedChildWithAnnotatedInterfaceParent());
@@ -233,6 +248,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedNamedChildWithPlainAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedNamedChildWithPlainInterfaceParent() {
         session.save(new AnnotatedNamedChildWithPlainInterfaceParent());
@@ -278,6 +296,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithAnnotatedAbstractNamedParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithAnnotatedNamedInterfaceParent() {
         session.save(new PlainChildWithAnnotatedNamedInterfaceParent());
@@ -296,6 +317,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithAnnotatedAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithAnnotatedInterfaceParent() {
         session.save(new PlainChildWithAnnotatedInterfaceParent());
@@ -332,6 +356,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithPlainAbstractParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithPlainInterfaceParent() {
         session.save(new PlainChildWithPlainInterfaceParent());
@@ -351,6 +378,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithPlainConcreteParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithPlainConcreteParentImplementingInterface() {
         session.save(new PlainChildWithPlainConcreteParentImplementingInterface());
@@ -361,6 +391,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainConcreteParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithPlainInterfaceChild() {
         session.save(new PlainChildWithPlainInterfaceChild());
@@ -370,6 +403,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithPlainInterfaceChild.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithAnnotatedSuperInterface() {
         /*
@@ -381,6 +417,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(PlainChildWithAnnotatedSuperInterface.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedChildWithAnnotatedInterface() {
         /*
@@ -394,7 +433,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertEquals("org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedChildWithAnnotatedInterface",session.load(AnnotatedInterfaceWithSingleImpl.class, 0L).getClass().getName());
     }
 
-
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithAnnotatedSuperclass() {
         /*
@@ -408,6 +449,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedConcreteParent.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildWithAbstractParentAndAnnotatedSuperclass() {
         /*
@@ -420,6 +464,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         assertNotNull(session.load(AnnotatedSingleClass.class, 0L));
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void annotatedChildWithMultipleAnnotatedInterfaces() {
         session.save(new AnnotatedChildWithMultipleAnnotatedInterfaces());
@@ -446,6 +493,9 @@ public class ClassHierarchiesIntegrationTest extends WrappingServerIntegrationTe
         }
     }
 
+    /**
+     * @see DATAGRAPH-577
+     */
     @Test
     public void plainChildOfTransientInterface() {
         session.save(new PlainChildOfTransientInterface());

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedInterface.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public class AnnotatedChildWithAnnotatedInterface implements AnnotatedInterfaceWithSingleImpl {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedInterfaceParent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public class AnnotatedChildWithAnnotatedInterfaceParent implements AnnotatedInterface {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedNamedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithAnnotatedNamedInterfaceParent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public class AnnotatedChildWithAnnotatedNamedInterfaceParent implements AnnotatedNamedInterfaceParent{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithMultipleAnnotatedInterfaces.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithMultipleAnnotatedInterfaces.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public class AnnotatedChildWithMultipleAnnotatedInterfaces implements AnnotatedInterface,AnnotatedNamedInterfaceParent{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithPlainInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedChildWithPlainInterfaceParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainInterface;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public class AnnotatedChildWithPlainInterfaceParent implements PlainInterface{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedInterface.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public interface AnnotatedInterface {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedInterfaceWithSingleImpl.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedInterfaceWithSingleImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity
+public interface AnnotatedInterfaceWithSingleImpl {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithAnnotatedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithAnnotatedInterfaceParent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity(label = "Child")
+public class AnnotatedNamedChildWithAnnotatedInterfaceParent implements AnnotatedInterface {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithAnnotatedNamedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithAnnotatedNamedInterfaceParent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity(label = "Child")
+public class AnnotatedNamedChildWithAnnotatedNamedInterfaceParent implements AnnotatedNamedInterfaceParent{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithPlainInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedChildWithPlainInterfaceParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.integration.hierarchy.domain.plain.PlainInterface;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity(label = "Child")
+public class AnnotatedNamedChildWithPlainInterfaceParent implements PlainInterface{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/annotated/AnnotatedNamedInterfaceParent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.annotated;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Luanne Misquitta
+ */
+@NodeEntity(label = "Parent")
+public interface AnnotatedNamedInterfaceParent {
+
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainAbstractWithAnnotatedParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainAbstractWithAnnotatedParent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+import org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedSingleClass;
+
+/**
+ * @author Luanne Misquitta
+ */
+public abstract class PlainAbstractWithAnnotatedParent extends AnnotatedSingleClass {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAbstractParentAndAnnotatedSuperclass.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAbstractParentAndAnnotatedSuperclass.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithAbstractParentAndAnnotatedSuperclass extends PlainAbstractWithAnnotatedParent {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedConcreteSuperclass.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedConcreteSuperclass.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithAnnotatedConcreteSuperclass extends PlainChildWithAnnotatedConcreteParent {
+
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedInterfaceParent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+import org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedInterface;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithAnnotatedInterfaceParent implements AnnotatedInterface {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedNamedInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedNamedInterfaceParent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+import org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedNamedInterfaceParent;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithAnnotatedNamedInterfaceParent implements AnnotatedNamedInterfaceParent {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedSuperInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithAnnotatedSuperInterface.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithAnnotatedSuperInterface implements PlainInterfaceChildWithAnnotatedParentInterface{
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainConcreteParentImplementingInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainConcreteParentImplementingInterface.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithPlainConcreteParentImplementingInterface extends PlainConcreteParent implements PlainInterface {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainInterfaceChild.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainInterfaceChild.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithPlainInterfaceChild implements PlainInterfaceChild {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainInterfaceParent.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainChildWithPlainInterfaceParent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildWithPlainInterfaceParent implements PlainInterface {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterface.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public interface PlainInterface {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterfaceChild.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterfaceChild.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+/**
+ * @author Luanne Misquitta
+ */
+public interface PlainInterfaceChild extends PlainInterface {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterfaceChildWithAnnotatedParentInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/plain/PlainInterfaceChildWithAnnotatedParentInterface.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.plain;
+
+import org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedInterface;
+
+/**
+ * @author Luanne Misquitta
+ */
+public interface PlainInterfaceChildWithAnnotatedParentInterface extends AnnotatedInterface{
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/trans/PlainChildOfTransientInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/trans/PlainChildOfTransientInterface.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.trans;
+
+/**
+ * @author Luanne Misquitta
+ */
+public class PlainChildOfTransientInterface implements TransientInterface {
+
+    Long id;
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/trans/TransientInterface.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/hierarchy/domain/trans/TransientInterface.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for the these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.integration.hierarchy.domain.trans;
+
+import org.neo4j.ogm.annotation.Transient;
+
+/**
+ * @author Luanne Misquitta
+ */
+@Transient
+public interface TransientInterface {
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/metadata/MetaDataTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/metadata/MetaDataTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
  */
 public class MetaDataTest {
 
-    private static final MetaData metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.canonical");
+    private static final MetaData metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.canonical","org.neo4j.ogm.integration.hierarchy.domain");
 
     /**
      * A class can be found if its simple name is unique in the domain
@@ -504,10 +504,20 @@ public class MetaDataTest {
 
     @Test
     /**
-     * Taxa corresponding to interfaces can't be resolved
+     * Taxa corresponding to interfaces with multiple implementations can't be resolved
      */
-    public void testInterfaceTaxa() {
+    public void testInterfaceWithMultipleImplTaxa() {
         assertEquals(null, metaData.resolve("IMembership"));
+    }
+
+    @Test
+    /**
+     * Taxa corresponding to interfaces with a single implementor can be resolved
+     */
+    public void testInterfaceWithSingleImplTaxa() {
+        ClassInfo classInfo = metaData.resolve("AnnotatedInterfaceWithSingleImpl");
+        assertNotNull(classInfo);
+        assertEquals("org.neo4j.ogm.integration.hierarchy.domain.annotated.AnnotatedChildWithAnnotatedInterface",classInfo.name());
     }
 
     @Test

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/metadata/MetaDataTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/metadata/MetaDataTest.java
@@ -513,6 +513,8 @@ public class MetaDataTest {
     @Test
     /**
      * Taxa corresponding to interfaces with a single implementor can be resolved
+     *
+     * @see DATAGRAPH-577
      */
     public void testInterfaceWithSingleImplTaxa() {
         ClassInfo classInfo = metaData.resolve("AnnotatedInterfaceWithSingleImpl");


### PR DESCRIPTION
Support for @NodeEntity and @Transient added for interfaces. Cleaned up InterfaceInfo and updated MetaData.resolve to look for implementing classes as well. 