### PR TITLE
Adding tests for incorrect relationship repository queries

### DIFF
--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/DerivedRelationshipEntityQueryTest2.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/DerivedRelationshipEntityQueryTest2.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.Neo4jIntegrationTestRule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.moreQueries.domain.Rating;
+import org.springframework.data.neo4j.moreQueries.context.MoviesContext;
+import org.springframework.data.neo4j.moreQueries.repo.RatingRepository;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Luanne Misquitta
+ */
+@ContextConfiguration(classes = {MoviesContext.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class DerivedRelationshipEntityQueryTest2 {
+
+	@ClassRule
+	public static Neo4jIntegrationTestRule neo4jRule = new Neo4jIntegrationTestRule(7879);
+
+	private static Session session;
+
+	@Autowired
+	private RatingRepository ratingRepository;
+
+	@Before
+	public void init() throws IOException {
+		session = new SessionFactory("org.springframework.data.neo4j.moreQueries.domain").openSession(neo4jRule.url());
+	}
+
+	@After
+	public void clearDatabase() {
+		neo4jRule.clearDatabase();
+	}
+
+	private void executeUpdate(String cypher) {
+		new ExecutionEngine(neo4jRule.getGraphDatabaseService()).execute(cypher);
+	}
+
+	@Test
+	public void shouldFindRelEntitiesWithBothStartEndNestedSamePropertyNames() {
+		executeUpdate("CREATE (m1:Movie {title:'Speed'}) CREATE (m2:Movie {name:'The Matrix'}) CREATE (m:Movie {name:'Chocolat'})" +
+				" CREATE (u:User {name:'Michal'}) CREATE (u)-[:RATED {stars:3}]->(m1)  CREATE (u)-[:RATED {stars:4}]->(m2)");
+		List<Rating> ratings = ratingRepository.findByUserNameAndMovieName("Michal", "Speed");
+		assertEquals(1, ratings.size());
+		assertEquals("Michal", ratings.get(0).user.name);
+		assertEquals("Speed", ratings.get(0).movie.name);
+
+		ratings = ratingRepository.findByUserNameAndMovieName("Michal", "Chocolat");
+		assertEquals(0, ratings.size());
+	}
+
+	@Test
+	public void shouldFindRelEntitiesWithNestedProperty() {
+		executeUpdate("CREATE (m1:Movie {title:'Speed'}) CREATE (m2:Movie {name:'The Matrix'}) CREATE (m:Movie {name:'Chocolat'})" +
+				" CREATE (u:User {name:'Michal', level:5}) CREATE (u)-[:RATED {stars:3}]->(m1)  CREATE (u)-[:RATED {stars:4}]->(m2)");
+		List<Rating> ratings = ratingRepository.findByUserLevel("5");
+		assertEquals(2, ratings.size());
+
+		ratings = ratingRepository.findByUserLevel("2");
+		assertEquals(0, ratings.size());
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/context/MoviesContext.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/context/MoviesContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries.context;
+
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.server.Neo4jServer;
+import org.springframework.data.neo4j.server.RemoteServer;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michal Bachman
+ */
+@Configuration
+@ComponentScan({"org.springframework.data.neo4j.moreQueries"})
+@EnableNeo4jRepositories("org.springframework.data.neo4j.moreQueries.repo")
+@EnableTransactionManagement
+public class MoviesContext extends Neo4jConfiguration {
+
+    @Autowired
+    private Environment env;
+
+    @Override
+    public SessionFactory getSessionFactory() {
+        return new SessionFactory("org.springframework.data.neo4j.moreQueries.domain");
+    }
+
+    @Bean
+    public Neo4jServer neo4jServer() {
+        return new RemoteServer("http://localhost:7879");
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/Movie.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/Movie.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries.domain;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Michal Bachman
+ */
+@NodeEntity
+public class Movie {
+
+    Long id;
+    public String name;
+
+    @Relationship(type = "RATED", direction = Relationship.INCOMING)
+    private Set<Rating> ratings = new HashSet<>();
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/Rating.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/Rating.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries.domain;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+import org.neo4j.ogm.annotation.Transient;
+
+/**
+ * @author Michal Bachman
+ */
+@RelationshipEntity(type = "RATED")
+public class Rating {
+
+    Long id;
+
+    @StartNode
+    public User user;
+    @EndNode
+    public Movie movie;
+
+    @Transient
+    public String getUserLevel() {
+        return user == null ? null : user.level;
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/domain/User.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries.domain;
+
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Michal Bachman
+ */
+public class User {
+
+    Long id;
+    public String name;
+    public String level;
+
+    @Relationship(type = "RATED")
+    private Set<Rating> ratings = new HashSet<>();
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/repo/RatingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/moreQueries/repo/RatingRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.moreQueries.repo;
+
+import org.springframework.data.neo4j.moreQueries.domain.Rating;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+import java.util.List;
+
+/**
+ * @author Luanne Misquitta
+ */
+public interface RatingRepository extends GraphRepository<Rating> {
+
+	List<Rating> findByUserNameAndMovieName(String userName, String movieName);
+
+	List<Rating> findByUserLevel(String userLevel);
+}


### PR DESCRIPTION
Hi Luanne,

I  think the genrated query for the repository method 
```
List<Rating> findByUserNameAndMovieName(String userName, String movieName)
```
should be
```
{"statements":[{"statement":"MATCH (n:`User`) WHERE n.`name` = { `userName` } MATCH (m:`Movie`) WHERE m.`name` = { `movieName` } MATCH (n)-[r:`RATED`]->(m) WITH n,r MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)","parameters":{"userName":"Michal","movieName":"Speed"},"resultDataContents":["graph","row"],"includeStats":false}]}
```
but the following were send to the neo4j server
```
{"statements":[{"statement":"MATCH (n:`User`) WHERE n.`name` = { `name` } MATCH (m:`Movie`) WHERE m.`name` = { `name` } MATCH (n)-[r:`RATED`]->(m) WITH n,r MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)","parameters":{"name":"Speed"},"resultDataContents":["graph","row"],"includeStats":false}]}
```

The second test is not so clear.
If Rating has a method getUserLevel() and RatingRepository a method List<Rating> findByUserLevel(String userLevel) but no attribute userLevel and no setter, then I would expect, that the query is 
```
{"statements":[{"statement":"MATCH (n)-[r:`RATED`]->(m) WHERE n.`level` = { `userLevel` } WITH n,r MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)","parameters":{"userLevel":"5"},"resultDataContents":["graph","row"],"includeStats":false}]}
```
and not
```
{"statements":[{"statement":"MATCH (n)-[r:`RATED`]->(m) WHERE r.`userLevel` = { `userLevel` } WITH n,r MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)","parameters":{"userLevel":"5"},"resultDataContents":["graph","row"],"includeStats":false}]}
```
but in any case should the should the upper query be send, if I add the annotaion @Transient to the method.