### PR TITLE
Update ExecutingRestRequest to allow HTTPS requests

### DIFF
--- a/spring-data-neo4j-rest/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
+++ b/spring-data-neo4j-rest/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
@@ -104,7 +104,7 @@ public class ExecutingRestRequest implements RestRequest {
     }
 
     private String pathOrAbsolute( String path ) {
-        if ( path.startsWith( "http://" ) ) return path;
+        if ( path.startsWith( "http://" ) || path.startsWith( "https://" ) return path;
         return baseUri + "/" + path;
     }
 

--- a/spring-data-neo4j-rest/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
+++ b/spring-data-neo4j-rest/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
@@ -104,7 +104,7 @@ public class ExecutingRestRequest implements RestRequest {
     }
 
     private String pathOrAbsolute( String path ) {
-        if ( path.startsWith( "http://" ) || path.startsWith( "https://" ) return path;
+        if ( path.startsWith( "http://" ) || path.startsWith( "https://") ) return path;
         return baseUri + "/" + path;
     }
 


### PR DESCRIPTION
Can we have this change implemented, Michael? We are using Neo4j behind an SSL protected nginx and the ExecutingRestRequest will only check for "http://" starting URLs. Otherwise, the url gets modified in bad way, i.e.

**/db/data/https://${domain}.com/db/data/transaction/25**

instead of **/db/data/transaction/25**,

whenever a transaction is created. So the initial transaction is OK, but when subsequent are to be created, requests will be made to ```this.baseUri + "/" + path;```, instead of ```path```

If you need a detailed scenario or nginx log, please let me know.

@jexp 