### PR TITLE
Set Neo4j 2.3 as Default and Upgrading QueryDSL to 4.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
 		<source.level>1.7</source.level>
 		<target.level>1.7</target.level>
 
-		<neo4j.version>2.2.5</neo4j.version>
-		<neo4j.spatial.version>0.14-neo4j-2.2.3</neo4j.spatial.version>
+		<neo4j.version>2.3.1</neo4j.version>
+		<neo4j.spatial.version>0.15-neo4j-2.3.0</neo4j.spatial.version>
 
-		<neo4j-cypher-dsl.version>2.0.1</neo4j-cypher-dsl.version>
+		<neo4j-cypher-dsl.version>2.3-SNAPSHOT</neo4j-cypher-dsl.version>
 		<bundlor.failOnWarnings>false</bundlor.failOnWarnings>
 	</properties>
 
@@ -60,9 +60,10 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>neo4j-23</id>
+			<id>neo4j-22</id>
 			<properties>
-				<neo4j.version>2.3.0-M03</neo4j.version>
+				<neo4j.version>2.2.7</neo4j.version>
+				<neo4j.spatial.version>0.14-neo4j-2.2.3</neo4j.spatial.version>
 			</properties>
 		</profile>
 		<profile>
@@ -190,10 +191,17 @@
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 		<repository>
-			<id>neo4j</id>
+			<id>neo4j-releases</id>
 			<url>http://m2.neo4j.org/content/repositories/releases</url>
 			<snapshots>
 				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>neo4j-snapshots</id>
+			<url>http://m2.neo4j.org/content/repositories/snapshots</url>
+			<snapshots>
+				<enabled>true</enabled>
 			</snapshots>
 		</repository>
 		<repository>
@@ -213,6 +221,10 @@
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
+		</repository>
+		<repository>
+			<id>oss-nexus-snapshots</id>
+			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>

--- a/spring-data-neo4j-rest/pom.xml
+++ b/spring-data-neo4j-rest/pom.xml
@@ -55,7 +55,7 @@
 		</dependency>
 
         <dependency>
-            <groupId>com.mysema.querydsl</groupId>
+            <groupId>com.querydsl</groupId>
             <artifactId>querydsl-lucene3</artifactId>
             <version>${querydsl}</version>
             <optional>true</optional>

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -67,7 +67,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
+			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-lucene3</artifactId>
 			<version>${querydsl}</version>
 			<optional>true</optional>
@@ -77,12 +77,17 @@
 					<artifactId>lucene-core</artifactId>
 				</exclusion>
 			</exclusions>
-
 		</dependency>
 
 		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
+			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-apt</artifactId>
+			<version>${querydsl}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-core</artifactId>
 			<version>${querydsl}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -225,7 +230,7 @@
 				<version>${apt}</version>
 				<dependencies>
 					<dependency>
-						<groupId>com.mysema.querydsl</groupId>
+						<groupId>com.querydsl</groupId>
 						<artifactId>querydsl-apt</artifactId>
 						<version>${querydsl}</version>
 					</dependency>

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/querydsl/SDNAnnotationProcessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/querydsl/SDNAnnotationProcessor.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.neo4j.querydsl;
 
-import com.mysema.query.annotations.*;
-import com.mysema.query.apt.AbstractQuerydslProcessor;
-import com.mysema.query.apt.Configuration;
-import com.mysema.query.apt.DefaultConfiguration;
+import com.querydsl.core.annotations.*;
+import com.querydsl.apt.AbstractQuerydslProcessor;
+import com.querydsl.apt.Configuration;
+import com.querydsl.apt.DefaultConfiguration;
 import org.springframework.data.neo4j.annotation.NodeEntity;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -31,7 +31,7 @@ import java.util.Collections;
 /**
  * TODO
  */
-@SupportedAnnotationTypes({"com.mysema.query.annotations.*","org.springframework.data.neo4j.annotation.*"})
+@SupportedAnnotationTypes({"com.querydsl.core.annotations.*","org.springframework.data.neo4j.annotation.*"})
 @SuppressWarnings("restriction")
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class SDNAnnotationProcessor extends AbstractQuerydslProcessor {

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactory.java
@@ -20,6 +20,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.neo4j.repository.query.GraphQueryMethod;
 import org.springframework.data.neo4j.support.Neo4jTemplate;
 import org.springframework.data.neo4j.support.mapping.Neo4jMappingContext;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryInformation;
@@ -93,13 +94,12 @@ public class GraphRepositoryFactory extends RepositoryFactorySupport {
     }
 
 
-
     @Override
-    protected QueryLookupStrategy getQueryLookupStrategy(QueryLookupStrategy.Key key) {
+    protected QueryLookupStrategy getQueryLookupStrategy(QueryLookupStrategy.Key key, EvaluationContextProvider evaluationContextProvider) {
         return new QueryLookupStrategy() {
             @Override
-            public RepositoryQuery resolveQuery(Method method, RepositoryMetadata repositoryMetadata, NamedQueries namedQueries) {
-                final GraphQueryMethod queryMethod = new GraphQueryMethod(method,repositoryMetadata,namedQueries,mappingContext);
+            public RepositoryQuery resolveQuery(Method method, RepositoryMetadata metadata, ProjectionFactory factory, NamedQueries namedQueries) {
+                final GraphQueryMethod queryMethod = new GraphQueryMethod(method, metadata, factory, namedQueries, mappingContext);
                 return queryMethod.createQuery(GraphRepositoryFactory.this.template);
             }
         };

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
@@ -19,6 +19,7 @@ import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.support.GenericTypeExtractor;
 import org.springframework.data.neo4j.support.Neo4jTemplate;
 import org.springframework.data.neo4j.support.mapping.Neo4jMappingContext;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.Parameter;
@@ -41,8 +42,8 @@ public class GraphQueryMethod extends QueryMethod {
     private final Neo4jMappingContext mappingContext;
     private final Query queryAnnotation;
 
-    public GraphQueryMethod(Method method, RepositoryMetadata metadata, NamedQueries namedQueries, Neo4jMappingContext mappingContext) {
-        super(method, metadata);
+    public GraphQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory, NamedQueries namedQueries, Neo4jMappingContext mappingContext) {
+        super(method, metadata, factory);
         this.method = method;
         this.namedQueries = namedQueries;
         this.mappingContext = mappingContext;

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractDerivedFinderMethodTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractDerivedFinderMethodTestBase.java
@@ -34,7 +34,6 @@ import org.springframework.data.repository.query.parser.Part;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -426,7 +425,7 @@ public abstract class AbstractDerivedFinderMethodTestBase {
 
     protected void assertRepositoryQueryMethod(Class<ThingRepository> repositoryClass, String methodName, Object[] paramValues, String expectedQuery, Object...expectedParam) {
         Method method = methodFor(repositoryClass, methodName);
-        DerivedCypherRepositoryQuery derivedCypherRepositoryQuery = new DerivedCypherRepositoryQuery(ctx, new GraphQueryMethod(method, new DefaultRepositoryMetadata(repositoryClass), null, ctx), template);
+        DerivedCypherRepositoryQuery derivedCypherRepositoryQuery = new DerivedCypherRepositoryQuery(ctx, new GraphQueryMethod(method, new DefaultRepositoryMetadata(repositoryClass), new DefaultProjectionFactory(), null, ctx), template);
         Parameters<?, ?> parameters = new DefaultParameters(method);
         ParametersParameterAccessor accessor = new ParametersParameterAccessor(parameters, paramValues);
         String query = derivedCypherRepositoryQuery.createQueryWithPagingAndSorting(accessor);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DefaultProjectionFactory.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DefaultProjectionFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.query;
+
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.ProjectionInformation;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Default implementation of {@link ProjectionFactory}.
+ * 
+ * @author Brad Nussbaum
+ */
+public class DefaultProjectionFactory implements ProjectionFactory {
+
+	@Override
+	public <T> T createProjection(Class<T> projectionType, Object source) {
+		return null;
+	}
+
+	@Override
+	public <T> T createProjection(Class<T> projectionType) {
+		return null;
+	}
+
+	@Override
+	public List<String> getInputProperties(Class<?> projectionType) {
+		return null;
+	}
+
+	@Override
+	public ProjectionInformation getProjectionInformation(Class<?> projectionType) {
+		return null;
+	}
+}

--- a/spring-data-neo4j/template.mf
+++ b/spring-data-neo4j/template.mf
@@ -38,9 +38,9 @@ Import-Template:
  javax.persistence.spi.*;version="[1.0.0, 3.0.0)";resolution:=optional,
  javax.transaction.*;version="[1.0.1, 2.0.0)";resolution:=optional,
  javax.enterprise.*;version="${cdi:[=.=.=,+1.0.0)}";resolution:=optional,
- com.mysema.query.annotations.*;version="0";resolution:=optional,
- com.mysema.query.apt.*;version="0";resolution:=optional,
- com.mysema.query.types.*;version="0";resolution:=optional,
+ com.querydsl.core.annotations.*;version="0";resolution:=optional,
+ com.querydsl.apt.*;version="0";resolution:=optional,
+ com.querydsl.types.*;version="0";resolution:=optional,
 Import-Package:
  sun.reflect;version="0";resolution:=optional,
  scala.collection;version="0";resolution:=optional,


### PR DESCRIPTION
Adding support for querydsl 4.0.7 upgrade
Upgrading neo4j to 2.3.1 and spatial to 0.15
Setting Neo4j 2.3 as the default version