### PR TITLE
Fix for issue #139 - graph repositories do not fire application events for save/delete operations

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactory.java
@@ -13,6 +13,7 @@
 package org.springframework.data.neo4j.repository.support;
 
 import org.neo4j.ogm.session.Session;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.neo4j.repository.GraphRepositoryImpl;
 import org.springframework.data.neo4j.repository.query.GraphQueryLookupStrategy;
 import org.springframework.data.repository.core.EntityInformation;
@@ -30,9 +31,11 @@ import java.io.Serializable;
 public class GraphRepositoryFactory extends RepositoryFactorySupport {
 
     private final Session session;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
-    public GraphRepositoryFactory(Session session) {
+    public GraphRepositoryFactory(Session session, ApplicationEventPublisher applicationEventPublisher) {
         this.session = session;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     @Override
@@ -42,7 +45,7 @@ public class GraphRepositoryFactory extends RepositoryFactorySupport {
 
     @Override
     protected Object getTargetRepository(RepositoryInformation information) {
-        return getTargetRepositoryViaReflection(information, information.getDomainType(), session);
+        return getTargetRepositoryViaReflection(information, information.getDomainType(), session, applicationEventPublisher);
     }
 
     @Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactoryBean.java
@@ -14,6 +14,8 @@ package org.springframework.data.neo4j.repository.support;
 
 import org.neo4j.ogm.session.Session;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -23,14 +25,17 @@ import org.springframework.data.repository.core.support.TransactionalRepositoryF
 /**
  * @author Vince Bickers
  */
-public class GraphRepositoryFactoryBean<S extends Repository<T, Long>, T> extends TransactionalRepositoryFactoryBeanSupport<S, T, Long> {
+public class GraphRepositoryFactoryBean<S extends Repository<T, Long>, T> extends TransactionalRepositoryFactoryBeanSupport<S, T, Long>
+        implements ApplicationEventPublisherAware {
 
     @Autowired
     private Session session;
 
     @Autowired
     private Neo4jMappingContext mappingContext;
-    
+
+    private ApplicationEventPublisher applicationEventPublisher;
+
     @Override
     public void afterPropertiesSet() {
         setMappingContext(mappingContext);
@@ -39,6 +44,12 @@ public class GraphRepositoryFactoryBean<S extends Repository<T, Long>, T> extend
 
     @Override
     protected RepositoryFactorySupport doCreateRepositoryFactory() {
-        return new GraphRepositoryFactory(session);
+        return new GraphRepositoryFactory(session, applicationEventPublisher);
     }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/TemplateApplicationEventTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/TemplateApplicationEventTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c)  [2011-2015] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.event;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.event.context.TestNeo4jEventListener;
+import org.springframework.data.neo4j.examples.movies.domain.Actor;
+import org.springframework.data.neo4j.event.context.DataManipulationEventConfiguration;
+import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.data.neo4j.template.Neo4jTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+/**
+ * Test to assert the behaviour of {@link Neo4jTemplate}'s interaction with Spring application events.
+ * @author Adam George
+ */
+@ContextConfiguration(classes = DataManipulationEventConfiguration.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TemplateApplicationEventTest extends MultiDriverTestClass {
+
+    @Autowired
+    private Neo4jOperations neo4jTemplate;
+
+    @Autowired
+    private TestNeo4jEventListener<BeforeSaveEvent> beforeSaveEventListener;
+    @Autowired
+    private TestNeo4jEventListener<AfterSaveEvent> afterSaveEventListener;
+    @Autowired
+    private TestNeo4jEventListener<BeforeDeleteEvent> beforeDeleteEventListener;
+    @Autowired
+    private TestNeo4jEventListener<AfterDeleteEvent> afterDeleteEventListener;
+
+    @Test
+    public void shouldCreateTemplateAndPublishAppropriateApplicationEventsOnSaveAndOnDelete() {
+        assertNotNull("The Neo4jTemplate wasn't autowired into this test", this.neo4jTemplate);
+
+        Actor entity = new Actor();
+        entity.setName("John Abraham");
+
+        assertFalse(this.beforeSaveEventListener.hasReceivedAnEvent());
+        assertFalse(this.afterSaveEventListener.hasReceivedAnEvent());
+        this.neo4jTemplate.save(entity);
+        assertTrue(this.beforeSaveEventListener.hasReceivedAnEvent());
+        assertSame(entity, this.beforeSaveEventListener.getEvent().getEntity());
+        assertTrue(this.afterSaveEventListener.hasReceivedAnEvent());
+        assertSame(entity, this.afterSaveEventListener.getEvent().getEntity());
+
+        assertFalse(this.beforeDeleteEventListener.hasReceivedAnEvent());
+        assertFalse(this.afterDeleteEventListener.hasReceivedAnEvent());
+        this.neo4jTemplate.delete(entity);
+        assertTrue(this.beforeDeleteEventListener.hasReceivedAnEvent());
+        assertSame(entity, this.beforeDeleteEventListener.getEvent().getEntity());
+        assertTrue(this.afterDeleteEventListener.hasReceivedAnEvent());
+        assertSame(entity, this.afterDeleteEventListener.getEvent().getEntity());
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/context/DataManipulationEventConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/context/DataManipulationEventConfiguration.java
@@ -10,7 +10,7 @@
  * conditions of the subcomponent's license, as noted in the LICENSE file.
  */
 
-package org.springframework.data.neo4j.template.context;
+package org.springframework.data.neo4j.event.context;
 
 import org.neo4j.ogm.session.SessionFactory;
 import org.springframework.context.ApplicationListener;
@@ -21,7 +21,6 @@ import org.springframework.data.neo4j.event.AfterDeleteEvent;
 import org.springframework.data.neo4j.event.AfterSaveEvent;
 import org.springframework.data.neo4j.event.BeforeDeleteEvent;
 import org.springframework.data.neo4j.event.BeforeSaveEvent;
-import org.springframework.data.neo4j.template.TestNeo4jEventListener;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/context/TestNeo4jEventListener.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/event/context/TestNeo4jEventListener.java
@@ -10,7 +10,7 @@
  * conditions of the subcomponent's license, as noted in the LICENSE file.
  */
 
-package org.springframework.data.neo4j.template;
+package org.springframework.data.neo4j.event.context;
 
 import org.springframework.context.ApplicationListener;
 import org.springframework.data.neo4j.event.Neo4jDataManipulationEvent;

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
@@ -12,6 +12,7 @@
 package org.springframework.data.neo4j.extensions;
 
 import org.neo4j.ogm.session.Session;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.neo4j.repository.GraphRepositoryImpl;
 import org.springframework.stereotype.Repository;
 
@@ -23,8 +24,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class CustomGraphRepositoryImpl<T> extends GraphRepositoryImpl<T> implements CustomGraphRepository<T> {
 
-    public CustomGraphRepositoryImpl(Class<T> clazz, Session session) {
-        super(clazz, session);
+    public CustomGraphRepositoryImpl(Class<T> clazz, Session session, ApplicationEventPublisher applicationEventPublisher) {
+        super(clazz, session, applicationEventPublisher);
     }
 
     @Override

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/ProgrammaticRepositoryTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/ProgrammaticRepositoryTest.java
@@ -44,7 +44,7 @@ public class ProgrammaticRepositoryTest extends MultiDriverTestClass {
     @Test
     public void canInstantiateRepositoryProgrammatically() {
 
-        RepositoryFactorySupport factory = new GraphRepositoryFactory(session);
+        RepositoryFactorySupport factory = new GraphRepositoryFactory(session, null);
 
         movieRepository = factory.getRepository(MovieRepository.class);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTest.java
@@ -8,6 +8,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.springframework.aop.framework.Advised;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.neo4j.repository.GraphRepository;
 import org.springframework.data.neo4j.repository.GraphRepositoryImpl;
 import org.springframework.data.neo4j.repository.support.GraphRepositoryFactory;
@@ -43,7 +44,7 @@ public class GraphRepositoryFactoryTest extends MultiDriverTestClass {
     @Before
     public void setUp() {
 
-        factory = new GraphRepositoryFactory(session) {
+        factory = new GraphRepositoryFactory(session, null) {
 
         };
     }
@@ -82,8 +83,8 @@ public class GraphRepositoryFactoryTest extends MultiDriverTestClass {
     }
 
     static class CustomGraphRepository<T> extends GraphRepositoryImpl<T> {
-        public CustomGraphRepository(Class<T> clazz, Session session) {
-            super(clazz, session);
+        public CustomGraphRepository(Class<T> clazz, Session session, ApplicationEventPublisher applicationEventPublisher) {
+            super(clazz, session, applicationEventPublisher);
         }
     }
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/ExceptionTranslationTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/ExceptionTranslationTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
-import org.springframework.data.neo4j.template.context.DataManipulationEventConfiguration;
+import org.springframework.data.neo4j.event.context.DataManipulationEventConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
Possible fix for issue #139 and DATAGRAPH-533, in which Neo4jDataManipulationEvents are not fired on graph repositories.