### PR TITLE
Cypher-based Message Source on 3.5.x branch

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/context/support/CypherMessageSource.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/context/support/CypherMessageSource.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2011-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.context.support;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.LocaleUtils;
+import org.neo4j.graphdb.Node;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.data.neo4j.conversion.Result;
+import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * An implementation of {@link org.springframework.context.MessageSource}
+ * which loads messages from a graph database using Cypher, 
+ * supporting basic localization and internationalization.
+ * </p>
+ * <p>
+ * The Cypher query used to retrieve localized messages from the database can be 
+ * overridden by using <code>setQueryCypher()</code>. Messages can be created within 
+ * the database by using Cypher statements such as:
+ * <br/>
+ * <br/>
+ * <blockquote>
+ * <pre>
+ * CREATE (n1:LocalizedMessage { code: 'goodbye', en_US: 'Goodbye', en_GB: 'Cheerio'})
+ * </pre>
+ * </blockquote>
+ * </p>
+ * <p>
+ * Should your application make use of JavaConfig, this class can be registered within 
+ * your <code>ApplicationContext</code> by using the following configuration:
+ * </p>
+ * <blockquote>
+ * <pre>
+ * {@literal @}Bean
+ *   public MessageSource messageSource() {
+ *
+ *        MessageSource cypherMessageSource = new CypherMessageSource();
+ *
+ *        return cypherMessageSource;
+ *
+ *    }
+ * }
+ * </pre>
+ * </blockquote>
+ * @author Eric Spiegelberg - eric [at] miletwentyfour [dot] com
+ */
+@Service
+public class CypherMessageSource extends AbstractMessageSource {
+
+    @Autowired
+    private Neo4jOperations neo4jOperations;
+
+    private boolean initialized;
+
+    private String queryCypher = "match (n:LocalizedMessage) return n";
+
+    private Map<String, Map<Locale, String>> messages = new HashMap<String, Map<Locale, String>>();
+
+    public void initialize() {
+
+        if (!initialized && neo4jOperations != null) {
+
+            initialized = true;
+
+            Map<String, Object> parameters = new HashMap<String, Object>();
+            Result<Map<String, Object>> results = neo4jOperations.query(queryCypher, parameters);
+            Iterator<Map<String, Object>> resultsIterator = results.iterator();
+            
+            while (resultsIterator.hasNext()) {
+            
+            	Map<String, Object> result = resultsIterator.next();
+
+                Iterator<Entry<String, Object>> resultEntry = result.entrySet().iterator();
+
+                while (resultEntry.hasNext()) {
+
+                    Entry<String, Object> node = resultEntry.next();
+
+                    Node n = (Node) node.getValue();
+                    
+                    String code = n.removeProperty("code").toString();
+                    
+                    Iterable<String> propertyKeys = n.getPropertyKeys();
+                    
+                    for (String propertyKey : propertyKeys) {
+                    	
+                    	String message = n.getProperty(propertyKey).toString();
+
+                    	String localeString = propertyKey;
+                        Locale locale = LocaleUtils.toLocale(localeString);
+
+                        addMessage(code, locale, message);
+                        
+                    }
+                    
+                }
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Associate the given message with the given code.
+     *
+     * @param code the lookup code
+     * @param locale the locale that the message should be found within
+     * @param text the message associated with this lookup code
+     */
+    public void addMessage(String code, Locale locale, String text) {
+
+        Assert.notNull(text, "Text must not be null");
+        Assert.notNull(code, "Code must not be null");
+        Assert.notNull(locale, "Locale must not be null");
+
+        initialize();
+
+        Map<Locale, String> messagesByCode = messages.get(code);
+
+        if (messagesByCode == null) {
+            messagesByCode = new HashMap<Locale, String>();
+            messages.put(code, messagesByCode);
+        }
+
+        messagesByCode.put(locale, text);
+
+    }
+
+    @Override
+    protected MessageFormat resolveCode(String code, Locale locale) {
+
+        initialize();
+
+        Map<Locale, String> localeToTextMap = messages.get(code);
+        String text = localeToTextMap.get(locale);
+
+        return createMessageFormat(text, locale);
+
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setUninitialized() {
+
+        this.initialized = false;
+
+    }
+
+    public String getQueryCypher() {
+        return queryCypher;
+    }
+
+    public void setQueryCypher(String queryCypher) {
+        this.queryCypher = queryCypher;
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/context/support/CypherMessageSourceTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/context/support/CypherMessageSourceTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2011-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.context.support;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.support.Neo4jTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Test coverage of the <code>CypherMessageSource</code>.
+ * 
+ * Both an integration and unit test are provided.
+ * 
+ * @author Eric Spiegelberg - eric [at] miletwentyfour [dot] com
+ */
+@Transactional
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class CypherMessageSourceTest {
+
+	@Autowired
+	private Neo4jTemplate neo4jTemplate;
+
+	@Autowired
+	private CypherMessageSource cypherMessageSource;
+
+	/**
+	 * This inner class uses JavaConfig to wire up the required dependencies and
+	 * configuration.
+	 */
+	@Configuration
+	@EnableNeo4jRepositories
+	protected static class TestConfig extends Neo4jConfiguration {
+
+		TestConfig() throws ClassNotFoundException {
+			setBasePackage(getClass().getPackage().getName());
+		}
+
+		@Bean
+		GraphDatabaseService graphDatabaseService() {
+			return new TestGraphDatabaseFactory().newImpermanentDatabase();
+		}
+
+		@Bean
+		public MessageSource messageSource() {
+
+			CypherMessageSource cypherMessageSource = new CypherMessageSource();
+
+			return cypherMessageSource;
+
+		}
+
+	}
+
+	/**
+	 * Reinitialize the CypherMessageSource between each test. This allows each
+	 * test to populate the CypherMessageSource with its own desired messages.
+	 */
+	@Before
+	public void setUp() {
+
+		cypherMessageSource.setUninitialized();
+
+	}
+
+	@Test
+	public void testLocalizedText() {
+
+		String code = "description";
+
+		String textUS = "This is the US description";
+		cypherMessageSource.addMessage(code, Locale.US, textUS);
+		String localizedText = cypherMessageSource.getMessage(code, new Object[] {}, Locale.US);
+		Assert.assertEquals(textUS, localizedText);
+
+		localizedText = cypherMessageSource.getMessage(code, new Object[] {}, Locale.UK);
+		Assert.assertEquals("", localizedText);
+		String textUK = "This is the UK description";
+		cypherMessageSource.addMessage(code, Locale.UK, textUK);
+		localizedText = cypherMessageSource.getMessage(code, new Object[] {}, Locale.UK);
+		Assert.assertEquals(textUK, localizedText);
+
+	}
+
+	/**
+	 * An integration populating the <code>CypherMessageSource</code> from the
+	 * impermanent database.
+	 */
+	@Test
+	@Transactional
+	public void testIntegration() {
+
+		// Delete any previously existing LocalizedMessage's
+		Map<String, Object> parameters = new HashMap<String, Object>(0);
+		String deleteLocalizedMessagesCypher = "match (n:LocalizedMessage) delete n";
+		neo4jTemplate.query(deleteLocalizedMessagesCypher, parameters);
+
+		String hello = "Hello";
+		String welcome = "Welcome";
+		String save = "Save";
+		String persist = "Persist";
+		String goodbye = "Goodbye";
+		String cherrio = "Cherrio";
+
+		String createLocalizedMessage1Cypher = "CREATE (n1:LocalizedMessage { code: 'welcome', en_US: '" + welcome + "', en_GB: '" + hello + "'})";
+		neo4jTemplate.query(createLocalizedMessage1Cypher, parameters);
+
+		String createLocalizedMessage2Cypher = "CREATE (n1:LocalizedMessage { code: 'save', en_US: '" + save + "', en_GB: '" + persist + "'})";
+		neo4jTemplate.query(createLocalizedMessage2Cypher, parameters);
+
+		String createLocalizedMessage3Cypher = "CREATE (n1:LocalizedMessage { code: 'goodbye', en_US: '" + goodbye + "', en_GB: '" + cherrio + "'})";
+		neo4jTemplate.query(createLocalizedMessage3Cypher, parameters);
+
+		String args[] = new String[] {};
+
+		String welcomeUS = cypherMessageSource.getMessage("welcome", args, Locale.US);
+		Assert.assertEquals(welcome, welcomeUS);
+
+		String welcomeUK = cypherMessageSource.getMessage("welcome", args, Locale.UK);
+		Assert.assertEquals(hello, welcomeUK);
+
+		String saveUS = cypherMessageSource.getMessage("save", args, Locale.US);
+		Assert.assertEquals(save, saveUS);
+
+		String saveUK = cypherMessageSource.getMessage("save", args, Locale.UK);
+		Assert.assertEquals(persist, saveUK);
+
+		String goodbyeUS = cypherMessageSource.getMessage("goodbye", args, Locale.US);
+		Assert.assertEquals(goodbye, goodbyeUS);
+
+		String goodbyeUK = cypherMessageSource.getMessage("goodbye", args, Locale.UK);
+		Assert.assertEquals(cherrio, goodbyeUK);
+
+	}
+
+	/**
+	 * Test/demonstrate the changing of the <code>CypherMessageSource</code> query.
+	 */
+	@Test
+	@Transactional
+	public void testSetQueryCypher() {
+
+		// Delete any previously existing LocalizedMessage's
+		Map<String, Object> parameters = new HashMap<String, Object>(0);
+		String deleteLocalizedMessagesCypher = "match (n:LocalizedText) delete n";
+		neo4jTemplate.query(deleteLocalizedMessagesCypher, parameters);
+
+		String queryCypher = "match (n:LocalizedText) return n";
+		cypherMessageSource.setQueryCypher(queryCypher);
+		
+		String hello = "Hello";
+		String welcome = "Welcome";
+
+		String createLocalizedMessage1Cypher = "CREATE (n1:n:LocalizedText { code: 'welcome', en_US: '" + welcome + "', en_GB: '" + hello + "'})";
+		neo4jTemplate.query(createLocalizedMessage1Cypher, parameters);
+
+		String args[] = new String[] {};
+
+		String welcomeUS = cypherMessageSource.getMessage("welcome", args, Locale.US);
+		Assert.assertEquals(welcome, welcomeUS);
+
+	}
+
+}


### PR DESCRIPTION
Resubmitted against the newly created 3.5.x branch.

The previous submission was against the 3.4.x branch and was pull request https://github.com/spring-projects/spring-data-neo4j/pull/328

------------------------

The Spring framework provides the MessageSource interface for resolving messages, with support for the parameterization and internationalization. Two out-of-the-box implementations are provided: ResourceBundleMessageSource, built on top of the standard ResourceBundle, and ReloadableResourceBundleMessageSource, being able to reload message definitions without restarting the VM.

While these implementations work very well, they rely on the message definitions being defined on the filesystem. It is not uncommon for some developers to create a custom MessageSource implementation that is backed by a database, rather than filesystem, and the web has numerous examples of such implementations using JDBC.

I believe a MessageSource implementation that makes use of Cypher to load messages from Neo4j is a worthwhile addition to the Spring Data Neo4j project. As developed on my SDN fork on github, I have created an implementation (and tests) and am submitting it for contribution.