### PR TITLE
Cypher-based Message Source on 4.1.x branch

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/context/support/CypherMessageSource.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/context/support/CypherMessageSource.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+package org.springframework.data.neo4j.context.support;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.LocaleUtils;
+import org.neo4j.ogm.model.Result;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * An implementation of {@link org.springframework.context.MessageSource} which loads messages from a graph database using Cypher, supporting basic localization and internationalization.
+ * </p>
+ * <p>
+ * The Cypher query used to retrieve localized messages from the database can be overridden by using <code>setQueryCypher()</code>. Messages can be created within the database by using Cypher
+ * statements such as: <br/>
+ * <br/>
+ * <blockquote>
+ * 
+ * <pre>
+ * CREATE (n1:LocalizedMessage { code: 'goodbye', en_US: 'Goodbye', en_GB: 'Cheerio'})
+ * </pre>
+ * 
+ * </blockquote>
+ * </p>
+ * <p>
+ * Should your application make use of JavaConfig, this class can be registered with your <code>ApplicationContext</code> by using the following configuration:
+ * </p>
+ * <blockquote>
+ * 
+ * <pre>
+ * {@literal @}Bean
+ *   public MessageSource messageSource() {
+ *
+ *        MessageSource cypherMessageSource = new CypherMessageSource();
+ *
+ *        return cypherMessageSource;
+ *
+ *    }
+ * }
+ * </pre>
+ * 
+ * </blockquote>
+ * 
+ * @author Eric Spiegelberg - eric [at] miletwentyfour [dot] com
+ */
+@Service
+public class CypherMessageSource extends AbstractMessageSource {
+
+    @Autowired
+    private Neo4jOperations neo4jOperations;
+
+    private boolean initialized;
+
+    private String queryCypher = "match (n:LocalizedMessage) return n.code as code, n.en_US as en_US, n.en_GB as en_GB";
+
+    private Map<String, Map<Locale, String>> messages = new HashMap<String, Map<Locale, String>>();
+
+    public void initialize() {
+
+        Assert.notNull(neo4jOperations, "neo4jOperations must not be null");
+
+        if (!initialized) {
+
+            initialized = true;
+
+            Map<String, Object> parameters = new HashMap<String, Object>();
+            Result results = neo4jOperations.query(queryCypher, parameters);
+
+            Iterable<Map<String, Object>> resultNodes = results.queryResults();
+
+            for (Map<String, Object> nodeMap : resultNodes) {
+
+                String code = nodeMap.remove("code").toString();
+
+                Set<String> propertyKeys = nodeMap.keySet();
+
+                for (String propertyKey : propertyKeys) {
+
+                    String message = nodeMap.get(propertyKey).toString();
+
+                    Locale locale = LocaleUtils.toLocale(propertyKey);
+                    addMessage(code, locale, message);
+
+                }
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Associate the given message with the given code.
+     *
+     * @param code the lookup code
+     * @param locale the locale that the message should be found within
+     * @param text the message associated with this lookup code
+     */
+    public void addMessage(String code, Locale locale, String text) {
+
+        Assert.notNull(text, "Text must not be null");
+        Assert.notNull(code, "Code must not be null");
+        Assert.notNull(locale, "Locale must not be null");
+
+        initialize();
+
+        Map<Locale, String> messagesByCode = messages.get(code);
+
+        if (messagesByCode == null) {
+            messagesByCode = new HashMap<Locale, String>();
+            messages.put(code, messagesByCode);
+        }
+
+        messagesByCode.put(locale, text);
+
+    }
+
+    @Override
+    protected MessageFormat resolveCode(String code, Locale locale) {
+
+        initialize();
+
+        Map<Locale, String> localeToTextMap = messages.get(code);
+        String text = localeToTextMap.get(locale);
+
+        return createMessageFormat(text, locale);
+
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setUninitialized() {
+
+        this.initialized = false;
+
+    }
+
+    public String getQueryCypher() {
+        return queryCypher;
+    }
+
+    public void setQueryCypher(String queryCypher) {
+        this.queryCypher = queryCypher;
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/CypherMessageSourceTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/CypherMessageSourceTest.java
@@ -113,23 +113,4 @@ public class CypherMessageSourceTest extends MultiDriverTestClass {
 
 	}
 
-	/**
-	 * Test/demonstrate the changing of the <code>CypherMessageSource</code> query.
-	 */
-	//@Test
-	public void testSetQueryCypher() {
-
-		Map<String, Object> parameters = new HashMap<String, Object>(0);
-		String createLocalizedMessageCypher = "CREATE (n:LocalizedMessage { custom_code: 'beverage', en_US: 'Coffee', en_GB: 'Tea'})";
-		neo4jTemplate.query(createLocalizedMessageCypher, parameters);
-
-		String queryCypher = "match (n:LocalizedMessage) return n.custom_code as code, n.en_US as en_US, n.en_GB as en_GB";
-		cypherMessageSource.setQueryCypher(queryCypher);
-
-		String args[] = new String[] {};
-
-		String beverage = cypherMessageSource.getMessage("beverage", args, Locale.US);
-		Assert.assertEquals("Coffee", beverage);
-
-	}
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/CypherMessageSourceTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/CypherMessageSourceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.examples.cypherMessageSource;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.context.support.CypherMessageSource;
+import org.springframework.data.neo4j.examples.cypherMessageSource.context.CypherMessageSourceContext;
+import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test coverage of the <code>CypherMessageSource</code>.
+ * 
+ * @author Eric Spiegelberg - eric [at] miletwentyfour [dot] com
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { CypherMessageSourceContext.class })
+public class CypherMessageSourceTest extends MultiDriverTestClass {
+
+    @Autowired
+    Session session;
+
+    @Autowired
+    Neo4jOperations neo4jTemplate;
+
+    @Autowired
+    CypherMessageSource messageSource;
+
+    @Test
+    public void unitTest() {
+
+    }
+
+    /**
+     * This integration test populates the underlying Neo4j instance with messages codes. The 
+     * autowired <code>CypherMessageSource</code> is used to retreive the internationalized messages.
+     */
+    @Test
+    public void integrationTest() {
+
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        String createCypher = "CREATE (n1:LocalizedMessage { code: 'hello', en_US: 'Hello', en_GB: 'Greetings'})";
+        neo4jTemplate.query(createCypher, params);
+
+        createCypher = "CREATE (n1:LocalizedMessage { code: 'goodbye', en_US: 'Goodbye', en_GB: 'Cheerio'})";
+        neo4jTemplate.query(createCypher, params);
+
+        String message = messageSource.getMessage("hello", new String[] {}, Locale.US);
+        Assert.assertEquals("Hello", message);
+
+        message = messageSource.getMessage("hello", new String[] {}, Locale.UK);
+        Assert.assertEquals("Greetings", message);
+
+        message = messageSource.getMessage("goodbye", new String[] {}, Locale.US);
+        Assert.assertEquals("Goodbye", message);
+
+        message = messageSource.getMessage("goodbye", new String[] {}, Locale.UK);
+        Assert.assertEquals("Cheerio", message);
+
+    }
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/context/CypherMessageSourceContext.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/cypherMessageSource/context/CypherMessageSourceContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.examples.cypherMessageSource.context;
+
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.context.support.CypherMessageSource;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Eric Spiegelberg - eric [at] miletwentyfour [dot] com
+ */
+@Configuration
+@EnableTransactionManagement
+@EnableNeo4jRepositories("org.springframework.data.neo4j.examples.cypherMessageSource.repo")
+@ComponentScan({ "org.springframework.data.neo4j.examples.cypherMessageSource" })
+public class CypherMessageSourceContext extends Neo4jConfiguration {
+
+    @Bean
+    @Override
+    public SessionFactory getSessionFactory() {
+        return new SessionFactory("org.springframework.data.neo4j.examples.cypherMessageSource.domain");
+    }
+
+    @Bean
+    public MessageSource getMessageSource() {
+
+        CypherMessageSource cypherMessageSouce = new CypherMessageSource();
+
+        return cypherMessageSouce;
+    }
+
+}


### PR DESCRIPTION
A parallel submission of these changes were submitted against the 3.5.x branch as pull request #329

The Spring framework provides the MessageSource interface for resolving messages, with support for the parameterization and internationalization. Two out-of-the-box implementations are provided: ResourceBundleMessageSource, built on top of the standard ResourceBundle, and ReloadableResourceBundleMessageSource, being able to reload message definitions without restarting the VM.

While these implementations work very well, they rely on the message definitions being defined on the filesystem. It is not uncommon for some developers to create a custom MessageSource implementation that is backed by a database, rather than filesystem, and the web has numerous examples of such implementations using JDBC.

I believe a MessageSource implementation that makes use of Cypher to load messages from Neo4j is a worthwhile addition to the Spring Data Neo4j project. As developed on my SDN fork on github, I have created an implementation (and tests) and am submitting it for contribution.