### PR TITLE
Change info to debug level for session init

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
@@ -50,7 +50,7 @@ public abstract class Neo4jConfiguration {
 
     @Bean
     public Session getSession() throws Exception {
-        logger.info("Initialising Neo4jSession");
+        logger.debug("Initialising Neo4jSession");
         SessionFactory sessionFactory = getSessionFactory();
         Assert.notNull(sessionFactory, "You must provide a SessionFactory instance in your Spring configuration classes");
         return sessionFactory.openSession();


### PR DESCRIPTION
In a web environment `getSession` can potentially get called very often.