### PR TITLE
DATAGRAPH-879 - Add repository support using CDI

### DIFF
--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -108,6 +108,28 @@
                 <version>3.1.0</version>
             </dependency>
 
+            <dependency>
+                <groupId>javax.el</groupId>
+                <artifactId>el-api</artifactId>
+                <version>${cdi}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- CDI -->
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>${cdi}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.openwebbeans.test</groupId>
+                <artifactId>cditest-owb</artifactId>
+                <version>${webbeans}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
 
     <build>

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repository.cdi;
+
+import org.neo4j.ogm.session.Session;
+import org.springframework.data.neo4j.repository.support.GraphRepositoryFactory;
+import org.springframework.data.neo4j.template.Neo4jTemplate;
+import org.springframework.data.repository.cdi.CdiRepositoryBean;
+import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * {@link org.springframework.data.repository.cdi.CdiRepositoryBean} to create Neo4j repository instances via CDI.
+ *
+ * @author Mark Paluch
+ * @since 4.2
+ */
+public class Neo4jCdiRepositoryBean<T> extends CdiRepositoryBean<T> {
+    private final Bean<Session> sessionBean;
+
+    /**
+     * Creates a new {@link Neo4jCdiRepositoryBean}.
+     *
+     * @param sessionBean must not be {@literal null}.
+     * @param qualifiers must not be {@literal null}.
+     * @param repositoryType must not be {@literal null}.
+     * @param beanManager must not be {@literal null}.
+     * @param detector detector for the custom {@link org.springframework.data.repository.Repository} implementations
+     *        {@link CustomRepositoryImplementationDetector}, can be {@literal null}.
+     */
+    public Neo4jCdiRepositoryBean(Bean<Session> sessionBean, Set<Annotation> qualifiers, Class<T> repositoryType,
+                                  BeanManager beanManager, CustomRepositoryImplementationDetector detector) {
+        super(qualifiers, repositoryType, beanManager, detector);
+        this.sessionBean = sessionBean;
+    }
+
+    @Override
+    protected T create(CreationalContext<T> creationalContext, Class<T> repositoryType, Object customImplementation) {
+
+        Session session = getDependencyInstance(sessionBean, Session.class);
+        Neo4jTemplate neo4jTemplate = new Neo4jTemplate(session);
+
+        GraphRepositoryFactory factory = new GraphRepositoryFactory(session, neo4jTemplate);
+        return factory.getRepository(repositoryType, customImplementation);
+    }
+}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repository.cdi;
+
+import org.neo4j.ogm.session.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.repository.cdi.CdiRepositoryBean;
+import org.springframework.data.repository.cdi.CdiRepositoryExtensionSupport;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.ProcessBean;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * CDI extension to export Neo4j repositories.
+ *
+ * @author Mark Paluch
+ * @since 4.2
+ */
+public class Neo4jCdiRepositoryExtension extends CdiRepositoryExtensionSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Neo4jCdiRepositoryExtension.class);
+    private final Map<Set<Annotation>, Bean<Session>> sessionBeans = new HashMap<Set<Annotation>, Bean<Session>>();
+
+    public Neo4jCdiRepositoryExtension() {
+        LOG.info("Activating CDI extension for Spring Data Neo4j repositories.");
+    }
+
+    @SuppressWarnings("unchecked")
+    <X> void processBean(@Observes ProcessBean<X> processBean) {
+        Bean<X> bean = processBean.getBean();
+
+        for (Type type : bean.getTypes()) {
+            if (type instanceof Class<?> && Session.class.isAssignableFrom((Class<?>) type)) {
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Discovered %s with qualifiers %s.", Session.class.getName(),
+                            bean.getQualifiers()));
+                }
+
+                sessionBeans.put(new HashSet<Annotation>(bean.getQualifiers()), (Bean<Session>) bean);
+            }
+        }
+    }
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+
+        for (Entry<Class<?>, Set<Annotation>> entry : getRepositoryTypes()) {
+
+            Class<?> repositoryType = entry.getKey();
+            Set<Annotation> qualifiers = entry.getValue();
+
+            // Create the bean representing the repository.
+            CdiRepositoryBean<?> repositoryBean = createRepositoryBean(repositoryType, qualifiers, beanManager);
+            if (LOG.isInfoEnabled()) {
+                LOG.info(String.format("Registering bean for %s with qualifiers %s.", repositoryType.getName(),
+                        qualifiers));
+            }
+
+            // Register the bean to the container.
+            registerBean(repositoryBean);
+            afterBeanDiscovery.addBean(repositoryBean);
+        }
+    }
+
+    /**
+     * Creates a {@link Bean}.
+     *
+     * @param <T> The type of the repository.
+     * @param repositoryType The class representing the repository.
+     * @param beanManager The BeanManager instance.
+     * @return The bean.
+     */
+    private <T> CdiRepositoryBean<T> createRepositoryBean(Class<T> repositoryType, Set<Annotation> qualifiers,
+                                                          BeanManager beanManager) {
+        Bean<Session> sessionBean = this.sessionBeans.get(qualifiers);
+
+        if (sessionBean == null) {
+            throw new UnsatisfiedResolutionException(String.format(
+                    "Unable to resolve a bean for '%s' with qualifiers %s.", Session.class.getName(), qualifiers));
+        }
+
+        return new Neo4jCdiRepositoryBean<T>(sessionBean, qualifiers, repositoryType, beanManager,
+                getCustomImplementationDetector());
+    }
+}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * CDI support for Neo4j specific repository implementation.
+ */
+package org.springframework.data.neo4j.repository.cdi;

--- a/spring-data-neo4j/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/spring-data-neo4j/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.springframework.data.neo4j.repository.cdi.Neo4jCdiRepositoryExtension

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/CdiExtensionIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/CdiExtensionIntegrationTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import org.apache.webbeans.cditest.CdiTestContainer;
+import org.apache.webbeans.cditest.CdiTestContainerLoader;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+
+/**
+ * Integration tests for {@link org.springframework.data.neo4j.repository.cdi.Neo4jCdiRepositoryExtension}.
+ *
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+public class CdiExtensionIntegrationTests extends MultiDriverTestClass {
+
+    static CdiTestContainer container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // Prevent the Jersey extension to interact with the InitialContext
+        System.setProperty("com.sun.jersey.server.impl.cdi.lookupExtensionInBeanManager", "true");
+
+        setupMultiDriverTestEnvironment();
+
+        container = CdiTestContainerLoader.getCdiContainer();
+        container.bootContainer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+
+        container.shutdownContainer();
+
+        tearDownMultiDriverTestEnvironment();
+    }
+
+    /**
+     * @see DATAGRAPH-879
+     */
+    @Test
+    @SuppressWarnings("null")
+    public void regularRepositoryShouldWork() {
+
+        RepositoryClient client = container.getInstance(RepositoryClient.class);
+        CdiPersonRepository repository = client.repository;
+
+        assertThat(repository, is(notNullValue()));
+
+        Person person = null;
+        Person result = null;
+
+        repository.deleteAll();
+
+        person = new Person();
+        person.setFirstName("Homer");
+        person.setLastName("Simpson");
+
+        result = repository.save(person);
+
+        assertThat(result, is(notNullValue()));
+        Long resultId = result.getId();
+        Person lookedUpPerson = repository.findOne(person.getId());
+        assertThat(lookedUpPerson.getId(), is(resultId));
+    }
+
+    /**
+     * @see DATAGRAPH-879
+     */
+    @Test
+    @SuppressWarnings("null")
+    public void repositoryWithQualifiersShouldWork() {
+
+        RepositoryClient client = container.getInstance(RepositoryClient.class);
+        client.qualifiedPersonRepository.deleteAll();
+
+        assertEquals(0, client.qualifiedPersonRepository.count());
+    }
+
+    /**
+     * @see DATAGRAPH-879
+     */
+    @Test
+    @SuppressWarnings("null")
+    public void repositoryWithCustomImplementationShouldWork() {
+
+        RepositoryClient client = container.getInstance(RepositoryClient.class);
+
+        assertEquals(1, client.samplePersonRepository.returnOne());
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/CdiPersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/CdiPersonRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+public interface CdiPersonRepository extends Repository<Person, Long> {
+
+    void deleteAll();
+
+    Person save(Person person);
+
+    Person findOne(Long id);
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/Neo4jCdiProducer.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/Neo4jCdiProducer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+/**
+ * Simple component exposing a {@link org.neo4j.ogm.session.Session} as CDI bean.
+ *
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+class Neo4jCdiProducer {
+
+    @Produces
+    @ApplicationScoped
+    Session createSession() {
+
+        SessionFactory sessionFactory = new SessionFactory(Person.class.getPackage().getName());
+        return sessionFactory.openSession();
+    }
+
+    @Produces
+    @ApplicationScoped
+    @PersonDB
+    @OtherQualifier
+    Session createQualifiedSession() {
+        return createSession();
+    }
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/OtherQualifier.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/OtherQualifier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@interface OtherQualifier {
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/PersonDB.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/PersonDB.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repositories.cdi;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@interface PersonDB {
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/QualifiedPersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/QualifiedPersonRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+@OtherQualifier
+@PersonDB
+public interface QualifiedPersonRepository extends CrudRepository<Person, Long> {
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/RepositoryClient.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/RepositoryClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import javax.inject.Inject;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+class RepositoryClient {
+
+    @Inject
+    CdiPersonRepository repository;
+
+    @OtherQualifier
+    @PersonDB
+    @Inject
+    QualifiedPersonRepository qualifiedPersonRepository;
+
+    @Inject
+    SamplePersonRepository samplePersonRepository;
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+public interface SamplePersonRepository extends Repository<Person, Long>, SamplePersonRepositoryCustom {
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepositoryCustom.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepositoryCustom.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+interface SamplePersonRepositoryCustom {
+
+    int returnOne();
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/cdi/SamplePersonRepositoryImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.repositories.cdi;
+
+/**
+ * @author Mark Paluch
+ * @see DATAGRAPH-879
+ */
+class SamplePersonRepositoryImpl implements SamplePersonRepositoryCustom {
+
+    @Override
+    public int returnOne() {
+        return 1;
+    }
+}

--- a/spring-data-neo4j/src/test/resources/META-INF/beans.xml
+++ b/spring-data-neo4j/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>


### PR DESCRIPTION
Spring Data Neo4j now supports CDI by exporting Neo4j repositories as CDI beans. CDI users need to provide a `org.neo4j.ogm.session.Session` bean to connect to Neo4j. The CDI extension supports qualifiers and custom repository implementations.