### PR TITLE
Support non Long ID's on Repositories.

### DIFF
--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>spring-data-neo4j</artifactId>
 
     <properties>
-        <neo4j.ogm.version>2.1.0-RC1</neo4j.ogm.version>
+        <neo4j.ogm.version>2.1.0-SNAPSHOT</neo4j.ogm.version>
         <ogm.properties>ogm-http.properties</ogm.properties>
     </properties>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepository.java
@@ -13,6 +13,8 @@
 
 package org.springframework.data.neo4j.repository;
 
+import java.io.Serializable;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -26,13 +28,13 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * @author Mark ANgrish
  */
 @NoRepositoryBean
-public interface GraphRepository<T> extends PagingAndSortingRepository<T, Long> {
+public interface GraphRepository<T, ID extends Serializable> extends PagingAndSortingRepository<T, ID> {
 
 	<S extends T> S save(S s, int depth);
 
 	<S extends T> Iterable<S> save(Iterable<S> entities, int depth);
 
-	T findOne(Long id, int depth);
+	T findOne(ID id, int depth);
 
 	Iterable<T> findAll();
 
@@ -43,13 +45,13 @@ public interface GraphRepository<T> extends PagingAndSortingRepository<T, Long> 
 	Iterable<T> findAll(Sort sort, int depth);
 
 
-	Iterable<T> findAll(Iterable<Long> ids);
+	Iterable<T> findAll(Iterable<ID> ids);
 
-	Iterable<T> findAll(Iterable<Long> ids, int depth);
+	Iterable<T> findAll(Iterable<ID> ids, int depth);
 
-	Iterable<T> findAll(Iterable<Long> ids, Sort sort);
+	Iterable<T> findAll(Iterable<ID> ids, Sort sort);
 
-	Iterable<T> findAll(Iterable<Long> ids, Sort sort, int depth);
+	Iterable<T> findAll(Iterable<ID> ids, Sort sort, int depth);
 
 	/**
 	 * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
@@ -13,10 +13,13 @@
 
 package org.springframework.data.neo4j.repository;
 
+import java.io.Serializable;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
  * Neo4j OGM specific extension of {@link org.springframework.data.repository.Repository}.
@@ -24,13 +27,14 @@ import org.springframework.data.domain.Sort;
  * @author Vince Bickers
  * @author Mark ANgrish
  */
-public interface GraphRepository<T> extends Neo4jRepository<T, Long> {
+@NoRepositoryBean
+public interface Neo4jRepository<T, ID extends Serializable> extends PagingAndSortingRepository<T, ID> {
 
 	<S extends T> S save(S s, int depth);
 
 	<S extends T> Iterable<S> save(Iterable<S> entities, int depth);
 
-	T findOne(Long id, int depth);
+	T findOne(ID id, int depth);
 
 	Iterable<T> findAll();
 
@@ -40,14 +44,13 @@ public interface GraphRepository<T> extends Neo4jRepository<T, Long> {
 
 	Iterable<T> findAll(Sort sort, int depth);
 
+	Iterable<T> findAll(Iterable<ID> ids);
 
-	Iterable<T> findAll(Iterable<Long> ids);
+	Iterable<T> findAll(Iterable<ID> ids, int depth);
 
-	Iterable<T> findAll(Iterable<Long> ids, int depth);
+	Iterable<T> findAll(Iterable<ID> ids, Sort sort);
 
-	Iterable<T> findAll(Iterable<Long> ids, Sort sort);
-
-	Iterable<T> findAll(Iterable<Long> ids, Sort sort, int depth);
+	Iterable<T> findAll(Iterable<ID> ids, Sort sort, int depth);
 
 	/**
 	 * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.support.Neo4jRepositoryFactoryBean;
 import org.springframework.data.neo4j.repository.support.SessionBeanDefinitionRegistrarPostProcessor;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
@@ -94,7 +94,7 @@ public class Neo4jRepositoryConfigurationExtension extends RepositoryConfigurati
 	 */
 	@Override
 	protected Collection<Class<?>> getIdentifyingTypes() {
-		return Collections.<Class<?>>singleton(GraphRepository.class);
+		return Collections.<Class<?>>singleton(Neo4jRepository.class);
 	}
 
 	/*

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
@@ -20,20 +20,20 @@ import java.io.Serializable;
 /**
  * @author Mark Angrish
  */
-public class GraphEntityInformation<ID extends Serializable, T> extends AbstractEntityInformation<T, Long> {
+public class GraphEntityInformation<T, ID extends Serializable> extends AbstractEntityInformation<T, ID> {
 
     public GraphEntityInformation(Class<T> type) {
         super(type);
     }
 
     @Override
-    public Long getId(T entity) {
+    public ID getId(T entity) {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     @Override
-    public Class<Long> getIdType() {
-        return Long.class;
+    public Class<ID> getIdType() {
+        return (Class<ID>) Long.class;
     }
 
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
@@ -13,6 +13,10 @@
 
 package org.springframework.data.neo4j.repository.support;
 
+import org.neo4j.ogm.MetaData;
+import org.neo4j.ogm.entity.io.EntityAccessManager;
+import org.neo4j.ogm.metadata.ClassInfo;
+import org.neo4j.ogm.metadata.FieldInfo;
 import org.springframework.data.repository.core.support.AbstractEntityInformation;
 
 import java.io.Serializable;
@@ -22,17 +26,33 @@ import java.io.Serializable;
  */
 public class GraphEntityInformation<T, ID extends Serializable> extends AbstractEntityInformation<T, ID> {
 
-    public GraphEntityInformation(Class<T> type) {
+    private final MetaData metaData;
+
+    public GraphEntityInformation(MetaData metaData, Class<T> type) {
         super(type);
+        this.metaData = metaData;
     }
 
     @Override
     public ID getId(T entity) {
-        throw new UnsupportedOperationException("Not implemented yet.");
+        final ClassInfo classInfo = metaData.classInfo(getJavaType().getName());
+        final FieldInfo primaryIndex = classInfo.primaryIndexField();
+
+        if (primaryIndex != null) {
+            return (ID) EntityAccessManager.getPropertyReader(classInfo, primaryIndex.getName()).readProperty(entity);
+        }
+        else {
+            return (ID) EntityAccessManager.getPropertyReader(classInfo, classInfo.identityField().getName()).readProperty(entity);
+        }
     }
 
     @Override
     public Class<ID> getIdType() {
+        final FieldInfo primaryIndex = metaData.classInfo(getJavaType().getName()).primaryIndexField();
+
+        if (primaryIndex != null) {
+            return (Class<ID>) primaryIndex.convertedType();
+        }
         return (Class<ID>) Long.class;
     }
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
@@ -15,6 +15,7 @@ package org.springframework.data.neo4j.repository.support;
 
 import java.io.Serializable;
 
+import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.Session;
 import org.springframework.data.neo4j.repository.query.GraphQueryLookupStrategy;
 import org.springframework.data.repository.core.EntityInformation;
@@ -54,7 +55,7 @@ public class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 	public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> type) {
 		Assert.notNull(type);
 		Assert.notNull(session);
-		return new GraphEntityInformation(type);
+		return new GraphEntityInformation(((Neo4jSession)session).metaData(), type);
 	}
 
 	@Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
@@ -52,6 +52,8 @@ public class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 
 	@Override
 	public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> type) {
+		Assert.notNull(type);
+		Assert.notNull(session);
 		return new GraphEntityInformation(type);
 	}
 
@@ -62,7 +64,7 @@ public class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 
 	@Override
 	protected Class<?> getRepositoryBaseClass(RepositoryMetadata repositoryMetadata) {
-		return SimpleGraphRepository.class;
+		return SimpleNeo4jRepository.class;
 	}
 
 	@Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -13,6 +13,8 @@
 
 package org.springframework.data.neo4j.repository.support;
 
+import java.io.Serializable;
+
 import org.neo4j.ogm.session.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mapping.context.MappingContext;
@@ -31,7 +33,7 @@ import org.springframework.util.Assert;
  * @author Luanne Misquitta
  * @author Mark Angrish
  */
-public class Neo4jRepositoryFactoryBean<T extends Repository<S, Long>, S> extends TransactionalRepositoryFactoryBeanSupport<T, S, Long> {
+public class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
 	private Session session;
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleGraphRepository.java
@@ -13,6 +13,7 @@
 
 package org.springframework.data.neo4j.repository.support;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -41,7 +42,7 @@ import org.springframework.util.Assert;
  */
 @Repository
 @Transactional(readOnly = true)
-public class SimpleGraphRepository<T> implements GraphRepository<T> {
+public class SimpleGraphRepository<T, ID extends Serializable> implements GraphRepository<T, ID> {
 
 	private static final int DEFAULT_QUERY_DEPTH = 1;
 	private static final String ID_MUST_NOT_BE_NULL = "The given id must not be null!";
@@ -81,13 +82,13 @@ public class SimpleGraphRepository<T> implements GraphRepository<T> {
 	}
 
 	@Override
-	public T findOne(Long id) {
+	public T findOne(ID id) {
 		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
 		return session.load(clazz, id);
 	}
 
 	@Override
-	public boolean exists(Long id) {
+	public boolean exists(ID id) {
 		return findOne(id) != null;
 	}
 
@@ -98,7 +99,7 @@ public class SimpleGraphRepository<T> implements GraphRepository<T> {
 
 	@Transactional
 	@Override
-	public void delete(Long id) {
+	public void delete(ID id) {
 		Object o = findOne(id);
 		if (o != null) {
 			session.delete(o);
@@ -140,7 +141,7 @@ public class SimpleGraphRepository<T> implements GraphRepository<T> {
 	}
 
 	@Override
-	public T findOne(Long id, int depth) {
+	public T findOne(ID id, int depth) {
 		return session.load(clazz, id, depth);
 	}
 
@@ -156,13 +157,13 @@ public class SimpleGraphRepository<T> implements GraphRepository<T> {
 	}
 
 	@Override
-	public Iterable<T> findAll(Iterable<Long> longs) {
+	public Iterable<T> findAll(Iterable<ID> longs) {
 		return findAll(longs, DEFAULT_QUERY_DEPTH);
 	}
 
 	@Override
-	public Iterable<T> findAll(Iterable<Long> ids, int depth) {
-		return session.loadAll(clazz, (Collection<Long>) ids, depth);
+	public Iterable<T> findAll(Iterable<ID> ids, int depth) {
+		return session.loadAll(clazz, (Collection<ID>) ids, depth);
 	}
 
 	@Override
@@ -176,12 +177,12 @@ public class SimpleGraphRepository<T> implements GraphRepository<T> {
 	}
 
 	@Override
-	public Iterable<T> findAll(Iterable<Long> ids, Sort sort) {
+	public Iterable<T> findAll(Iterable<ID> ids, Sort sort) {
 		return findAll(ids, sort, DEFAULT_QUERY_DEPTH);
 	}
 
 	@Override
-	public Iterable<T> findAll(Iterable<Long> ids, Sort sort, int depth) {
+	public Iterable<T> findAll(Iterable<ID> ids, Sort sort, int depth) {
 		return session.loadAll(clazz, (Collection<Long>) ids, convert(sort), depth);
 	}
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
@@ -25,7 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  */
 @Repository
 @Transactional(readOnly = true)
-public class SimpleGraphRepository<T, ID extends Serializable> implements GraphRepository<T, ID> {
+public class SimpleNeo4jRepository<T, ID extends Serializable> implements Neo4jRepository<T, ID> {
 
 	private static final int DEFAULT_QUERY_DEPTH = 1;
 	private static final String ID_MUST_NOT_BE_NULL = "The given id must not be null!";
@@ -51,12 +51,12 @@ public class SimpleGraphRepository<T, ID extends Serializable> implements GraphR
 	private Session session;
 
 	/**
-	 * Creates a new {@link SimpleGraphRepository} to manage objects of the given domain type.
+	 * Creates a new {@link SimpleNeo4jRepository} to manage objects of the given domain type.
 	 *
 	 * @param domainClass must not be {@literal null}.
 	 * @param session must not be {@literal null}.
 	 */
-	public SimpleGraphRepository(Class<T> domainClass, Session session) {
+	public SimpleNeo4jRepository(Class<T> domainClass, Session session) {
 		this.clazz = domainClass;
 		this.session = session;
 	}
@@ -183,7 +183,7 @@ public class SimpleGraphRepository<T, ID extends Serializable> implements GraphR
 
 	@Override
 	public Iterable<T> findAll(Iterable<ID> ids, Sort sort, int depth) {
-		return session.loadAll(clazz, (Collection<Long>) ids, convert(sort), depth);
+		return session.loadAll(clazz, (Collection<ID>) ids, convert(sort), depth);
 	}
 
 	@Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
@@ -18,8 +18,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.neo4j.ogm.MetaData;
 import org.neo4j.ogm.cypher.query.Pagination;
 import org.neo4j.ogm.cypher.query.SortOrder;
+import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.Session;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -57,6 +59,9 @@ public class SimpleNeo4jRepository<T, ID extends Serializable> implements Neo4jR
 	 * @param session must not be {@literal null}.
 	 */
 	public SimpleNeo4jRepository(Class<T> domainClass, Session session) {
+		Assert.notNull(domainClass);
+		Assert.notNull(session);
+
 		this.clazz = domainClass;
 		this.session = session;
 	}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
@@ -16,12 +16,12 @@ package org.springframework.data.neo4j.examples.friends.repo;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.examples.friends.domain.Friendship;
 import org.springframework.data.neo4j.examples.friends.domain.Person;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
  * @author Luanne Misquitta
  */
-public interface FriendshipRepository extends GraphRepository<Friendship, Long> {
+public interface FriendshipRepository extends Neo4jRepository<Friendship, Long> {
 
 	@Query("MATCH (person1)-[rel:IS_FRIEND]->(person2) WHERE ID(person1)={0} AND ID(person2)={1} return rel")
 	Friendship getFriendship(Person person1, Person person2);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
@@ -21,7 +21,7 @@ import org.springframework.data.neo4j.repository.GraphRepository;
 /**
  * @author Luanne Misquitta
  */
-public interface FriendshipRepository extends GraphRepository<Friendship> {
+public interface FriendshipRepository extends GraphRepository<Friendship, Long> {
 
 	@Query("MATCH (person1)-[rel:IS_FRIEND]->(person2) WHERE ID(person1)={0} AND ID(person2)={1} return rel")
 	Friendship getFriendship(Person person1, Person person2);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Repository;
  * @author Luanne Misquitta
  */
 @Repository
-public interface WorldRepository extends GraphRepository<World> {
+public interface WorldRepository extends GraphRepository<World, Long> {
 
     @Query("MATCH (n:World) SET n.updated=timestamp()")
     void touchAllWorlds();

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
@@ -17,6 +17,7 @@ import org.neo4j.ogm.model.Result;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.examples.galaxy.domain.World;
 import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Repository;
  * @author Luanne Misquitta
  */
 @Repository
-public interface WorldRepository extends GraphRepository<World, Long> {
+public interface WorldRepository extends GraphRepository<World> {
 
     @Query("MATCH (n:World) SET n.updated=timestamp()")
     void touchAllWorlds();

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
@@ -21,5 +21,5 @@ import org.springframework.stereotype.Repository;
  * @author Vince Bickers
  */
 @Repository
-public interface AdultRepository extends GraphRepository<Adult> {
+public interface AdultRepository extends GraphRepository<Adult, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
@@ -14,12 +14,12 @@
 package org.springframework.data.neo4j.examples.jsr303.repo;
 
 import org.springframework.data.neo4j.examples.jsr303.domain.Adult;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Vince Bickers
  */
 @Repository
-public interface AdultRepository extends GraphRepository<Adult, Long> {
+public interface AdultRepository extends Neo4jRepository<Adult, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
@@ -14,12 +14,12 @@
 package org.springframework.data.neo4j.examples.movies.repo;
 
 import org.springframework.data.neo4j.examples.movies.domain.AbstractAnnotatedEntity;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Michal Bachman
  */
 @Repository
-public interface AbstractAnnotatedEntityRepository extends GraphRepository<AbstractAnnotatedEntity, Long> {
+public interface AbstractAnnotatedEntityRepository extends Neo4jRepository<AbstractAnnotatedEntity, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
@@ -21,5 +21,5 @@ import org.springframework.stereotype.Repository;
  * @author Michal Bachman
  */
 @Repository
-public interface AbstractAnnotatedEntityRepository extends GraphRepository<AbstractAnnotatedEntity> {
+public interface AbstractAnnotatedEntityRepository extends GraphRepository<AbstractAnnotatedEntity, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
@@ -21,5 +21,5 @@ import org.springframework.stereotype.Repository;
  * @author Michal Bachman
  */
 @Repository
-public interface AbstractEntityRepository extends GraphRepository<AbstractEntity> {
+public interface AbstractEntityRepository extends GraphRepository<AbstractEntity, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
@@ -14,12 +14,12 @@
 package org.springframework.data.neo4j.examples.movies.repo;
 
 import org.springframework.data.neo4j.examples.movies.domain.AbstractEntity;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Michal Bachman
  */
 @Repository
-public interface AbstractEntityRepository extends GraphRepository<AbstractEntity, Long> {
+public interface AbstractEntityRepository extends Neo4jRepository<AbstractEntity, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
@@ -14,12 +14,12 @@
 package org.springframework.data.neo4j.examples.movies.repo;
 
 import org.springframework.data.neo4j.examples.movies.domain.Actor;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 
 /**
  * @author Michal Bachman
  */
-public interface ActorRepository extends GraphRepository<Actor, Long> {
+public interface ActorRepository extends Neo4jRepository<Actor, Long> {
 }
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
@@ -20,6 +20,6 @@ import org.springframework.data.neo4j.repository.GraphRepository;
 /**
  * @author Michal Bachman
  */
-public interface ActorRepository extends GraphRepository<Actor> {
+public interface ActorRepository extends GraphRepository<Actor, Long> {
 }
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Jasper Blues
  */
 @Repository
-public interface CinemaRepository extends GraphRepository<Cinema> {
+public interface CinemaRepository extends GraphRepository<Cinema, Long> {
 
 	Collection<Cinema> findByName(String name);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
@@ -21,7 +21,7 @@ import org.springframework.data.neo4j.annotation.Depth;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.examples.movies.domain.Cinema;
 import org.springframework.data.neo4j.examples.movies.domain.queryresult.CinemaQueryResultInterface;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.examples.movies.domain.queryresult.CinemaQueryResult;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Jasper Blues
  */
 @Repository
-public interface CinemaRepository extends GraphRepository<Cinema, Long> {
+public interface CinemaRepository extends Neo4jRepository<Cinema, Long> {
 
 	Collection<Cinema> findByName(String name);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/DirectorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/DirectorRepository.java
@@ -18,6 +18,6 @@ import org.springframework.data.neo4j.examples.movies.domain.Director;
 /**
  * @author Luanne Misquitta
  */
-public interface DirectorRepository extends PersonRepository<Director> {
+public interface DirectorRepository extends PersonRepository<Director, Long> {
 
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
@@ -21,5 +21,5 @@ import org.springframework.stereotype.Repository;
  * @author Michal Bachman
  */
 @Repository
-public interface GenreRepository extends GraphRepository<Genre> {
+public interface GenreRepository extends GraphRepository<Genre, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
@@ -14,12 +14,12 @@
 package org.springframework.data.neo4j.examples.movies.repo;
 
 import org.springframework.data.neo4j.examples.movies.domain.Genre;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Michal Bachman
  */
 @Repository
-public interface GenreRepository extends GraphRepository<Genre, Long> {
+public interface GenreRepository extends Neo4jRepository<Genre, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
@@ -17,12 +17,12 @@ import java.io.Serializable;
 import java.util.Collection;
 
 import org.springframework.data.neo4j.examples.movies.domain.Person;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
  * @author Luanne Misquitta
  */
-public interface PersonRepository<T extends Person, ID extends Serializable> extends GraphRepository<T, ID> {
+public interface PersonRepository<T extends Person, ID extends Serializable> extends Neo4jRepository<T, ID> {
 
 	Collection<T> findByName(String name);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
@@ -13,6 +13,7 @@
 
 package org.springframework.data.neo4j.examples.movies.repo;
 
+import java.io.Serializable;
 import java.util.Collection;
 
 import org.springframework.data.neo4j.examples.movies.domain.Person;
@@ -21,7 +22,7 @@ import org.springframework.data.neo4j.repository.GraphRepository;
 /**
  * @author Luanne Misquitta
  */
-public interface PersonRepository<T extends Person> extends GraphRepository<T> {
+public interface PersonRepository<T extends Person, ID extends Serializable> extends GraphRepository<T, ID> {
 
 	Collection<T> findByName(String name);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
@@ -16,13 +16,13 @@ package org.springframework.data.neo4j.examples.movies.repo;
 import java.util.List;
 
 import org.springframework.data.neo4j.examples.movies.domain.Rating;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
  * @author Luanne Misquitta
  * @author Vince Bickers
  */
-public interface RatingRepository extends GraphRepository<Rating, Long> {
+public interface RatingRepository extends Neo4jRepository<Rating, Long> {
 
 	List<Rating> findByStars(int stars);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
@@ -22,7 +22,7 @@ import org.springframework.data.neo4j.repository.GraphRepository;
  * @author Luanne Misquitta
  * @author Vince Bickers
  */
-public interface RatingRepository extends GraphRepository<Rating> {
+public interface RatingRepository extends GraphRepository<Rating, Long> {
 
 	List<Rating> findByStars(int stars);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
@@ -19,5 +19,5 @@ import org.springframework.data.neo4j.repository.GraphRepository;
 /**
  * @author Michal Bachman
  */
-public interface TempMovieRepository extends GraphRepository<TempMovie> {
+public interface TempMovieRepository extends GraphRepository<TempMovie, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
@@ -14,10 +14,10 @@
 package org.springframework.data.neo4j.examples.movies.repo;
 
 import org.springframework.data.neo4j.examples.movies.domain.TempMovie;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
  * @author Michal Bachman
  */
-public interface TempMovieRepository extends GraphRepository<TempMovie, Long> {
+public interface TempMovieRepository extends Neo4jRepository<TempMovie, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * @author Luanne Misquitta
  */
 @Repository
-public interface UserRepository extends PersonRepository<User> {
+public interface UserRepository extends PersonRepository<User, Long> {
 
     Collection<User> findByMiddleName(String middleName);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -25,7 +25,7 @@ import org.springframework.data.neo4j.repository.GraphRepository;
 /**
  * @author Jasper Blues
  */
-public interface RestaurantRepository extends GraphRepository<Restaurant> {
+public interface RestaurantRepository extends GraphRepository<Restaurant, Long> {
 
 	List<Restaurant> findByNameAndLocationNear(String name, Distance distance, Point point);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -13,19 +13,18 @@
 
 package org.springframework.data.neo4j.examples.restaurants.repo;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
 import org.springframework.data.neo4j.examples.restaurants.domain.Restaurant;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
  * @author Jasper Blues
  */
-public interface RestaurantRepository extends GraphRepository<Restaurant, Long> {
+public interface RestaurantRepository extends Neo4jRepository<Restaurant, Long> {
 
 	List<Restaurant> findByNameAndLocationNear(String name, Distance distance, Point point);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepository.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.data.neo4j.extensions;
 
+import java.io.Serializable;
+
 import org.springframework.data.neo4j.repository.GraphRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -22,7 +24,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @author: Vince Bickers
  */
 @NoRepositoryBean
-public interface CustomGraphRepository<T> extends GraphRepository<T> {
+public interface CustomGraphRepository<T, ID extends Serializable> extends GraphRepository<T, ID> {
 
     boolean sharedCustomMethod();
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.data.neo4j.extensions;
 
+import java.io.Serializable;
+
 import org.neo4j.ogm.session.Session;
 import org.springframework.data.neo4j.repository.support.SimpleGraphRepository;
 import org.springframework.stereotype.Repository;
@@ -24,7 +26,7 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public class CustomGraphRepositoryImpl<T> extends SimpleGraphRepository<T> implements CustomGraphRepository<T> {
+public class CustomGraphRepositoryImpl<T, ID extends Serializable> extends SimpleGraphRepository<T, ID> implements CustomGraphRepository<T, ID> {
 
 	public CustomGraphRepositoryImpl(Class<T> clazz, Session session) {
 		super(clazz, session);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
@@ -15,7 +15,7 @@ package org.springframework.data.neo4j.extensions;
 import java.io.Serializable;
 
 import org.neo4j.ogm.session.Session;
-import org.springframework.data.neo4j.repository.support.SimpleGraphRepository;
+import org.springframework.data.neo4j.repository.support.SimpleNeo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public class CustomGraphRepositoryImpl<T, ID extends Serializable> extends SimpleGraphRepository<T, ID> implements CustomGraphRepository<T, ID> {
+public class CustomGraphRepositoryImpl<T, ID extends Serializable> extends SimpleNeo4jRepository<T, ID> implements CustomNeo4jRepository<T, ID> {
 
 	public CustomGraphRepositoryImpl(Class<T> clazz, Session session) {
 		super(clazz, session);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomNeo4jRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomNeo4jRepository.java
@@ -14,7 +14,7 @@ package org.springframework.data.neo4j.extensions;
 
 import java.io.Serializable;
 
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
 /**
@@ -24,7 +24,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @author: Vince Bickers
  */
 @NoRepositoryBean
-public interface CustomGraphRepository<T, ID extends Serializable> extends GraphRepository<T, ID> {
+public interface CustomNeo4jRepository<T, ID extends Serializable> extends Neo4jRepository<T, ID> {
 
     boolean sharedCustomMethod();
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
@@ -19,5 +19,5 @@ import org.springframework.stereotype.Repository;
  * @author: Vince Bickers
  */
 @Repository
-public interface UserRepository extends CustomGraphRepository<User> {
+public interface UserRepository extends CustomGraphRepository<User, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
@@ -19,5 +19,5 @@ import org.springframework.stereotype.Repository;
  * @author: Vince Bickers
  */
 @Repository
-public interface UserRepository extends CustomGraphRepository<User, Long> {
+public interface UserRepository extends CustomNeo4jRepository<User, Long> {
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Repository;
  * @author Adam George
  */
 @Repository
-public interface JavaElementRepository extends GraphRepository<JavaElement> {
+public interface JavaElementRepository extends GraphRepository<JavaElement, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
@@ -14,14 +14,14 @@
 package org.springframework.data.neo4j.integration.conversion;
 
 import org.springframework.data.neo4j.integration.conversion.domain.JavaElement;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Adam George
  */
 @Repository
-public interface JavaElementRepository extends GraphRepository<JavaElement, Long> {
+public interface JavaElementRepository extends Neo4jRepository<JavaElement, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Repository;
  * @author Adam George
  */
 @Repository
-public interface PensionRepository extends GraphRepository<PensionPlan> {
+public interface PensionRepository extends GraphRepository<PensionPlan, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
@@ -14,14 +14,14 @@
 package org.springframework.data.neo4j.integration.conversion;
 
 import org.springframework.data.neo4j.integration.conversion.domain.PensionPlan;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Adam George
  */
 @Repository
-public interface PensionRepository extends GraphRepository<PensionPlan, Long> {
+public interface PensionRepository extends Neo4jRepository<PensionPlan, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
@@ -14,14 +14,14 @@
 package org.springframework.data.neo4j.integration.conversion;
 
 import org.springframework.data.neo4j.integration.conversion.domain.SiteMember;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Adam George
  */
 @Repository
-public interface SiteMemberRepository extends GraphRepository<SiteMember, Long> {
+public interface SiteMemberRepository extends Neo4jRepository<SiteMember, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Repository;
  * @author Adam George
  */
 @Repository
-public interface SiteMemberRepository extends GraphRepository<SiteMember> {
+public interface SiteMemberRepository extends GraphRepository<SiteMember, Long> {
 
     // no additional repository methods
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Repository;
  * @author Vince Bickers
  */
 @Repository
-public interface UserRepository extends GraphRepository<User> {
+public interface UserRepository extends GraphRepository<User, Long> {
 
 	/*
 	 * @see DATAGRAPH-813

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.springframework.data.neo4j.repositories.domain.User;
 import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Repository;
  * @author Vince Bickers
  */
 @Repository
-public interface UserRepository extends GraphRepository<User, Long> {
+public interface UserRepository extends GraphRepository<User> {
 
 	/*
 	 * @see DATAGRAPH-813

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryIT.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryIT.java
@@ -15,6 +15,8 @@ package org.springframework.data.neo4j.repositories.support;
 
 import static org.junit.Assert.*;
 
+import java.io.Serializable;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,14 +79,14 @@ public class GraphRepositoryFactoryIT extends MultiDriverTestClass {
 		assertEquals(CustomGraphRepository.class, ((Advised) repository).getTargetClass());
 	}
 
-	private interface ObjectRepository extends GraphRepository<Object> {
+	private interface ObjectRepository extends GraphRepository<Object, Long> {
 
 		@Override
 		@Transactional
 		Object findOne(Long id);
 	}
 
-	static class CustomGraphRepository<T> extends SimpleGraphRepository<T> {
+	static class CustomGraphRepository<T, ID extends Serializable> extends SimpleGraphRepository<T, ID> {
 
 		public CustomGraphRepository(Class<T> clazz, Session session) {
 			super(clazz, session);

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryIT.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryIT.java
@@ -25,9 +25,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.springframework.aop.framework.Advised;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.support.Neo4jRepositoryFactory;
-import org.springframework.data.neo4j.repository.support.SimpleGraphRepository;
+import org.springframework.data.neo4j.repository.support.SimpleNeo4jRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -74,21 +74,21 @@ public class GraphRepositoryFactoryIT extends MultiDriverTestClass {
 
 	@Test
 	public void usesConfiguredRepositoryBaseClass() {
-		factory.setRepositoryBaseClass(CustomGraphRepository.class);
+		factory.setRepositoryBaseClass(CustomNeo4jRepository.class);
 		ObjectRepository repository = factory.getRepository(ObjectRepository.class);
-		assertEquals(CustomGraphRepository.class, ((Advised) repository).getTargetClass());
+		assertEquals(CustomNeo4jRepository.class, ((Advised) repository).getTargetClass());
 	}
 
-	private interface ObjectRepository extends GraphRepository<Object, Long> {
+	private interface ObjectRepository extends Neo4jRepository<Object, Long> {
 
 		@Override
 		@Transactional
 		Object findOne(Long id);
 	}
 
-	static class CustomGraphRepository<T, ID extends Serializable> extends SimpleGraphRepository<T, ID> {
+	static class CustomNeo4jRepository<T, ID extends Serializable> extends SimpleNeo4jRepository<T, ID> {
 
-		public CustomGraphRepository(Class<T> clazz, Session session) {
+		public CustomNeo4jRepository(Class<T> clazz, Session session) {
 			super(clazz, session);
 		}
 	}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryIT.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryIT.java
@@ -46,7 +46,7 @@ public class Neo4jRepositoryIT extends MultiDriverTestClass {
 
 	@Autowired Session session;
 
-	GraphRepository<SampleEntity, Long> repository;
+	Neo4jRepository<SampleEntity, Long> repository;
 
 	@Before
 	public void setUp() {
@@ -68,7 +68,7 @@ public class Neo4jRepositoryIT extends MultiDriverTestClass {
 	}
 
 
-	private interface SampleEntityRepository extends GraphRepository<SampleEntity, Long> {
+	private interface SampleEntityRepository extends Neo4jRepository<SampleEntity, Long> {
 
 	}
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryIT.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryIT.java
@@ -46,7 +46,7 @@ public class Neo4jRepositoryIT extends MultiDriverTestClass {
 
 	@Autowired Session session;
 
-	GraphRepository<SampleEntity> repository;
+	GraphRepository<SampleEntity, Long> repository;
 
 	@Before
 	public void setUp() {
@@ -68,7 +68,7 @@ public class Neo4jRepositoryIT extends MultiDriverTestClass {
 	}
 
 
-	private interface SampleEntityRepository extends GraphRepository<SampleEntity> {
+	private interface SampleEntityRepository extends GraphRepository<SampleEntity, Long> {
 
 	}
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.domain.sample.User;
 import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Mark Angrish
  */
-public interface UserRepository extends GraphRepository<User, Long> {
+public interface UserRepository extends GraphRepository<User> {
 
 	/**
 	 * Retrieve users by their lastname. The finder {@literal User.findByLastname} is declared in

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Mark Angrish
  */
-public interface UserRepository extends GraphRepository<User> {
+public interface UserRepository extends GraphRepository<User, Long> {
 
 	/**
 	 * Retrieve users by their lastname. The finder {@literal User.findByLastname} is declared in

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
@@ -18,6 +18,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
 @RunWith(MockitoJUnitRunner.class)
 public class Neo4jRepositoryFactoryBeanTests {
 
-	Neo4jRepositoryFactoryBean<SimpleSampleRepository, User> factoryBean;
+	Neo4jRepositoryFactoryBean<SimpleSampleRepository, User, Long> factoryBean;
 
 	@Mock
 	Session session;
@@ -114,8 +115,8 @@ public class Neo4jRepositoryFactoryBeanTests {
 		factoryBean.afterPropertiesSet();
 	}
 
-	private class DummyNeo4jRepositoryFactoryBean<T extends GraphRepository<S>, S> extends
-			Neo4jRepositoryFactoryBean<T, S> {
+	private class DummyNeo4jRepositoryFactoryBean<T extends GraphRepository<S, ID>, S, ID extends Serializable> extends
+			Neo4jRepositoryFactoryBean<T, S, ID> {
 
 		/*
 		 * (non-Javadoc)
@@ -131,7 +132,7 @@ public class Neo4jRepositoryFactoryBeanTests {
 		}
 	}
 
-	private interface SimpleSampleRepository extends GraphRepository<User> {
+	private interface SimpleSampleRepository extends GraphRepository<User, Long> {
 
 	}
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.domain.Persistable;
-import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 
@@ -115,7 +115,7 @@ public class Neo4jRepositoryFactoryBeanTests {
 		factoryBean.afterPropertiesSet();
 	}
 
-	private class DummyNeo4jRepositoryFactoryBean<T extends GraphRepository<S, ID>, S, ID extends Serializable> extends
+	private class DummyNeo4jRepositoryFactoryBean<T extends Neo4jRepository<S, ID>, S, ID extends Serializable> extends
 			Neo4jRepositoryFactoryBean<T, S, ID> {
 
 		/*
@@ -132,7 +132,7 @@ public class Neo4jRepositoryFactoryBeanTests {
 		}
 	}
 
-	private interface SimpleSampleRepository extends GraphRepository<User, Long> {
+	private interface SimpleSampleRepository extends Neo4jRepository<User, Long> {
 
 	}
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Repository;
  * @author Michal Bachman
  */
 @Repository
-public interface UserRepository extends GraphRepository<User> {
+public interface UserRepository extends GraphRepository<User, Long> {
 
     Collection<User> findUserByName(String name);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Repository;
  * @author Michal Bachman
  */
 @Repository
-public interface UserRepository extends GraphRepository<User, Long> {
+public interface UserRepository extends GraphRepository<User> {
 
     Collection<User> findUserByName(String name);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/controller/UserController.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/controller/UserController.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @author Michal Bachman
@@ -37,11 +38,11 @@ public class UserController {
     @Autowired
     private UserService userService;
 
-    @RequestMapping(value = "/user/{name}/friends")
+    @RequestMapping(value = "/user/{uuid}/friends")
     @ResponseBody
     @Transactional
-    public String listFriends(@PathVariable String name, HttpSession session) {
-        User user = userService.getUserByName(name);
+    public String listFriends(@PathVariable UUID uuid, HttpSession session) {
+        User user = userService.getUserByUuid(uuid);
 
         if (user == null) {
             return "No such user!";
@@ -55,11 +56,11 @@ public class UserController {
         return result.toString().trim();
     }
 
-    @RequestMapping(value = "/user/{name}/immediateFriends")
+    @RequestMapping(value = "/user/{uuid}/immediateFriends")
     @ResponseBody
     @Transactional
-    public String listImmediateFriends(@PathVariable String name, HttpSession session) {
-        User user = userService.getUserByName(name);
+    public String listImmediateFriends(@PathVariable UUID uuid, HttpSession session) {
+        User user = userService.getUserByUuid(uuid);
 
         if (user == null) {
             return "No such user!";

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Cinema.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Cinema.java
@@ -13,28 +13,42 @@
 
 package org.springframework.data.neo4j.web.domain;
 
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Index;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author Michal Bachman
+ * @author Mark Angrish
  */
 @NodeEntity
 public class Cinema {
 
+    @GraphId
     private Long id;
+
+    @Convert(UuidStringConverter.class)
+    @Index(unique = true, primary = true)
+    private UUID uuid;
+
     private String name;
 
     @Relationship(direction = Relationship.INCOMING)
-    private Set<User> visited = new HashSet<>();
+    private Set<User> visited;
 
     public Cinema() {
     }
 
     public Cinema(String name) {
+        this.visited = new HashSet<>();
+        this.uuid = UUID.randomUUID();
         this.name = name;
     }
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Genre.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Genre.java
@@ -13,18 +13,35 @@
 
 package org.springframework.data.neo4j.web.domain;
 
+import java.util.UUID;
+
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
 /**
  * @author Michal Bachman
+ * @author Mark Angrish
  */
+@NodeEntity
 public class Genre {
 
+    @GraphId
     private Long id;
+
+    @Convert(UuidStringConverter.class)
+    @Index(unique = true, primary = true)
+    private UUID uuid;
+
     private String name;
 
     public Genre() {
     }
 
     public Genre(String name) {
+        this.uuid = UUID.randomUUID();
         this.name = name;
     }
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/User.java
@@ -13,28 +13,46 @@
 
 package org.springframework.data.neo4j.web.domain;
 
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author Michal Bachman
+ * @author Mark Angrish
  */
+@NodeEntity
 public class User {
 
+    @GraphId
     private Long id;
+
+    @Convert(UuidStringConverter.class)
+    @Index(unique = true, primary = true)
+    private UUID uuid;
+
     private String name;
-    private Collection<Genre> interested = new HashSet<>();
+
+    private Collection<Genre> interested;
 
     @Relationship(type = "FRIEND_OF", direction = Relationship.UNDIRECTED)
-    private Set<User> friends = new HashSet<>();
+    private Set<User> friends;
 
     public User() {
     }
 
     public User(String name) {
+        this.interested = new HashSet<>();
+        this.friends = new HashSet<>();
+        this.uuid = UUID.randomUUID();
         this.name = name;
     }
 
@@ -65,5 +83,9 @@ public class User {
 
     public Collection<User> getFriends() {
         return friends;
+    }
+
+    public UUID getUuid() {
+        return uuid;
     }
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
@@ -22,6 +22,6 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public interface GenreRepository extends GraphRepository<Genre> {
+public interface GenreRepository extends GraphRepository<Genre, Long> {
 
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
@@ -13,7 +13,9 @@
 
 package org.springframework.data.neo4j.web.repo;
 
-import org.springframework.data.neo4j.repository.GraphRepository;
+import java.util.UUID;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.web.domain.Genre;
 import org.springframework.stereotype.Repository;
 
@@ -22,6 +24,6 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public interface GenreRepository extends GraphRepository<Genre, Long> {
+public interface GenreRepository extends Neo4jRepository<Genre, UUID> {
 
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
@@ -22,6 +22,6 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public interface UserRepository extends GraphRepository<User> {
+public interface UserRepository extends GraphRepository<User, Long> {
 
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
@@ -13,7 +13,10 @@
 
 package org.springframework.data.neo4j.web.repo;
 
+import java.util.UUID;
+
 import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.web.domain.User;
 import org.springframework.stereotype.Repository;
 
@@ -22,6 +25,6 @@ import org.springframework.stereotype.Repository;
  * @author Mark Angrish
  */
 @Repository
-public interface UserRepository extends GraphRepository<User, Long> {
+public interface UserRepository extends Neo4jRepository<User, UUID> {
 
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserService.java
@@ -16,13 +16,14 @@ package org.springframework.data.neo4j.web.service;
 import org.springframework.data.neo4j.web.domain.User;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * @author Michal Bachman
  */
 public interface UserService {
 
-    User getUserByName(String name);
+    User getUserByUuid(UUID uuid);
 
     Collection<User> getNetwork(User user);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserServiceImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserServiceImpl.java
@@ -13,15 +13,11 @@
 
 package org.springframework.data.neo4j.web.service;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
-import org.neo4j.ogm.cypher.Filter;
-import org.neo4j.ogm.session.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.neo4j.web.domain.User;
+import org.springframework.data.neo4j.web.repo.UserRepository;
 import org.springframework.stereotype.Service;
 
 /**
@@ -32,15 +28,11 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
 	@Autowired
-	private Session session;
+	private UserRepository userRepository;
 
 	@Override
-	public User getUserByName(String name) {
-		Iterable<User> users = findByProperty("name", name);
-		if (!users.iterator().hasNext()) {
-			return null;
-		}
-		return users.iterator().next();
+	public User getUserByUuid(UUID uuid) {
+		return  userRepository.findOne(uuid);
 	}
 
 	@Override
@@ -63,9 +55,5 @@ public class UserServiceImpl implements UserService {
 				buildNetwork(friend, network);
 			}
 		}
-	}
-
-	protected Iterable<User> findByProperty(String propertyName, Object propertyValue) {
-		return session.loadAll(User.class, new Filter(propertyName, propertyValue));
 	}
 }


### PR DESCRIPTION
Currently SDN Repositories do not support any type of lookup that is not a Graph Id of type Long. For most users of SDN that persist entities across restarts this is of little value.
GraphRepository should be able to define a serializable ID that can be used for looking up entities.

This PR allows keys to be defined by `@Index(unique=true,primary=true)` semantics of the Neo4j-OGM. This field's type can then be used to lookup entities via SDN Repositories.