### PR TITLE
DATAGRAPH-980 - Cleanup javax.el and javax.validation versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,28 +143,6 @@
         </developer>
     </developers>
 
-    <dependencyManagement>
-
-        <dependencies>
-
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>5.1.2.Final</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>3.0.0</version>
-                <scope>test</scope>
-            </dependency>
-
-        </dependencies>
-
-    </dependencyManagement>
-
     <profiles>
         <profile>
             <id>release</id>

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <neo4j.ogm.version>3.0.0-M01</neo4j.ogm.version>
         <ogm.properties>ogm-bolt.properties</ogm.properties>
+        <el-api.version>2.2</el-api.version>
     </properties>
 
 
@@ -91,13 +92,7 @@
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>el-api</artifactId>
-            <version>${cdi}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <version>${el-api.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -127,7 +122,14 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-			<version>4.2.0.Final</version>
+			<version>5.1.2.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Remove duplicate versions of hibernate-validator.
EL dependency to be used with CDI 1.0 is 2.2 (not 2.1).
These deps will need to be upgraded when Spring framework will switch to JEE 7.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAGRAPH).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
