### PR TITLE
Datagraph-1027 - use inclusive range for Between operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-neo4j-parent</artifactId>
-    <version>5.0.0.BUILD-SNAPSHOT</version>
+    <version>5.0.0.DATAGRAPH-1027-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.0.0.BUILD-SNAPSHOT</version>
+		<version>5.0.0.DATAGRAPH-1027-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-neo4j-parent</artifactId>
-        <version>5.0.0.BUILD-SNAPSHOT</version>
+        <version>5.0.0.DATAGRAPH-1027-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/derived/builder/BetweenComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/derived/builder/BetweenComparisonBuilder.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
 package org.springframework.data.neo4j.repository.query.derived.builder;
 
 import java.util.Arrays;
@@ -13,6 +26,7 @@ import org.springframework.data.repository.query.parser.Part;
 /**
  * @author Jasper Blues
  * @author Nicolas Mervaillie
+ * @author Gerrit Meier
  */
 public class BetweenComparisonBuilder extends FilterBuilder {
 
@@ -23,7 +37,7 @@ public class BetweenComparisonBuilder extends FilterBuilder {
 	@Override
 	public List<Filter> build(Stack<Object> params) {
 		final Object value1 = params.pop();
-		Filter gt = new Filter(propertyName(), ComparisonOperator.GREATER_THAN, value1);
+		Filter gt = new Filter(propertyName(), ComparisonOperator.GREATER_THAN_EQUAL, value1);
 		gt.setOwnerEntityType(entityType);
 		gt.setBooleanOperator(booleanOperator);
 		gt.setNegated(isNegated());
@@ -31,7 +45,7 @@ public class BetweenComparisonBuilder extends FilterBuilder {
 		setNestedAttributes(part, gt);
 
 		final Object value2 = params.pop();
-		Filter lt = new Filter(propertyName(), ComparisonOperator.LESS_THAN, value2);
+		Filter lt = new Filter(propertyName(), ComparisonOperator.LESS_THAN_EQUAL, value2);
 		lt.setOwnerEntityType(entityType);
 		lt.setBooleanOperator(BooleanOperator.AND);
 		lt.setNegated(isNegated());

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * Tests that we support each kind of keyword specified by Part.Type
  *
  * @author Jasper Blues
+ * @author Gerrit Meier
  */
 public class RestaurantTests extends MultiDriverTestClass {
 
@@ -137,6 +138,25 @@ public class RestaurantTests extends MultiDriverTestClass {
 		List<Restaurant> shouldBeEmpty = restaurantRepository.findByScoreBetween(30.0, 40.0);
 		assertNotNull(shouldBeEmpty);
 		assertEquals(0, shouldBeEmpty.size());
+	}
+
+	/**
+	 * @see DATAGRAPH-1027
+	 */
+	@Test
+	public void shouldFindRestaurantsWithScoreBetweenInclusive() {
+		Restaurant kuroda = new Restaurant("Kuroda", 72.4);
+		restaurantRepository.save(kuroda);
+
+		Restaurant cyma = new Restaurant("Cyma", 80.6);
+		restaurantRepository.save(cyma);
+
+		Restaurant awful = new Restaurant("Awful", 20.0);
+		restaurantRepository.save(awful);
+
+		List<Restaurant> results = restaurantRepository.findByScoreBetween(20.0, 80.6);
+		assertNotNull(results);
+		assertEquals(3, results.size());
 	}
 
 	/**


### PR DESCRIPTION
This will change the behaviour of the Between operator used in query methods. Instead of the previous exclusive selection it will now include the end points.
The changes will also be noted in the migration documents for SDN5.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAGRAPH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
