### PR TITLE
DATAGRAPH-1094 - Neo4jRepositories don't work with multiple Neo4j instances.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-neo4j-parent</artifactId>
-    <version>5.1.0.BUILD-SNAPSHOT</version>
+    <version>5.1.0.DATAGRAPH-1094-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.1.0.BUILD-SNAPSHOT</version>
+		<version>5.1.0.DATAGRAPH-1094-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-neo4j-parent</artifactId>
-        <version>5.1.0.BUILD-SNAPSHOT</version>
+        <version>5.1.0.DATAGRAPH-1094-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
@@ -13,9 +13,15 @@
 
 package org.springframework.data.neo4j.repository.config;
 
-import java.lang.annotation.*;
+import static org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension.*;
 
-import org.neo4j.ogm.session.SessionFactory;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.neo4j.repository.support.Neo4jRepositoryFactoryBean;
@@ -29,6 +35,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * @author Vince Bickers
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -101,16 +108,34 @@ public @interface EnableNeo4jRepositories {
     Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
     /**
-     * Configures the name of the {@link SessionFactory} bean definition to be used to create repositories
-     * discovered through this annotation. Defaults to {@code sessionFactory}.
+     * Configures the name of the {@link org.neo4j.ogm.session.SessionFactory} bean definition to be used to create
+     * repositories discovered through this annotation. Defaults to {@code sessionFactory}.
      */
-    String sessionFactoryRef() default "sessionFactory";
+    String sessionFactoryRef() default DEFAULT_SESSION_FACTORY_BEAN_NAME;
+
+    /**
+     * Configures the name of the {@link org.neo4j.ogm.session.Session} bean definition created. Defaults to a generated
+     * name.
+     *
+     * @return
+     * @since 5.1.1
+     */
+    String sessionBeanName() default GENERATE_BEAN_NAME;
 
     /**
      * Configures the name of the {@link PlatformTransactionManager} bean definition to be used to create repositories
      * discovered through this annotation. Defaults to {@code transactionManager}.
      */
-    String transactionManagerRef() default "transactionManager";
+    String transactionManagerRef() default DEFAULT_TRANSACTION_MANAGER_BEAN_NAME;
+
+    /**
+     * Configures the name of the {@link org.springframework.data.neo4j.mapping.Neo4jMappingContext} bean definition
+     * created. Defaults to a generated name.
+     *
+     * @return
+     * @since 5.1.1
+     */
+    String mappingContextBeanName() default GENERATE_BEAN_NAME;
 
     /**
      * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
+import org.springframework.util.Assert;
 
 /**
  * {@link FactoryBean} to setup {@link Neo4jMappingContext} instances from Spring configuration.
@@ -37,10 +38,11 @@ public class Neo4jMappingContextFactoryBean extends AbstractFactoryBean<Neo4jMap
 	private ListableBeanFactory beanFactory;
 
 	/**
-	 * Uses the default session factory name {@link Neo4jRepositoryConfigurationExtension#DEFAULT_SESSION_FACTORY_BEAN_NAME}
-	 * for finding the session factory passed to the {@link Neo4jMappingContext}.
+	 * Uses the default session factory name
+	 * {@link Neo4jRepositoryConfigurationExtension#DEFAULT_SESSION_FACTORY_BEAN_NAME} for finding the session factory
+	 * passed to the {@link Neo4jMappingContext}.
 	 *
-	 * @deprecated
+	 * @deprecated since 5.1.1, use {@link #Neo4jMappingContextFactoryBean(String)} instead
 	 */
 	public Neo4jMappingContextFactoryBean() {
 		this(Neo4jRepositoryConfigurationExtension.DEFAULT_SESSION_FACTORY_BEAN_NAME);
@@ -49,10 +51,12 @@ public class Neo4jMappingContextFactoryBean extends AbstractFactoryBean<Neo4jMap
 	/**
 	 * Configures the mapping context with a named {@link SessionFactory}.
 	 *
-	 * @param sessionFactoryBeanName
+	 * @param sessionFactoryBeanName must not be {@literal null} or empty.
 	 * @since 5.1.0
 	 */
-	Neo4jMappingContextFactoryBean(String sessionFactoryBeanName) {
+	public Neo4jMappingContextFactoryBean(String sessionFactoryBeanName) {
+
+		Assert.hasText(sessionFactoryBeanName, "SessionFactoryBeanName must not be null nor empty!");
 		this.sessionFactoryBeanName = sessionFactoryBeanName;
 	}
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
@@ -27,11 +27,34 @@ import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
  *
  * @author Mark Angrish
  * @author Nicolas Mervaillie
+ * @author Michael J. Simons
  */
 public class Neo4jMappingContextFactoryBean extends AbstractFactoryBean<Neo4jMappingContext> implements
 		ApplicationContextAware {
 
+	private final String sessionFactoryBeanName;
+
 	private ListableBeanFactory beanFactory;
+
+	/**
+	 * Uses the default session factory name {@link Neo4jRepositoryConfigurationExtension#DEFAULT_SESSION_FACTORY_BEAN_NAME}
+	 * for finding the session factory passed to the {@link Neo4jMappingContext}.
+	 *
+	 * @deprecated
+	 */
+	public Neo4jMappingContextFactoryBean() {
+		this(Neo4jRepositoryConfigurationExtension.DEFAULT_SESSION_FACTORY_BEAN_NAME);
+	}
+
+	/**
+	 * Configures the mapping context with a named {@link SessionFactory}.
+	 *
+	 * @param sessionFactoryBeanName
+	 * @since 5.1.0
+	 */
+	Neo4jMappingContextFactoryBean(String sessionFactoryBeanName) {
+		this.sessionFactoryBeanName = sessionFactoryBeanName;
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -57,7 +80,8 @@ public class Neo4jMappingContextFactoryBean extends AbstractFactoryBean<Neo4jMap
 	 */
 	@Override
 	protected Neo4jMappingContext createInstance() {
-		SessionFactory sessionFactory = beanFactory.getBean(SessionFactory.class);
+
+		SessionFactory sessionFactory = beanFactory.getBean(this.sessionFactoryBeanName, SessionFactory.class);
 		Neo4jMappingContext context = new Neo4jMappingContext(sessionFactory.metaData());
 		context.initialize();
 		return context;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." / "Pivotal Software, Inc."
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.neo4j.repository.config;
 
 import org.neo4j.ogm.session.SessionFactory;
@@ -6,6 +21,9 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService;
 import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
 
+/**
+ * @author Gerrit Meier
+ */
 public class Neo4jOgmEntityInstantiatorConfigurationBean {
 
 	public Neo4jOgmEntityInstantiatorConfigurationBean(SessionFactory sessionFactory, Neo4jMappingContext mappingContext,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -73,6 +73,17 @@ public class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 	 */
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
+		return createRepositoryFactory(session);
+	}
+
+	/**
+	 * Returns a {@link RepositoryFactorySupport}.
+	 *
+	 * @deprecated since 5.1.1, will be removed in 5.2.x
+	 * @param session
+	 * @return
+	 */
+	protected RepositoryFactorySupport createRepositoryFactory(Session session) {
 		return new Neo4jRepositoryFactory(session);
 	}
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -32,14 +32,15 @@ import org.springframework.util.Assert;
  * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
 	private Session session;
-	
+
 	/**
 	 * Creates a new {@link Neo4jRepositoryFactoryBean} for the given repository interface.
-	 * 
+	 *
 	 * @param repositoryInterface must not be {@literal null}.
 	 */
 	public Neo4jRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
@@ -66,18 +67,12 @@ public class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 		super.afterPropertiesSet();
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport#doCreateRepositoryFactory()
+	 */
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return createRepositoryFactory(session);
-	}
-
-	/**
-	 * Returns a {@link RepositoryFactorySupport}.
-	 *
-	 * @param session
-	 * @return
-	 */
-	protected RepositoryFactorySupport createRepositoryFactory(Session session) {
 		return new Neo4jRepositoryFactory(session);
 	}
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." / "Pivotal Software, Inc."
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.ogm.drivers.embedded.driver.EmbeddedDriver;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.examples.friends.domain.Friendship;
+import org.springframework.data.neo4j.examples.friends.domain.Person;
+import org.springframework.data.neo4j.examples.friends.repo.FriendshipRepository;
+import org.springframework.data.neo4j.examples.restaurants.domain.Diner;
+import org.springframework.data.neo4j.examples.restaurants.domain.Restaurant;
+import org.springframework.data.neo4j.examples.restaurants.repo.RestaurantRepository;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * DATAGRAPH-1094
+ *
+ * @author Michael J. Simons
+ */
+@ContextConfiguration(classes = { MultipleSessionFactorySupportTests.BaseConfiguration.class,
+		MultipleSessionFactorySupportTests.FriendsConfiguration.class,
+		MultipleSessionFactorySupportTests.RestaurantsConfiguration.class })
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MultipleSessionFactorySupportTests {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MultipleSessionFactorySupportTests.class);
+
+	private static final String BEAN_NAME_FRIENDS_SESSION_FACTORY = "sessionFactoryFriends";
+	private static final String BEAN_NAME_FRIENDS_TX_MANAGER = "txManagerFriends";
+
+	private static final String BEAN_NAME_RESTAURANTS_SESSION_FACTORY = "sessionFactoryRestaurants";
+	private static final String BEAN_NAME_RESTAURANTS_TX_MANAGER = "txManagerRestaurants";
+
+	private static final String PACKAGE_FOR_DOMAIN_OF_INSTANCE1 = "org.springframework.data.neo4j.examples.friends";
+	private static final String PACKAGE_FOR_DOMAIN_OF_INSTANCE2 = "org.springframework.data.neo4j.examples.restaurants";
+
+	private static final String QUERY_COUNT_PERSON_NODES = "MATCH (n:Person) RETURN count(n) as cnt";
+	private static final String QUERY_COUNT_DINER_NODES = "MATCH (n:Diner) RETURN count(n) as cnt";
+
+	private static DatabaseHolder instance1;
+
+	private static DatabaseHolder instance2;
+
+	@Autowired @Qualifier(BEAN_NAME_FRIENDS_SESSION_FACTORY) private Session friendsSession;
+
+	@Autowired private FriendshipRepository friendshipRepository;
+
+	@Autowired @Qualifier(BEAN_NAME_RESTAURANTS_SESSION_FACTORY) private Session restaurantsSession;
+
+	@Autowired private RestaurantRepository restaurantRepository;
+
+	@BeforeClass
+	public static void initializeDatabase() throws IOException {
+
+		instance1 = createAndStartEmbeddedInstance();
+		instance2 = createAndStartEmbeddedInstance();
+	}
+
+	@Test
+	public void sessionsShouldUseCorrectMappingContext() {
+
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> friendsSession.loadAll(Restaurant.class));
+		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> restaurantsSession.loadAll(Person.class));
+	}
+
+	@Test
+	public void repositoriesShouldUseCorrectSessionFactory() {
+
+		this.friendshipRepository.save(buildFriendship());
+		this.restaurantRepository.save(openRestaurant());
+
+		assertThat(this.friendsSession.loadAll(Person.class)).hasSize(2);
+		assertThat(this.restaurantsSession.loadAll(Diner.class)).hasSize(2);
+
+		assertThat(executeCountQuery(QUERY_COUNT_PERSON_NODES, instance1.graphDatabaseService)).isEqualTo(2L);
+		assertThat(executeCountQuery(QUERY_COUNT_PERSON_NODES, instance2.graphDatabaseService)).isEqualTo(0L);
+		assertThat(executeCountQuery(QUERY_COUNT_DINER_NODES, instance1.graphDatabaseService)).isEqualTo(0L);
+		assertThat(executeCountQuery(QUERY_COUNT_DINER_NODES, instance2.graphDatabaseService)).isEqualTo(2L);
+	}
+
+	@AfterClass
+	public static void tearDownDatabase() {
+		instance1.close();
+		instance2.close();
+	}
+
+	private Friendship buildFriendship() {
+
+		Person person1 = new Person();
+		person1.setFirstName("Homer");
+		person1.setLastName("Simpson");
+
+		Person person2 = new Person();
+		person2.setFirstName("Lenny");
+		person2.setLastName("Leonard");
+
+		return new Friendship(person1, person2);
+	}
+
+	private Restaurant openRestaurant() {
+
+		Restaurant restaurant = new Restaurant("The Restaurant at the End of the Universe", "A nice place.");
+		restaurant.addRegularDiner(new Diner());
+		restaurant.addRegularDiner(new Diner());
+		return restaurant;
+	}
+
+	private long executeCountQuery(String countQuery, GraphDatabaseService onInstance) {
+
+		try (Transaction ignored = onInstance.beginTx()) {
+			return (long) onInstance.execute(countQuery).next().get("cnt");
+		}
+	}
+
+	private static DatabaseHolder createAndStartEmbeddedInstance() throws IOException {
+
+		final File dataStore1 = Files.createTempDirectory("neo4j.db").toFile();
+		final GraphDatabaseService graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(dataStore1)
+				.newGraphDatabase();
+		return new DatabaseHolder(dataStore1, graphDatabaseService);
+	}
+
+	/**
+	 * Just keep database and directory together.
+	 */
+	static class DatabaseHolder {
+
+		final File dataStoreDirectory;
+
+		final GraphDatabaseService graphDatabaseService;
+
+		public DatabaseHolder(File dataStoreDirectory, GraphDatabaseService graphDatabaseService) {
+
+			this.dataStoreDirectory = dataStoreDirectory;
+			this.graphDatabaseService = graphDatabaseService;
+		}
+
+		void close() {
+
+			this.graphDatabaseService.shutdown();
+			try {
+				FileUtils.deleteDirectory(dataStoreDirectory);
+			} catch (IOException e) {
+				LOGGER.warn("Failed to delete database store in {}" + dataStoreDirectory.getAbsolutePath());
+			}
+		}
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	static class BaseConfiguration {}
+
+	@Configuration
+	@EnableNeo4jRepositories(sessionFactoryRef = BEAN_NAME_FRIENDS_SESSION_FACTORY,
+			transactionManagerRef = BEAN_NAME_FRIENDS_TX_MANAGER, basePackages = PACKAGE_FOR_DOMAIN_OF_INSTANCE1)
+	static class FriendsConfiguration {
+
+		@Bean(BEAN_NAME_FRIENDS_TX_MANAGER)
+		public PlatformTransactionManager transactionManager() {
+			return new Neo4jTransactionManager(sessionFactory());
+		}
+
+		@Bean(BEAN_NAME_FRIENDS_SESSION_FACTORY)
+		public SessionFactory sessionFactory() {
+			return new SessionFactory(new EmbeddedDriver(instance1.graphDatabaseService),
+					PACKAGE_FOR_DOMAIN_OF_INSTANCE1 + ".domain");
+		}
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(sessionFactoryRef = BEAN_NAME_RESTAURANTS_SESSION_FACTORY,
+			transactionManagerRef = BEAN_NAME_RESTAURANTS_TX_MANAGER, basePackages = PACKAGE_FOR_DOMAIN_OF_INSTANCE2)
+	static class RestaurantsConfiguration {
+
+		@Bean(BEAN_NAME_RESTAURANTS_TX_MANAGER)
+		public PlatformTransactionManager transactionManager() {
+			return new Neo4jTransactionManager(sessionFactory());
+		}
+
+		@Bean(BEAN_NAME_RESTAURANTS_SESSION_FACTORY)
+		public SessionFactory sessionFactory() {
+			return new SessionFactory(new EmbeddedDriver(instance2.graphDatabaseService),
+					PACKAGE_FOR_DOMAIN_OF_INSTANCE2 + ".domain");
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
@@ -47,19 +47,17 @@ import org.springframework.data.neo4j.examples.restaurants.repo.RestaurantReposi
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
- * DATAGRAPH-1094
- *
  * @author Michael J. Simons
  */
 @ContextConfiguration(classes = { MultipleSessionFactorySupportTests.BaseConfiguration.class,
 		MultipleSessionFactorySupportTests.FriendsConfiguration.class,
 		MultipleSessionFactorySupportTests.RestaurantsConfiguration.class })
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 public class MultipleSessionFactorySupportTests {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MultipleSessionFactorySupportTests.class);
@@ -95,14 +93,14 @@ public class MultipleSessionFactorySupportTests {
 		instance2 = createAndStartEmbeddedInstance();
 	}
 
-	@Test
+	@Test // DATAGRAPH-1094
 	public void sessionsShouldUseCorrectMappingContext() {
 
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> friendsSession.loadAll(Restaurant.class));
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> restaurantsSession.loadAll(Person.class));
 	}
 
-	@Test
+	@Test // DATAGRAPH-1094
 	public void repositoriesShouldUseCorrectSessionFactory() {
 
 		this.friendshipRepository.save(buildFriendship());
@@ -153,8 +151,8 @@ public class MultipleSessionFactorySupportTests {
 
 	private static DatabaseHolder createAndStartEmbeddedInstance() throws IOException {
 
-		final File dataStore1 = Files.createTempDirectory("neo4j.db").toFile();
-		final GraphDatabaseService graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(dataStore1)
+		File dataStore1 = Files.createTempDirectory("neo4j.db").toFile();
+		GraphDatabaseService graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(dataStore1)
 				.newGraphDatabase();
 		return new DatabaseHolder(dataStore1, graphDatabaseService);
 	}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtensionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -12,15 +12,17 @@
  */
 package org.springframework.data.neo4j.repository.config;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension.*;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -44,35 +46,29 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  * @author Mark Angrish
  * @author Mark Paluch
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 public class Neo4jRepositoryConfigurationExtensionTests {
 
 	private static final String CUSTOM_SESSION_FACTORY_BEAN_NAME = "mySessionFactory";
-	private static final String DEFAULT_SESSION_FACTORY_BEAN_NAME = "sessionFactory";
-	private static final String SHARED_SESSION_CREATOR_BEAN_NAME = "sharedSessionCreatorBean";
 
 	public @Rule ExpectedException exception = ExpectedException.none();
-
-	private StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(Config.class, true);
-
-	@Before
-	public void setup() {
-		metadata = new StandardAnnotationMetadata(Config.class, true);
-	}
 
 	@Test
 	public void registersSharedSessionCreatorBeanByDefault() {
 
-		DefaultListableBeanFactory factory = getBeanRegistry();
+		DefaultListableBeanFactory factory = getBeanRegistry(new StandardAnnotationMetadata(Config.class, true));
 
 		Iterable<String> names = Arrays.asList(factory.getBeanDefinitionNames());
 
-		assertThat(names, hasItems(SHARED_SESSION_CREATOR_BEAN_NAME));
+		assertThat(names, hasItems(DEFAULT_SESSION_FACTORY_BEAN_NAME));
 	}
 
 	@Test
 	public void sessionFactoryBeanNameDefaultsToSessionFactory() {
-		BeanDefinition beanDefinition = getBeanRegistry().getBeanDefinition(SHARED_SESSION_CREATOR_BEAN_NAME);
+
+		BeanDefinition beanDefinition = getBeanRegistry(new StandardAnnotationMetadata(Config.class, true))
+				.getBeanDefinition(DEFAULT_SESSION_BEAN_NAME);
 
 		RuntimeBeanReference sessionFactoryBean = (RuntimeBeanReference) beanDefinition.getConstructorArgumentValues()
 				.getIndexedArgumentValue(0, RuntimeBeanReference.class).getValue();
@@ -84,9 +80,9 @@ public class Neo4jRepositoryConfigurationExtensionTests {
 
 	@Test
 	public void customSessionFactoryBeanNameWillGetUsed() {
-		metadata = new StandardAnnotationMetadata(CustomSessionRefConfig.class, true);
 
-		BeanDefinition beanDefinition = getBeanRegistry().getBeanDefinition(SHARED_SESSION_CREATOR_BEAN_NAME);
+		BeanDefinition beanDefinition = getBeanRegistry(new StandardAnnotationMetadata(CustomSessionRefConfig.class, true))
+				.getBeanDefinition(DEFAULT_SESSION_BEAN_NAME);
 
 		RuntimeBeanReference sessionFactoryBean = (RuntimeBeanReference) beanDefinition.getConstructorArgumentValues()
 				.getIndexedArgumentValue(0, RuntimeBeanReference.class).getValue();
@@ -106,18 +102,19 @@ public class Neo4jRepositoryConfigurationExtensionTests {
 
 		Set<ClassInfo> managedTypes = Collections.singleton(classInfo);
 
-		when(context.getBean(SessionFactory.class)).thenReturn(sessionFactory);
+		when(context.getBean(any(String.class), eq(SessionFactory.class))).thenReturn(sessionFactory);
 		when(sessionFactory.metaData()).thenReturn(metaData);
 		when(metaData.persistentEntities()).thenReturn(managedTypes);
 		when(classInfo.name()).thenReturn("Test");
 
-		Neo4jMappingContextFactoryBean factoryBean = new Neo4jMappingContextFactoryBean();
+		Neo4jMappingContextFactoryBean factoryBean = new Neo4jMappingContextFactoryBean(Neo4jRepositoryConfigurationExtension.DEFAULT_SESSION_FACTORY_BEAN_NAME);
 		factoryBean.setApplicationContext(context);
 
 		factoryBean.createInstance().afterPropertiesSet();
 	}
 
-	private DefaultListableBeanFactory getBeanRegistry() {
+	private DefaultListableBeanFactory getBeanRegistry(final StandardAnnotationMetadata metadata) {
+
 		AnnotationConfigApplicationContext factory = new AnnotationConfigApplicationContext();
 
 		factory.registerBean(DEFAULT_SESSION_FACTORY_BEAN_NAME, SessionFactory.class, "dummypackage");


### PR DESCRIPTION
This changes the way the shared session and `Neo4jRepositoryConfigurationExtension` are registered as root beans:

1. the shared session is no longer called `SharedSessionCreator`. The `SharedSessionCreator` is only the factory creating new shared sessions, so that was misleading when reading the code. @meistermeier and I opted for an ok in this possible breaking change, as hardly anyone would have injected a `Session` and added a `@Qualifier("sharedSessionCreator")`
2. Add a qualifier to the session using the name of the `SessionFactory` from which the session is created. This is now consistent with the way Spring Data JPA works
3. if there are no root beans under the given name, nothing changes. If there's already a root bean with the given default bean, the `registerWithSourceAndGeneratedBeanName` helper is used.
4. The now uses the correct factory configured in `@EnableNeo4jRepositories`

Apart from the changed bean name, nothing changes when the user only has one `SessionFactory`. If he wants multiple, than we fully support this while still having an injectable session factory.

Formattings as suggested in DATAGRAPH-1093 are not applied yet and will follow. Also the test need some more polishing.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAGRAPH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).