### PR TITLE
Support version property information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.1.0.BUILD-SNAPSHOT</version>
+	<version>5.1.0.DATAGRAPH-1081-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.1.0.BUILD-SNAPSHOT</version>
+		<version>5.1.0.DATAGRAPH-1081-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.1.0.BUILD-SNAPSHOT</version>
+		<version>5.1.0.DATAGRAPH-1081-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
@@ -54,24 +54,6 @@ public class Neo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		super(information);
 	}
 
-	@Override
-	public boolean hasVersionProperty() {
-		logger.debug("[entity].hasVersionProperty() returns false"); // by design
-		return false;
-	}
-
-	@Override
-	public Neo4jPersistentProperty getVersionProperty() {
-		logger.debug("[entity].getVersionProperty() returns null"); // by design
-		return null;
-	}
-
-	@Override
-	public boolean isVersionProperty(PersistentProperty<?> property) {
-		logger.debug("[entity].isIdProperty({}) returns false", property); // again, by design
-		return false;
-	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.model.BasicPersistentEntity#getFallbackIsNewStrategy()

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
@@ -15,6 +15,7 @@ package org.springframework.data.neo4j.mapping;
 import org.neo4j.ogm.annotation.EndNode;
 import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.annotation.StartNode;
+import org.neo4j.ogm.annotation.Version;
 import org.neo4j.ogm.exception.core.MetadataException;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.slf4j.Logger;
@@ -111,8 +112,7 @@ public class Neo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 
 	@Override
 	public boolean isVersionProperty() {
-		logger.debug("[property].isVersionProperty() returns false"); // by design
-		return false;
+		return isAnnotationPresent(Version.class);
 	}
 
 	/**

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/User.java
@@ -9,6 +9,7 @@ import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.Version;
 import org.neo4j.ogm.annotation.typeconversion.DateString;
 
 /**
@@ -23,6 +24,8 @@ public class User {
 	private String firstname;
 
 	private String lastname;
+
+	@Version Long version;
 
 	private int age;
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.springframework.data.neo4j.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.neo4j.ogm.metadata.MetaData;
+import org.springframework.data.neo4j.domain.sample.User;
+
+/**
+ * @author Gerrit Meier
+ */
+public class Neo4jPersistentPropertyTest {
+
+	@Test // DATAGRAPH-1081
+	public void detectsOgmVersionAnnotation() {
+		MetaData metaData = new MetaData("org.springframework.data.neo4j.domain.sample");
+		Neo4jMappingContext mappingContext = new Neo4jMappingContext(metaData);
+		Neo4jPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(User.class);
+		Neo4jPersistentProperty version = persistentEntity.getRequiredPersistentProperty("version");
+		assertThat(version.isVersionProperty()).isTrue();
+	}
+
+}


### PR DESCRIPTION
Let Spring Data Rest pick up the right version property to provide its value as an Etag.