### PR TITLE
Fix wrong closing tag in pom example

### DIFF
--- a/src/main/asciidoc/reference/getting-started.adoc
+++ b/src/main/asciidoc/reference/getting-started.adoc
@@ -97,7 +97,7 @@ See the section on <<reference.getting_started.dependencies.testing,Testing>> be
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-ogm-http-driver</artifactId>
     </dependency>
-</dependency>
+</dependencies>
 ----
 
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAGRAPH).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Obvious fix: use correct xml closing tag in a pom example in the reference documentation