### PR TITLE
DATAGRAPH-1126 Fix application startup with multiple ConversionServices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.1.0.BUILD-SNAPSHOT</version>
+	<version>5.1.0.DATAGRAPH-1126-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.1.0.BUILD-SNAPSHOT</version>
+		<version>5.1.0.DATAGRAPH-1126-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.1.0.BUILD-SNAPSHOT</version>
+		<version>5.1.0.DATAGRAPH-1126-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionService.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -19,7 +19,6 @@ import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.typeconversion.AttributeConverter;
-import org.neo4j.ogm.typeconversion.ConversionCallback;
 import org.neo4j.ogm.typeconversion.ProxyAttributeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,8 +32,9 @@ import org.springframework.core.convert.support.GenericConversionService;
  * @author Adam George
  * @author Luanne Misquitta
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
-public class MetaDataDrivenConversionService extends GenericConversionService implements ConversionCallback {
+public class MetaDataDrivenConversionService extends GenericConversionService {
 
 	private static final Logger logger = LoggerFactory.getLogger(MetaDataDrivenConversionService.class);
 
@@ -45,7 +45,6 @@ public class MetaDataDrivenConversionService extends GenericConversionService im
 	 *          object-graph mapping layer
 	 */
 	public MetaDataDrivenConversionService(MetaData metaData) {
-		metaData.registerConversionCallback(this);
 
 		for (ClassInfo classInfo : metaData.persistentEntities()) {
 			for (FieldInfo fieldInfo : classInfo.propertyFields()) {
@@ -100,13 +99,4 @@ public class MetaDataDrivenConversionService extends GenericConversionService im
 			addConverter(targetType, sourceType, toEntityConverter);
 		}
 	}
-
-	@Override
-	public <T> T convert(Class<T> targetType, Object value) {
-		if (value == null) {
-			return null;
-		}
-		return convert(value, targetType);
-	}
-
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
@@ -25,6 +25,7 @@ import org.springframework.data.neo4j.conversion.Neo4jOgmEntityInstantiatorAdapt
 import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
 
 /**
+ *
  * @author Gerrit Meier
  * @author Michael J. Simons
  */
@@ -33,13 +34,10 @@ public class Neo4jOgmEntityInstantiatorConfigurationBean {
 	public Neo4jOgmEntityInstantiatorConfigurationBean(SessionFactory sessionFactory, Neo4jMappingContext mappingContext,
 			ObjectProvider<ConversionService> conversionServiceObjectProvider) {
 
-		ConversionService conversionService = conversionServiceObjectProvider.getIfUnique();
 		MetaData metaData = sessionFactory.metaData();
-		if (conversionService == null) {
-			conversionService = new MetaDataDrivenConversionService(metaData);
-		} else {
-			metaData.registerConversionCallback(new ConversionServiceBasedConversionCallback(conversionService));
-		}
+		ConversionService conversionService = conversionServiceObjectProvider
+				.getIfUnique(() -> new MetaDataDrivenConversionService(metaData));
+		metaData.registerConversionCallback(new ConversionServiceBasedConversionCallback(conversionService));
 
 		sessionFactory.setEntityInstantiator(new Neo4jOgmEntityInstantiatorAdapter(mappingContext, conversionService));
 	}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ConversionServiceTests.java
@@ -33,7 +33,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService;
 import org.springframework.data.neo4j.integration.conversion.domain.JavaElement;
 import org.springframework.data.neo4j.integration.conversion.domain.MonetaryAmount;
@@ -48,13 +47,14 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
+ * See DATAGRAPH-624
+ *
  * @author Adam George
  * @author Luanne Misquitta
  * @author Vince Bickers
  * @author Mark Angrish
  * @author Mark Paluch
  * @author Jens Schauder
- * @see DATAGRAPH-624
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = { ConversionServiceTests.ConversionServicePersistenceContext.class })
@@ -64,7 +64,11 @@ public class ConversionServiceTests extends MultiDriverTestClass {
 	@Autowired private PensionRepository pensionRepository;
 	@Autowired private JavaElementRepository javaElementRepository;
 	@Autowired private SiteMemberRepository siteMemberRepository;
-	@Autowired private GenericConversionService conversionService;
+	// TODO See below, for the time being at least be explicit on which type of conversion service we're working on here
+	// The only thing that is under test, is the instance of MetaDataDrivenConversionService which get's even
+	// modified heavily be this test. This needs to be fixed in the near future.
+	// Also it doesn't test conversion with `graphPropertyType` attribute and a standard Spring Converter.
+	@Autowired private MetaDataDrivenConversionService conversionService;
 
 	@Autowired Session session;
 
@@ -219,10 +223,7 @@ public class ConversionServiceTests extends MultiDriverTestClass {
 		assertEquals(50, siteMember.getYears().intValue());
 	}
 
-	/**
-	 * @see DATAGRAPH-659
-	 */
-	@Test
+	@Test // DATAGRAPH-659
 	public void shouldRecognizeJavaEnums() {
 		SiteMember siteMember = new SiteMember();
 		siteMember.setRoundingModes(Arrays.asList(RoundingMode.DOWN, RoundingMode.FLOOR));

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldGracefullyHandleMultipleConversionServicesTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldGracefullyHandleMultipleConversionServicesTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.integration.conversion;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+		classes = { ShouldGracefullyHandleMultipleConversionServicesTests.ConversionServicePersistenceContext.class })
+public class ShouldGracefullyHandleMultipleConversionServicesTests extends MultiDriverTestClass {
+
+	@Test
+	public void contextLoads() {}
+
+	@Configuration
+	@EnableNeo4jRepositories(basePackageClasses = { SiteMemberRepository.class })
+	@EnableTransactionManagement
+	static class ConversionServicePersistenceContext {
+
+		@Bean
+		public ConversionService conversionService1() {
+			return new MetaDataDrivenConversionService(sessionFactory().metaData());
+		}
+
+		@Bean
+		public ConversionService conversionService2() {
+			return DefaultConversionService.getSharedInstance();
+		}
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+			return new Neo4jTransactionManager(sessionFactory());
+		}
+
+		@Bean
+		public SessionFactory sessionFactory() {
+			return new SessionFactory(getBaseConfiguration().build(),
+					"org.springframework.data.neo4j.integration.conversion.domain");
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldPickPrimaryConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldPickPrimaryConversionServiceTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.integration.conversion;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.Result;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.neo4j.integration.conversion.domain.MonetaryAmount;
+import org.springframework.data.neo4j.integration.conversion.domain.PensionPlan;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * @author Michael J. Simons
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = { ShouldPickPrimaryConversionServiceTests.ConversionServicePersistenceContext.class })
+public class ShouldPickPrimaryConversionServiceTests extends MultiDriverTestClass {
+
+	@Autowired private PensionRepository pensionRepository;
+
+	@Before
+	public void setUp() {
+		getGraphDatabaseService().execute("MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE r, n");
+	}
+
+	@Test
+	public void shouldWorkWithArbitraryPrimaryConversionBeans() {
+		PensionPlan pension = new PensionPlan(new MonetaryAmount(16472, 81), "Tightfist Asset Management Ltd");
+		pension = this.pensionRepository.save(pension);
+
+		Result result = getGraphDatabaseService().execute("MATCH (p:PensionPlan) RETURN p.fundValue AS fv");
+		assertTrue("Nothing was saved", result.hasNext());
+		assertEquals("The amount wasn't converted and persisted correctly", "42", String.valueOf(result.next().get("fv")));
+		result.close();
+
+		PensionPlan reloadedPension = this.pensionRepository.findById(pension.getPensionPlanId()).get();
+		assertEquals("The amount was converted incorrectly", new MonetaryAmount(21, 0), reloadedPension.getFundValue());
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(basePackageClasses = { PensionRepository.class })
+	@EnableTransactionManagement
+	static class ConversionServicePersistenceContext {
+
+		/**
+		 * @return A pretty bogus conversion, basically only half the truth.
+		 */
+		@Bean
+		@Primary
+		public ConversionService conversionService1() {
+			GenericConversionService conversionService = new GenericConversionService();
+			// Please don't replace with lambdas, otherwise Spring won't be able to determine source and target types
+			conversionService.addConverter(new Converter<MonetaryAmount, Integer>() {
+				@Override
+				public Integer convert(MonetaryAmount source) {
+					return 42;
+				}
+			});
+			conversionService.addConverter(new Converter<Long, MonetaryAmount>() {
+				@Override
+				public MonetaryAmount convert(Long source) {
+					return new MonetaryAmount(21, 0);
+				}
+			});
+			return conversionService;
+		}
+
+		@Bean
+		public ConversionService conversionService2() {
+			return DefaultConversionService.getSharedInstance();
+		}
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+			return new Neo4jTransactionManager(sessionFactory());
+		}
+
+		@Bean
+		public SessionFactory sessionFactory() {
+			return new SessionFactory(getBaseConfiguration().build(),
+					"org.springframework.data.neo4j.integration.conversion.domain");
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/PensionPlan.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/PensionPlan.java
@@ -35,10 +35,6 @@ public class PensionPlan {
 
 	private String providerName;
 
-	PensionPlan() {
-		// default constructor for OGM
-	}
-
 	public PensionPlan(MonetaryAmount fundValue, String providerName) {
 		this.fundValue = fundValue;
 		this.providerName = providerName;

--- a/src/main/asciidoc/reference/neo4j-repositories.adoc
+++ b/src/main/asciidoc/reference/neo4j-repositories.adoc
@@ -630,19 +630,10 @@ It is highly recommended to create _JSR-303_ annotations on actual Java Beans, s
 [[reference_programming-model_conversion]]
 === Conversion Service
 It is possible to have Spring Data Neo4j use converters registered with http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/html/validation.html#core-convert[Spring's ConversionService].
-In order to do this, provide `org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService` as a Spring bean.
+There must be one unique instance of a `ConversionService`-Bean in your application context to use this.
+If there is more than one instance, you have to mark the one to be used by SDN with `@Primary`, otherwise an internal conversion service will be used.
 
-.Provide MetaDataDrivenConversionService as a Spring bean
-[source,java]
-----
-@Bean
-public ConversionService conversionService() {
-    return new MetaDataDrivenConversionService(getSessionFactory().metaData());
-}
-----
-
-Then, instead of defining an implementation of `org.neo4j.ogm.typeconversion.AttributeConverter` on the `@Convert` annotation,
-use the `graphPropertyType` attribute to define the type to convert to.
+When those requirements are met, use the `graphPropertyType` attribute on the `@Convert` annotation instead of specifying an `org.neo4j.ogm.typeconversion.AttributeConverter` through its `value`:
 
 .Using graphPropertyType
 [source,java]


### PR DESCRIPTION
4 commits here. The first 3 are required and should be picked/squash. They fix the issue at hand.

Have a sharp look at number 4: It will break things, i.e. if people brought in SDN without actually using it but calling the constructor of MetaDataDrivenConversionService and relying on the fact that it does all kinds of stuff or requiring MetaDataDrivenConversionService to implement the callback interface.

However, this stuff is new anyway in 5.1, so better break it now than in 5.2.