### PR TITLE
Fix possible ArrayIndexOutOfBoundsException in MetaDataDrivenConversionService during startup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1131-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1131-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1131-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceIntegrationTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.conversion;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.Result;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.conversion.support.ConvertedClass;
+import org.springframework.data.neo4j.conversion.support.EntityRepository;
+import org.springframework.data.neo4j.conversion.support.EntityWithConvertedAttributes;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Murray Gold - Doctor Who Season 9
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = MetaDataDrivenConversionServiceIntegrationTests.Config.class)
+public class MetaDataDrivenConversionServiceIntegrationTests extends MultiDriverTestClass {
+
+	@Autowired private EntityRepository entityRepository;
+
+	@Test // DATAGRAPH-1131
+	public void conversionWithConverterHierarchyShouldWork() {
+
+		ConvertedClass convertedClass = new ConvertedClass();
+		convertedClass.setValue("Some value");
+		EntityWithConvertedAttributes entity = new EntityWithConvertedAttributes("name");
+		entity.setConvertedClass(convertedClass);
+		entity.setDoubles(Arrays.asList(21.0, 21.0));
+		entity.setTheDouble(42.0);
+		entityRepository.save(entity);
+
+		Result result = getGraphDatabaseService()
+				.execute("MATCH (e:EntityWithConvertedAttributes) RETURN e.convertedClass, e.doubles, e.theDouble");
+
+		assertThat(result.hasNext()).isTrue();
+		Map<String, Object> row = result.next();
+		assertThat(row) //
+				.containsEntry("e.convertedClass", "n/a") //
+				.containsEntry("e.doubles", "21.0,21.0") //
+				.containsEntry("e.theDouble", "that has been a double");
+
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(basePackageClasses = EntityWithConvertedAttributes.class)
+	@EnableTransactionManagement
+	public static class Config {
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+			return new Neo4jTransactionManager(sessionFactory());
+		}
+
+		@Bean
+		public SessionFactory sessionFactory() {
+			return new SessionFactory(getBaseConfiguration().build(),
+					EntityWithConvertedAttributes.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.conversion;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.springframework.data.neo4j.conversion.support.ConvertedClass;
+import org.springframework.data.neo4j.conversion.support.Converters;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Murray Gold - Doctor Who Season 9
+ */
+public class MetaDataDrivenConversionServiceTests extends MultiDriverTestClass {
+
+	@Test
+	public void shouldDetermineConvertersForClasses() {
+		MetaDataDrivenConversionService.PairOfTypes pairOfTypes = MetaDataDrivenConversionService
+				.getPairOfTypes(new Converters.DoubleToStringConverter());
+
+		assertThat(pairOfTypes.sourceType).isEqualTo(Double.class);
+		assertThat(pairOfTypes.targetType).isEqualTo(String.class);
+	}
+
+	@Test
+	public void shouldDetermineConvertersForTypedClasses() {
+		MetaDataDrivenConversionService.PairOfTypes pairOfTypes = MetaDataDrivenConversionService
+				.getPairOfTypes(new Converters.ListToStringConverter());
+
+		assertThat(pairOfTypes.sourceType).isEqualTo(Double.class);
+		assertThat(pairOfTypes.targetType).isEqualTo(String.class);
+	}
+
+	@Test // DATAGRAPH-1131
+	public void shouldWorkWithConvertersInvolvingAbstractBaseClasses() {
+		MetaDataDrivenConversionService.PairOfTypes pairOfTypes = MetaDataDrivenConversionService
+				.getPairOfTypes(new Converters.ConvertedClassToStringConverter());
+
+		assertThat(pairOfTypes.sourceType).isEqualTo(ConvertedClass.class);
+		assertThat(pairOfTypes.targetType).isEqualTo(String.class);
+	}
+
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/ConvertedClass.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/ConvertedClass.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.conversion.support;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Murray Gold - Doctor Who Season 9
+ */
+public class ConvertedClass {
+	private String value;
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
@@ -13,6 +13,8 @@
 
 package org.springframework.data.neo4j.conversion.support;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.List;
 
 import org.neo4j.ogm.typeconversion.AttributeConverter;
@@ -64,7 +66,7 @@ public final class Converters {
 
 		@Override
 		public String toGraphProperty(Double value) {
-			return null;
+			return "that has been a double";
 		}
 
 		@Override
@@ -77,7 +79,7 @@ public final class Converters {
 
 		@Override
 		public String toGraphProperty(List<Double> value) {
-			return null;
+			return value.stream().map(d -> d.toString()).collect(joining(","));
 		}
 
 		@Override

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.springframework.data.neo4j.conversion.support;
+
+import java.util.List;
+
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+
+/**
+ * Wraps a some converters.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Murray Gold - Doctor Who Season 9
+ */
+public final class Converters {
+
+	private Converters() {
+	}
+
+	/**
+	 * Concrete implementation doesn't matter and is meaningless on purpose.
+	 *
+	 * @param <T>
+	 */
+	public static abstract class AbstractObjectToString<T> implements AttributeConverter<T, String> {
+
+		@Override
+		public String toGraphProperty(T value) {
+			return "n/a";
+		}
+
+		@Override
+		public T toEntityAttribute(String value) {
+			try {
+				return getTypeClass().newInstance();
+			} catch (InstantiationException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		protected abstract Class<T> getTypeClass();
+	}
+
+	public static class ConvertedClassToStringConverter extends AbstractObjectToString<ConvertedClass> {
+
+		@Override
+		protected Class<ConvertedClass> getTypeClass() {
+			return ConvertedClass.class;
+		}
+	}
+
+	public static class DoubleToStringConverter implements AttributeConverter<Double, String> {
+
+		@Override
+		public String toGraphProperty(Double value) {
+			return null;
+		}
+
+		@Override
+		public Double toEntityAttribute(String value) {
+			return null;
+		}
+	}
+
+	public static class ListToStringConverter implements AttributeConverter<List<Double>, String> {
+
+		@Override
+		public String toGraphProperty(List<Double> value) {
+			return null;
+		}
+
+		@Override
+		public List<Double> toEntityAttribute(String value) {
+			return null;
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityRepository.java
@@ -1,0 +1,7 @@
+package org.springframework.data.neo4j.conversion.support;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface EntityRepository extends Neo4jRepository<EntityWithConvertedAttributes, Long> {
+}
+

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityWithConvertedAttributes.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityWithConvertedAttributes.java
@@ -1,0 +1,57 @@
+package org.springframework.data.neo4j.conversion.support;
+
+import java.util.List;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+
+@NodeEntity
+public class EntityWithConvertedAttributes {
+	@Id @GeneratedValue private Long id;
+
+	private String name;
+
+	@Property
+	@Convert(Converters.ConvertedClassToStringConverter.class)
+	private ConvertedClass convertedClass;
+
+	@Property
+	@Convert(Converters.ListToStringConverter.class)
+	private List<Double> doubles;
+
+	@Convert(Converters.DoubleToStringConverter.class)
+	private Double theDouble;
+
+	public EntityWithConvertedAttributes() {}
+
+	public EntityWithConvertedAttributes(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setConvertedClass(ConvertedClass convertedClass) {
+		this.convertedClass = convertedClass;
+	}
+
+	public void setDoubles(List<Double> doubles) {
+		this.doubles = doubles;
+	}
+
+	public void setTheDouble(Double theDouble) {
+		this.theDouble = theDouble;
+	}
+}


### PR DESCRIPTION
I have rewritten most of the `MetaDataDrivenConversionService`. It now uses Springs `ResolvableType` to deal with resolution of type parameters, which makes things a lot less error prone.

`ResolvableType` is available since 4.0 which makes it safe to use.

I opted to make the determination non-private to verify the behavior before and after my change.

Added unit as well as integration tests.