### PR TITLE
DATAGRAPH-1135 Fix resolution of implicitly named parameters on Repository queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1135-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -209,4 +209,25 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<compilerArgs>-parameters</compilerArgs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
@@ -36,18 +36,6 @@ public class GraphParameters extends Parameters<GraphParameters, GraphParameters
 		super(method);
 	}
 
-	GraphParameters(Method method, List<GraphParameter> parameters) {
-
-		super(parameters);
-
-		for (int i = 0; i < parameters.size(); i++) {
-			GraphParameter parameter = parameters.get(i);
-			if (parameter.isDepthParameter()) {
-				this.depthIndex = i;
-			}
-		}
-	}
-
 	GraphParameters(List<GraphParameter> parameters, Integer depthIndex) {
 		super(parameters);
 		this.depthIndex = depthIndex;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.data.repository.query.Parameters;
  * Custom extension of {@link Parameters} discovering additional to handle @link{Depth} special parameter.
  *
  * @author Nicolas Mervaillie
+ * @author Michael J. Simons
  */
 public class GraphParameters extends Parameters<GraphParameters, GraphParameters.GraphParameter> {
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -89,19 +89,27 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 	}
 
 	Map<String, Object> resolveParams(Parameters<?, ?> methodParameters, Object[] parameters) {
-		Map<String, Object> params = new HashMap<>();
 
-		for (int i = 0; i < parameters.length; i++) {
-			Parameter parameter = methodParameters.getParameter(i);
-			Object parameterValue = getParameterValue(parameters[i]);
+		Map<String, Object> resolvedParameters = new HashMap<>();
 
-			if (parameter.isExplicitlyNamed()) {
-				parameter.getName().ifPresent(name -> params.put(name, parameterValue));
+		for(Parameter parameter : methodParameters) {
+			int parameterIndex = parameter.getIndex();
+			Object parameterValue = getParameterValue(parameters[parameterIndex]);
+
+			// We support using parameters based on their index and their name at the same time
+			// and don't check the query upfront whether the parameter is bound via name or index
+			// as Spring Data JPA does for example.
+			resolvedParameters.put(Integer.toString(parameterIndex), parameterValue);
+
+			// Make sure we don't add "special" parameters as named parameters
+			if(parameter.isNamedParameter()) {
+				// even though the above check ensures the presence usually, it's probably better to
+				// treat #isNamedParameter as a blackbox and not just calling #get() on the optional.
+				parameter.getName().ifPresent(parameterName -> resolvedParameters.put(parameterName, parameterValue));
 			}
-			params.put("" + i, parameterValue);
 		}
 
-		return params;
+		return resolvedParameters;
 	}
 
 	// just an horrible trick to get the metadata from OGM

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.data.repository.query.ResultProcessor;
  * @author Jasper Blues
  * @author Mark Paluch
  * @author Nicolas Mervaillie
+ * @author Michael J. Simons
  */
 public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 
@@ -96,9 +97,8 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 			int parameterIndex = parameter.getIndex();
 			Object parameterValue = getParameterValue(parameters[parameterIndex]);
 
-			// We support using parameters based on their index and their name at the same time
-			// and don't check the query upfront whether the parameter is bound via name or index
-			// as Spring Data JPA does for example.
+			// We support using parameters based on their index and their name at the same time,
+			// so parameters are always bound by index.
 			resolvedParameters.put(Integer.toString(parameterIndex), parameterValue);
 
 			// Make sure we don't add "special" parameters as named parameters

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
@@ -70,6 +70,9 @@ public interface UserRepository extends PersonRepository<User, Long> {
 	@Query("MATCH (user:User{name:{name}}) RETURN user")
 	User findUserByNameWithNamedParam(@Param("name") String name);
 
+	@Query("MATCH (user:User{name:{name}}) RETURN user")
+	User findUserByNameWithNamedParamWithoutParamAnnotation(String name);
+
 	@Query("MATCH (user:User{name:{0}}) RETURN user")
 	User findUserByName(String name);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
@@ -364,10 +364,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-698, DATAGRAPH-861
-	 */
-	@Test
+	@Test // DATAGRAPH-698, DATAGRAPH-861
 	public void shouldFindUsersAndMapThemToConcreteQueryResultObjectCollection() {
 		executeUpdate(
 				"CREATE (g:User {name:'Gary', age:32}), (s:User {name:'Sheila', age:29}), (v:User {name:'Vince', age:66})");
@@ -451,10 +448,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-694
-	 */
-	@Test
+	@Test // DATAGRAPH-694
 	public void shouldSubstituteUserId() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
 
@@ -469,10 +463,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-694
-	 */
-	@Test
+	@Test // DATAGRAPH-694
 	public void shouldSubstituteNamedParamUserId() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
 
@@ -487,10 +478,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-727
-	 */
-	@Test
+	@Test // DATAGRAPH-727
 	public void shouldFindIterableUsers() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
 
@@ -507,10 +495,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-772
-	 */
-	@Test
+	@Test // DATAGRAPH-772
 	public void shouldAllowNullParameters() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
 
@@ -526,10 +511,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-772
-	 */
-	@Test
+	@Test // DATAGRAPH-772
 	public void shouldMapNullsToQueryResults() {
 		executeUpdate("CREATE (g:User), (s:User)");
 
@@ -550,10 +532,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldMapNodeEntitiesIntoQueryResultObjects() {
 		executeUpdate("CREATE (:User {name:'Abraham'}), (:User {name:'Barry'}), (:User {name:'Colin'})");
 
@@ -568,10 +547,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldMapNodeCollectionsIntoQueryResultObjects() {
 		executeUpdate(
 				"CREATE (d:User {name:'Daniela'}),  (e:User {name:'Ethan'}), (f:User {name:'Finn'}), (d)-[:FRIEND_OF]->(e), (d)-[:FRIEND_OF]->(f)");
@@ -590,16 +566,13 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 				}
 				assertTrue(friends.contains("Ethan"));
 				assertTrue(friends.contains("Finn"));
-				assertEquals(2, result.getUser().getFriends().size()); // we expect friends to be mapped since the relationships
-																																// were returned
+				// we expect friends to be mapped since the relationships were returned
+				assertEquals(2, result.getUser().getFriends().size());
 			}
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldMapRECollectionsIntoQueryResultObjects() {
 		executeUpdate(
 				"CREATE (g:User {name:'Gary'}), (sw:Movie {name: 'Star Wars: The Force Awakens'}), (hob:Movie {name:'The Hobbit: An Unexpected Journey'}), (g)-[:RATED {stars : 5}]->(sw), (g)-[:RATED {stars: 4}]->(hob) ");
@@ -632,10 +605,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldMapRelationshipCollectionsWithDepth0IntoQueryResultObjects() {
 		executeUpdate(
 				"CREATE (i:User {name:'Ingrid'}),  (j:User {name:'Jake'}), (k:User {name:'Kate'}), (i)-[:FRIEND_OF]->(j), (i)-[:FRIEND_OF]->(k)");
@@ -654,16 +624,13 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 				}
 				assertTrue(friends.contains("Kate"));
 				assertTrue(friends.contains("Jake"));
-				assertEquals(0, result.getUser().getFriends().size()); // we do not expect friends to be mapped since the
-																																// relationships were not returned
+				// we do not expect friends to be mapped since the relationships were not returned
+				assertEquals(0, result.getUser().getFriends().size());
 			}
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldReturnMultipleQueryResultObjects() {
 		executeUpdate(
 				"CREATE (g:User {name:'Gary'}), (h:User {name:'Harry'}), (sw:Movie {name: 'Star Wars: The Force Awakens'}), (hob:Movie {name:'The Hobbit: An Unexpected Journey'}), (g)-[:RATED {stars : 5}]->(sw), (g)-[:RATED {stars: 4}]->(hob), (h)-[:RATED {stars: 3}]->(hob) ");
@@ -710,10 +677,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-700
-	 */
-	@Test
+	@Test // DATAGRAPH-700
 	public void shouldMapEntitiesToProxiedQueryResultInterface() {
 		executeUpdate(
 				"CREATE (:User {name:'Morne', age:30}), (:User {name:'Abraham', age:31}), (:User {name:'Virat', age:27})");
@@ -730,10 +694,7 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
-	/**
-	 * @see DATAGRAPH-860
-	 */
-	@Test
+	@Test // DATAGRAPH-860
 	public void shouldMapEmptyNullCollectionsToQueryResultInterface() {
 		executeUpdate("CREATE (g:User {name:'Gary'})");
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
@@ -332,6 +332,19 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
+	@Test // DATAGRAPH-1135
+	public void namedParameterShouldWorkWithouthAtParamsInAtQueryMethods() {
+		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
+
+		transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+			@Override
+			public void doInTransactionWithoutResult(TransactionStatus status) {
+				User user = userRepository.findUserByNameWithNamedParamWithoutParamAnnotation("Michal");
+				assertEquals("Michal", user.getName());
+			}
+		});
+	}
+
 	@Test
 	public void shouldFindUsersAsProperties() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");


### PR DESCRIPTION
This checks wether a Parameter is actually a named parameter (not special and having a name determinable by some means) and if so, adds it to map of parameters.

We still add the parameter based on its index, otherwise we would break existing behavior (parameters can be used mixed: By index and name at the same time).

There is another PR incoming for the 5.0.x series. It keeps the logic, but skips the polishing due to other changes.