### PR TITLE
DATAGRAPH-1135 Fix resolution of implicitly named parameters on Repository queries. (5.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.0.12.BUILD-SNAPSHOT</version>
+	<version>5.0.12.DATAGRAPH-1135-BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.0.12.BUILD-SNAPSHOT</version>
+		<version>5.0.12.DATAGRAPH-1135-BUILD-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.0.12.BUILD-SNAPSHOT</version>
+		<version>5.0.12.DATAGRAPH-1135-BUILD-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -198,4 +198,25 @@
 		</dependency>
 
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<compilerArgs>-parameters</compilerArgs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -92,10 +92,10 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 			Parameter parameter = methodParameters.getParameter(i);
 			Object parameterValue = getParameterValue(parameters[i]);
 
-			if (parameter.isExplicitlyNamed()) {
-				parameter.getName().ifPresent(name -> params.put(name, parameterValue));
-			} else {
-				params.put("" + i, parameterValue);
+			params.put(Integer.toString(i), parameterValue);
+
+			if(parameter.isNamedParameter()) {
+				parameter.getName().ifPresent(parameterName -> params.put(parameterName, parameterValue));
 			}
 		}
 		return params;

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
@@ -62,6 +62,9 @@ public interface UserRepository extends PersonRepository<User, Long> {
 	@Query("MATCH (user:User{name:{name}}) RETURN user")
 	User findUserByNameWithNamedParam(@Param("name") String name);
 
+	@Query("MATCH (user:User{name:{name}}) RETURN user")
+	User findUserByNameWithNamedParamWithoutParamAnnotation(String name);
+
 	@Query("MATCH (user:User{name:{0}}) RETURN user")
 	User findUserByName(String name);
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
@@ -171,6 +171,19 @@ public class QueryIntegrationTests extends MultiDriverTestClass {
 		});
 	}
 
+	@Test // DATAGRAPH-1135
+	public void namedParameterShouldWorkWithouthAtParamsInAtQueryMethods() {
+		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");
+
+		transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+			@Override
+			public void doInTransactionWithoutResult(TransactionStatus status) {
+				User user = userRepository.findUserByNameWithNamedParamWithoutParamAnnotation("Michal");
+				assertEquals("Michal", user.getName());
+			}
+		});
+	}
+
 	@Test
 	public void shouldFindUsersAsProperties() {
 		executeUpdate("CREATE (m:User {name:'Michal'})<-[:FRIEND_OF]-(a:User {name:'Adam'})");


### PR DESCRIPTION
This is essentially the same as https://github.com/spring-projects/spring-data-neo4j/pull/433, but adapted to the 5.0.x. series.