### PR TITLE
DATAGRAPH-1144 Recognize not only internal ids as id properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1144-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1144-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1144-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
@@ -62,6 +62,10 @@ public class Neo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		return new Neo4jIsNewStrategy(this);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.BasicPersistentEntity#returnPropertyIfBetterIdPropertyCandidateOrNull(PersistentProperty)
+	 */
 	@Override
 	protected Neo4jPersistentProperty returnPropertyIfBetterIdPropertyCandidateOrNull(Neo4jPersistentProperty property) {
 
@@ -87,10 +91,10 @@ public class Neo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 
 	/**
 	 * Custom {@link IsNewStrategy} to also consider entities with identifiers of negative Long values new.
+	 * See also DATAGRAPH-1031.
 	 *
 	 * @author Frantisek Hartman
 	 * @author Oliver Gierke
-	 * @see DATAGRAPH-1031
 	 */
 	private static class Neo4jIsNewStrategy implements IsNewStrategy {
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2017] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -12,14 +12,19 @@
  */
 package org.springframework.data.neo4j.mapping;
 
+import java.lang.reflect.Field;
+import java.util.Optional;
+
 import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.annotation.StartNode;
 import org.neo4j.ogm.annotation.Version;
-import org.neo4j.ogm.exception.core.MetadataException;
 import org.neo4j.ogm.metadata.ClassInfo;
+import org.neo4j.ogm.metadata.FieldInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
@@ -50,13 +55,24 @@ import org.springframework.data.neo4j.annotation.QueryResult;
  * @author Luanne Misquitta
  * @author Mark Angrish
  * @author Mark Paluch
+ * @author Michael J. Simons
  * @since 4.0.0
  */
 public class Neo4jPersistentProperty extends AnnotationBasedPersistentProperty<Neo4jPersistentProperty> {
 
 	private static final Logger logger = LoggerFactory.getLogger(Neo4jPersistentProperty.class);
 
-	private final boolean isIdProperty;
+	enum PropertyType {
+		REGULAR_PROPERTY(false), INTERNAL_ID_PROPERTY(true), ID_PROPERTY(true);
+
+		private final boolean idProperty;
+
+		PropertyType(boolean idProperty) {
+			this.idProperty = idProperty;
+		}
+	}
+
+	private final PropertyType propertyType;
 
 	/**
 	 * Constructs a new {@link Neo4jPersistentProperty} based on the given arguments.
@@ -70,44 +86,63 @@ public class Neo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 	public Neo4jPersistentProperty(ClassInfo owningClassInfo, Property property,
 			PersistentEntity<?, Neo4jPersistentProperty> owner, SimpleTypeHolder simpleTypeHolder) {
 		super(property, owner, simpleTypeHolder);
+
 		if (owningClassInfo == null) {
 			logger.warn("Owning ClassInfo is null for property: {}", property);
 		}
-		if ((owningClassInfo != null && owningClassInfo.getUnderlyingClass() != null
-				&& simpleTypeHolder.isSimpleType(owningClassInfo.getUnderlyingClass())) || owner.getType().isEnum()) { // TODO
-																																																								// refactor
-																																																								// all
-																																																								// these
-																																																								// null
-																																																								// checks
-			this.isIdProperty = false;
+
+		if (owningClassInfo == null || owningClassIsSimple(owningClassInfo, simpleTypeHolder)
+				|| owningClassDoesNotSupportIdProperties(owningClassInfo) || owningPropertyIsEnum(owner)) {
+			this.propertyType = PropertyType.REGULAR_PROPERTY;
+		} else if (isInternalIdentityField(owningClassInfo, property)) {
+			this.propertyType = PropertyType.INTERNAL_ID_PROPERTY;
+		} else if (isExplicitIdentityField(owningClassInfo, property)) {
+			this.propertyType = PropertyType.ID_PROPERTY;
 		} else {
-			this.isIdProperty = resolveWhetherIdProperty(owningClassInfo, property);
+			this.propertyType = PropertyType.REGULAR_PROPERTY;
 		}
 	}
 
-	private static boolean resolveWhetherIdProperty(ClassInfo owningClassInfo, Property property) {
-		if (owningClassInfo == null || owningClassInfo.isInterface()
-				|| owningClassInfo.annotationsInfo().get(QueryResult.class.getName()) != null || owningClassInfo.isEnum()) {
-			// no ID properties on @QueryResult or non-concrete objects
-			return false;
-		} else {
-			try {
-				return property.getField() //
-						.filter(field -> owningClassInfo.getField(owningClassInfo.identityField()).equals(field)) //
-						.isPresent();
-			} catch (MetadataException noIdentityField) {
-				logger.warn("No identity field found for class of type: {} when creating persistent property for : {}",
-						owningClassInfo.name(), property);
-				return false;
-			}
-		}
+	private static boolean owningPropertyIsEnum(PersistentEntity<?, Neo4jPersistentProperty> owner) {
+		return owner.getType().isEnum();
+	}
+
+	private static boolean owningClassIsSimple(ClassInfo owningClassInfo, SimpleTypeHolder simpleTypeHolder) {
+
+		return owningClassInfo.getUnderlyingClass() != null
+				&& simpleTypeHolder.isSimpleType(owningClassInfo.getUnderlyingClass());
+	}
+
+	private static boolean owningClassDoesNotSupportIdProperties(ClassInfo owningClassInfo) {
+
+		return owningClassInfo.isInterface() || owningClassInfo.annotationsInfo().get(QueryResult.class.getName()) != null
+				|| owningClassInfo.isEnum();
+	}
+
+	private static boolean isInternalIdentityField(ClassInfo owningClassInfo, Property property) {
+
+		Optional<Field> optionalInternalIdentityField = Optional.ofNullable(owningClassInfo.identityFieldOrNull())
+				.map(FieldInfo::getField);
+		return property.getField().equals(optionalInternalIdentityField);
+	}
+
+	private static boolean isExplicitIdentityField(ClassInfo owningClassInfo, Property property) {
+
+		// Cannot use owningClassInfo.propertyField() as those are not initialized yet. They will
+		// be initialized on the call, but that would change behaviour: SDN fails late when there
+		// are invalid properties atm. Even if'ts better to fail early, it means at least changing
+		// a dozen tests in SDN itself.
+		return property.getField().map(field -> AnnotatedElementUtils.findMergedAnnotation(field, Id.class)).isPresent();
 	}
 
 	@Override
 	public boolean isIdProperty() {
-		logger.debug("[property].isIdProperty() returns {}", this.isIdProperty);
-		return this.isIdProperty;
+
+		return this.propertyType != PropertyType.REGULAR_PROPERTY;
+	}
+
+	PropertyType getPropertyType() {
+		return propertyType;
 	}
 
 	@Override

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/NodeWithUUIDAsId.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/NodeWithUUIDAsId.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." / "Pivotal Software, Inc."
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.domain.sample;
+
+import java.util.UUID;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.id.UuidStrategy;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
+/**
+ * @author Michael J. Simons
+ */
+public class NodeWithUUIDAsId {
+
+	private Long id;
+
+	@Id @GeneratedValue(strategy = UuidStrategy.class) @Convert(UuidStringConverter.class) private UUID myNiceId;
+
+	private String someProperty;
+
+	public NodeWithUUIDAsId(String someProperty) {
+		this.someProperty = someProperty;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public UUID getMyNiceId() {
+		return myNiceId;
+	}
+
+	public String getSomeProperty() {
+		return someProperty;
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTests.java
@@ -16,10 +16,12 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Test;
 import org.neo4j.ogm.metadata.MetaData;
+import org.springframework.data.neo4j.domain.sample.NodeWithUUIDAsId;
 import org.springframework.data.neo4j.domain.sample.User;
 
 /**
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 public class Neo4jPersistentPropertyTests {
 
@@ -32,4 +34,13 @@ public class Neo4jPersistentPropertyTests {
 		assertThat(version.isVersionProperty()).isTrue();
 	}
 
+	@Test // DATAGRAPH-1144
+	public void shouldDetectExplicitIdFieldsAsIdProperties() {
+		MetaData metaData = new MetaData("org.springframework.data.neo4j.domain.sample");
+		Neo4jMappingContext mappingContext = new Neo4jMappingContext(metaData);
+		Neo4jPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(NodeWithUUIDAsId.class);
+		Neo4jPersistentProperty idProperty = persistentEntity.getRequiredIdProperty();
+		assertThat(idProperty.isIdProperty());
+		assertThat(idProperty.getName()).isEqualTo("myNiceId");
+	}
 }


### PR DESCRIPTION
From the main commit:

Fix the determination of Spring Data Id Properties:

Before the fix, Neo4jPersistentProperty only considered the „identityField“ from OGMs ClassInfo as id property. This identifyField maps only to Neo4j internal, native ids.

As soon as a user annotates a non-long field with Id Spring Data cannot determine a required id property for the entity anymore.
While the entity can still be found by the „external“ id due to the fact that OGM keeps a cache mapping from external to internal / native, modules depending on knowing the property attribute, break.

The fix introduces a property type, which can be regular, internal id or id property.

Id properties are preferred over internal id properties based on the identityField as SDN id propertiers. This has the byproduckt that we now can have an „external“ id (the property mapped with @Id) and a „Long id“ field in an entity so that a developer can refer to both.

Also take note, that I'll provide a fix for the fact that `org.springframework.data.neo4j.repository.Neo4jRepositoryTests` works only exactly in the transactional setup and the deleteAll will fail in a different transaction with OGM later this wake.