### PR TITLE
DATAGRAPH-1149 - Introduce MetaDataProvider to avoid unnecessary transactions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1149-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1149-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1149-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology"
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+package org.springframework.data.neo4j.mapping;
+
+import org.neo4j.ogm.metadata.MetaData;
+
+/**
+ * The only meta-data provider currently is a Neo4j-OGM {@link org.neo4j.ogm.session.SessionFactory} by proxy. The
+ * meta-data is needed during execution of graph-repository-queries to lookup mappings etc.
+ *
+ * @author Michael J. Simons
+ */
+@FunctionalInterface
+public interface MetaDataProvider {
+	MetaData getMetaData();
+}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
@@ -19,6 +19,7 @@ import org.neo4j.ogm.metadata.MetaData;
  * meta-data is needed during execution of graph-repository-queries to lookup mappings etc.
  *
  * @author Michael J. Simons
+ * @since 5.1.2
  */
 @FunctionalInterface
 public interface MetaDataProvider {

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
@@ -29,13 +29,13 @@ import org.springframework.data.repository.query.RepositoryQuery;
  */
 public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 
-	protected final GraphQueryMethod method;
+	protected final GraphQueryMethod queryMethod;
 	protected final MetaData metaData;
 	protected final Session session;
 
-	protected AbstractGraphRepositoryQuery(GraphQueryMethod method, MetaData metaData, Session session) {
+	protected AbstractGraphRepositoryQuery(GraphQueryMethod queryMethod, MetaData metaData, Session session) {
 
-		this.method = method;
+		this.queryMethod = queryMethod;
 		this.metaData = metaData;
 		this.session = session;
 	}
@@ -59,30 +59,30 @@ public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 
 	@Override
 	public GraphQueryMethod getQueryMethod() {
-		return method;
+		return queryMethod;
 	}
 
 	protected GraphQueryExecution getExecution(GraphParameterAccessor accessor) {
 
-		if (method.isStreamQuery()) {
+		if (queryMethod.isStreamQuery()) {
 			return new GraphQueryExecution.CollectionExecution(session, accessor);
 		}
 		if (isCountQuery()) {
 			return new GraphQueryExecution.CountByExecution(session, accessor);
 		}
 		if (isDeleteQuery()) {
-			return new GraphQueryExecution.DeleteByExecution(session, method, accessor);
+			return new GraphQueryExecution.DeleteByExecution(session, queryMethod, accessor);
 		}
 		if (returnsOgmSpecificType()) {
 			return new GraphQueryExecution.QueryResultExecution(session, accessor);
 		}
-		if (method.isCollectionQuery()) {
+		if (queryMethod.isCollectionQuery()) {
 			return new GraphQueryExecution.CollectionExecution(session, accessor);
 		}
-		if (method.isPageQuery()) {
+		if (queryMethod.isPageQuery()) {
 			return new GraphQueryExecution.PagedExecution(session, accessor);
 		}
-		if (method.isSliceQuery()) {
+		if (queryMethod.isSliceQuery()) {
 			return new GraphQueryExecution.SlicedExecution(session, accessor);
 		}
 		return new GraphQueryExecution.SingleEntityExecution(session, accessor);
@@ -94,7 +94,7 @@ public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 	 * @return true if that's the case
 	 */
 	private boolean returnsOgmSpecificType() {
-		Class returnType = method.getMethod().getReturnType();
+		Class returnType = queryMethod.getMethod().getReturnType();
 		return QueryStatistics.class.isAssignableFrom(returnType) || Result.class.isAssignableFrom(returnType);
 	}
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
@@ -15,6 +15,7 @@ package org.springframework.data.neo4j.repository.query;
 
 import java.util.EmptyStackException;
 
+import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.model.QueryStatistics;
 import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.session.Session;
@@ -28,12 +29,14 @@ import org.springframework.data.repository.query.RepositoryQuery;
  */
 public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 
-	private final GraphQueryMethod method;
-	private final Session session;
+	protected final GraphQueryMethod method;
+	protected final MetaData metaData;
+	protected final Session session;
 
-	protected AbstractGraphRepositoryQuery(GraphQueryMethod method, Session session) {
+	protected AbstractGraphRepositoryQuery(GraphQueryMethod method, MetaData metaData, Session session) {
 
 		this.method = method;
+		this.metaData = metaData;
 		this.session = session;
 	}
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryLookupStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryLookupStrategy.java
@@ -66,7 +66,7 @@ public class GraphQueryLookupStrategy implements QueryLookupStrategy {
 		this.mappingContext = mappingContext;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.QueryLookupStrategy#resolveQuery(java.lang.reflect.Method, org.springframework.data.repository.core.RepositoryMetadata, org.springframework.data.projection.ProjectionFactory, org.springframework.data.repository.core.NamedQueries)
 	 */

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -57,31 +57,31 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 	protected Object doExecute(Query query, Object[] parameters) {
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Executing query for method {}", method.getName());
+			LOG.debug("Executing query for method {}", queryMethod.getName());
 		}
 
-		GraphParameterAccessor accessor = new GraphParametersParameterAccessor(method, parameters);
-		Class<?> returnType = method.getMethod().getReturnType();
+		GraphParameterAccessor accessor = new GraphParametersParameterAccessor(queryMethod, parameters);
+		Class<?> returnType = queryMethod.getMethod().getReturnType();
 
-		ResultProcessor processor = method.getResultProcessor().withDynamicProjection(accessor);
+		ResultProcessor processor = queryMethod.getResultProcessor().withDynamicProjection(accessor);
 
 		Object result = getExecution(accessor).execute(query, processor.getReturnedType().getReturnedType());
 
 		return Result.class.equals(returnType) ? result
 				: processor.processResult(result, new CustomResultConverter(metaData,
-						processor.getReturnedType().getReturnedType(), method.getMappingContext()));
+						processor.getReturnedType().getReturnedType(), queryMethod.getMappingContext()));
 	}
 
 	protected Query getQuery(Object[] parameters) {
 		ParameterizedQuery parameterizedQuery = getParameterizedQuery();
 		Map<String, Object> parametersFromQuery = parameterizedQuery.resolveParameter(parameters, this::resolveParams);
-		return new Query(parameterizedQuery.getQueryString(), method.getCountQueryString(), parametersFromQuery);
+		return new Query(parameterizedQuery.getQueryString(), queryMethod.getCountQueryString(), parametersFromQuery);
 	}
 
 	private ParameterizedQuery getParameterizedQuery() {
 		if (parameterizedQuery == null) {
 
-			Parameters<?, ?> methodParameters = method.getParameters();
+			Parameters<?, ?> methodParameters = queryMethod.getParameters();
 			parameterizedQuery = ParameterizedQuery.getParameterizedQuery(getAnnotationQueryString(), methodParameters,
 					evaluationContextProvider);
 		}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
@@ -13,6 +13,7 @@
 
 package org.springframework.data.neo4j.repository.query;
 
+import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.session.Session;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 
@@ -21,20 +22,22 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
  * {@code META-INFO/neo4j-named-queries.properties}.
  *
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 public class NamedGraphRepositoryQuery extends GraphRepositoryQuery {
 
 	private final String cypherQuery;
 
-	NamedGraphRepositoryQuery(GraphQueryMethod graphQueryMethod, Session session, String cypherQuery,
+	NamedGraphRepositoryQuery(GraphQueryMethod graphQueryMethod, MetaData metaData, Session session, String cypherQuery,
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
-		super(graphQueryMethod, session, evaluationContextProvider);
+
+		super(graphQueryMethod, metaData, session, evaluationContextProvider);
 		this.cypherQuery = cypherQuery;
 	}
 
 	@Override
 	protected Query getQuery(Object[] parameters) {
-		return new Query(cypherQuery, resolveParams(getGraphQueryMethod().getParameters(), parameters));
+		return new Query(cypherQuery, resolveParams(method.getParameters(), parameters));
 	}
 
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
@@ -37,7 +37,7 @@ public class NamedGraphRepositoryQuery extends GraphRepositoryQuery {
 
 	@Override
 	protected Query getQuery(Object[] parameters) {
-		return new Query(cypherQuery, resolveParams(method.getParameters(), parameters));
+		return new Query(cypherQuery, resolveParams(queryMethod.getParameters(), parameters));
 	}
 
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -16,6 +16,7 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.session.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +43,8 @@ public class PartTreeNeo4jQuery extends AbstractGraphRepositoryQuery {
 
 	private final TemplatedQuery queryTemplate;
 
-	public PartTreeNeo4jQuery(GraphQueryMethod graphQueryMethod, Session session) {
-		super(graphQueryMethod, session);
+	public PartTreeNeo4jQuery(GraphQueryMethod graphQueryMethod, MetaData metaData, Session session) {
+		super(graphQueryMethod, metaData, session);
 
 		Class<?> domainType = graphQueryMethod.getEntityInformation().getJavaType();
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTests.java
@@ -14,17 +14,17 @@
 package org.springframework.data.neo4j.repositories.support;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.Serializable;
 import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
 import org.neo4j.ogm.session.Session;
 import org.springframework.aop.framework.Advised;
+import org.springframework.data.neo4j.mapping.MetaDataProvider;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.support.Neo4jRepositoryFactory;
 import org.springframework.data.neo4j.repository.support.SimpleNeo4jRepository;
@@ -38,20 +38,17 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Mark Angrish
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Michael J. Simons
  */
-@RunWith(MockitoJUnitRunner.class)
 public class GraphRepositoryFactoryTests {
 
 	Neo4jRepositoryFactory factory;
 
-	@Mock org.neo4j.ogm.session.Session session;
-
 	@Before
 	public void setUp() {
 
-		factory = new Neo4jRepositoryFactory(session) {
-
-		};
+		Session session = mock(Session.class, withSettings().extraInterfaces(MetaDataProvider.class));
+		factory = new Neo4jRepositoryFactory(session, null);
 	}
 
 	/**

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
@@ -24,18 +24,18 @@ import org.neo4j.ogm.session.Session;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.neo4j.mapping.MetaDataProvider;
 import org.springframework.data.neo4j.repository.ContactRepository;
 
 /**
  * @author Mark Angrish
  * @author Mark Paluch
+ * @author Michael J. Simons
  */
 @RunWith(MockitoJUnitRunner.class)
 public class Neo4jRepositoryFactoryBeanTests {
 
 	Neo4jRepositoryFactoryBean factoryBean;
-
-	@Mock Session session;
 
 	@Mock ListableBeanFactory beanFactory;
 
@@ -44,6 +44,8 @@ public class Neo4jRepositoryFactoryBeanTests {
 	@Before
 	@SuppressWarnings("unchecked")
 	public void setUp() {
+
+		Session session = mock(Session.class, withSettings().extraInterfaces(MetaDataProvider.class));
 
 		// Setup standard factory configuration
 		factoryBean = new Neo4jRepositoryFactoryBean(ContactRepository.class);


### PR DESCRIPTION
The newly introduced MetaDataProvider is used to retrieve the OGM MetaData from the session factory as the „source of truth.“ Getting them from the session itself is hacky and can lead to the creation of a huge amount of unnessary transactions.

As SDN works only on the session object and keeps the session factory hidden, we faciliate the shared session creator to add this interface to the session and delegate back to the session factory. If the proxy isn’t used, we’ll try to lookup the meta data on the concrete Neo4jSession.

Two test that mock the session and don’t use the proxy had to be fixed to include the additional interface.