### PR TITLE
DATAGRAPH-1151 - Remove usage of undeclared dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1151-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1151-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -169,6 +169,12 @@
 
 		<dependency>
 			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-ogm-api</artifactId>
+			<version>${neo4j.ogm.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-ogm-bolt-driver</artifactId>
 			<version>${neo4j.ogm.version}</version>
 		</dependency>

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1151-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  [2011-2016] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
+ * Copyright (c)  [2011-2018] "Pivotal Software, Inc." / "Neo Technology" / "Graph Aware Ltd."
  *
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
@@ -13,7 +13,6 @@
 
 package org.springframework.data.neo4j.examples.movies.domain.queryresult;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.neo4j.ogm.annotation.Property;
 import org.springframework.data.neo4j.annotation.QueryResult;
 import org.springframework.data.neo4j.examples.movies.repo.UserRepository;
@@ -86,7 +85,11 @@ public class UserQueryResult {
 
 	@Override
 	public String toString() {
-		return ReflectionToStringBuilder.toString(this);
+		return "UserQueryResult{" +
+				"id=" + id +
+				", userId=" + userId +
+				", userName='" + userName + '\'' +
+				", age=" + age +
+				'}';
 	}
-
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
@@ -4,12 +4,12 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.neo4j.namedquery.domain.SampleEntityForNamedQuery;
 import org.springframework.data.neo4j.namedquery.repo.SampleEntityForNamedQueryRepository;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
@@ -67,7 +67,7 @@ public class NamedQueryTests extends MultiDriverTestClass {
 		repository.save(entity);
 	}
 
-	@org.springframework.context.annotation.Configuration
+	@Configuration
 	@ComponentScan({ "org.springframework.data.neo4j.namedquery" })
 	@EnableNeo4jRepositories(value = "org.springframework.data.neo4j.namedquery.repo")
 	@EnableTransactionManagement
@@ -80,11 +80,7 @@ public class NamedQueryTests extends MultiDriverTestClass {
 
 		@Bean
 		public SessionFactory sessionFactory() {
-			Configuration.Builder builder = getBaseConfiguration();
-
-			Configuration configuration = builder.build();
-
-			return new SessionFactory(configuration, "org.springframework.data.neo4j.namedquery.domain");
+			return new SessionFactory("org.springframework.data.neo4j.namedquery.domain");
 		}
 	}
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2017-2018 "Neo4j, Inc." / "Pivotal Software, Inc."
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.neo4j.namedquery;
 
 import static org.junit.Assert.*;
@@ -5,7 +20,6 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.neo4j.ogm.session.SessionFactory;
-import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -20,10 +34,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * @author Gerrit Meier
+ * @author Michael J. Simons
+ */
 @ContextConfiguration(classes = { NamedQueryTests.NamedQueryContext.class })
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-public class NamedQueryTests extends MultiDriverTestClass {
+public class NamedQueryTests {
 
 	private static final String SAMPLE_ENTITY_NAME = "test";
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
@@ -19,9 +19,12 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -176,10 +179,30 @@ public class MultipleSessionFactorySupportTests {
 
 			this.graphDatabaseService.shutdown();
 			try {
-				FileUtils.deleteDirectory(dataStoreDirectory);
+				deleteDirectory(dataStoreDirectory.toPath());
 			} catch (IOException e) {
 				LOGGER.warn("Failed to delete database store in {}" + dataStoreDirectory.getAbsolutePath());
 			}
+		}
+
+		private static void deleteDirectory(Path directory) throws IOException {
+			Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					Files.delete(file);
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+
+					if(exc != null) {
+						throw exc;
+					}
+					Files.delete(dir);
+					return FileVisitResult.CONTINUE;
+				}
+			});
 		}
 	}
 


### PR DESCRIPTION
This can be merged as is into 5.1.x and master.

I made the dependency to OGM-API explicit and removed some superfluous calls to commons lang and commons io. Other compile-dependencies look ok.

To merge it into 5.0.x one has to remove the `MultipleSessionFactorySupportTests` class.