### PR TITLE
docs(readme): replace links to spring source with spring.io

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,11 +26,11 @@ To learn more refer to:
 
 * the http://docs.spring.io/spring-data/neo4j/docs/5.0.x/reference/html/[Reference Manual];
 * the https://github.com/neo4j-examples/sdn-university[sample project: SDN University].  More example projects for Spring Data Neo4j are available in the https://github.com/neo4j-examples?query=sdn4[Neo4j-Examples] repository
-* The main http://projects.spring.io/spring-data-neo4j[SpringSource project site] contains links to basic project information such as source code, JavaDocs, Issue tracking, etc.
+* The main http://projects.spring.io/spring-data-neo4j[Spring project site] contains links to basic project information such as source code, JavaDocs, Issue tracking, etc.
 * the http://docs.spring.io/spring-data/neo4j/docs/5.0.x/api/[Javadocs];
 * for more detailed questions, use http://stackoverflow.com/questions/tagged/spring-data-neo4j-5[Spring Data Neo4j on StackOverflow]
 
-If you are new to Spring as well as to Spring Data, look for information about http://www.springsource.org/projects[Spring projects].
+If you are new to Spring as well as to Spring Data, look for information about https://spring.io/projects[Spring projects].
 
 == Quick start
 
@@ -65,7 +65,7 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
     </repository>
 ----
 
-TIP: You can check out how to get setup with Gradle in the the http://static.springsource.org/spring-data/data-neo4j/docs/current/reference/html/[Reference Manual].
+TIP: You can check out how to get setup with Gradle in the the https://docs.spring.io/spring-data/data-neo4j/docs/current/reference/html/[Reference Manual].
 
 
 Configure Spring Data Neo4j in your application using JavaConfig bean configuration


### PR DESCRIPTION
This is an obvious fix replacing links to SpringSource to spring.io.

Please replace the project's website with https://spring.io/projects/spring-data-neo4j