### PR TITLE
Allow concatenation of ignoreCase modifier keyword.

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/PropertyComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/PropertyComparisonBuilder.java
@@ -116,6 +116,11 @@ class PropertyComparisonBuilder extends FilterBuilder {
 	}
 
 	private boolean canIgnoreCase(Part part) {
-		return part.getType() == SIMPLE_PROPERTY && String.class.equals(part.getProperty().getLeafType());
+		return isSupportedIgnoreKeyword(part) && String.class.equals(part.getProperty().getLeafType());
+	}
+
+	private boolean isSupportedIgnoreKeyword(Part part) {
+		Part.Type type = part.getType();
+		return type == SIMPLE_PROPERTY || type == CONTAINING;
 	}
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
@@ -30,4 +30,6 @@ public interface PersonRepository<T extends Person, ID extends Serializable> ext
 	Collection<T> findByName(String name);
 
 	Collection<T> findByNameIgnoreCase(String name);
+
+	Collection<T> findByNameContainingIgnoreCase(String name);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedQueryTests.java
@@ -649,6 +649,18 @@ public class DerivedQueryTests {
 				.withMessageStartingWith("Unable to ignore case of int types, the property 'ratings' must reference a String");
 	}
 
+	@Test // DATAGRAPH-1190
+	public void shouldFindNodeByNameContainingAndIgnoreCase() {
+
+		String userName = "ABCD";
+		User user = new User(userName);
+		userRepository.save(user);
+
+		User foundUser = userRepository.findByNameContainingIgnoreCase("bc").iterator().next();
+		assertThat(foundUser).isNotNull();
+		assertThat(foundUser.getName()).isEqualTo(userName);
+	}
+
 	class DerivedQueryRunner implements Runnable {
 
 		private final CountDownLatch latch;


### PR DESCRIPTION
Add support for using `containing` with the `ignoreCase` keyword in derived finder methods. 

This PR can only get merged in master after upgrading to Neo4j-OGM 3.2.0-alpha04.