### PR TITLE
Handle @QueryResult properties case-sensitive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1189-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1189-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1189-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
@@ -90,7 +90,7 @@ public interface UserRepository extends PersonRepository<User, Long> {
 	@Query("MATCH (user:User) WHERE user.name={0} RETURN user as user, user.age AS ageOfUser")
 	UserQueryResultObject findWrappedUserAsProxiedObject(String name);
 
-	@Query("MATCH (user:User) WHERE user.gender={0} RETURN user.name AS UserName, user.gender AS UserGender, user.account as UserAccount, user.yearOfBirth as yearOfBirth, user.yearOfBirth as plainYearValue, user.deposits as UserDeposits")
+	@Query("MATCH (user:User) WHERE user.gender={0} RETURN user.name AS userName, user.gender AS userGender, user.account as userAccount, user.yearOfBirth as yearOfBirth, user.yearOfBirth as plainYearValue, user.deposits as userDeposits")
 	Iterable<RichUserQueryResult> findUsersByGender(Gender gender);
 
 	@Query("MATCH (user:User) WHERE user.name={0} RETURN user")

--- a/src/main/asciidoc/reference/neo4j-repositories.adoc
+++ b/src/main/asciidoc/reference/neo4j-repositories.adoc
@@ -372,8 +372,11 @@ public interface PersonRepository extends Neo4jRepository<Person, Long> {
 
 For queries executed via `@Query` repository methods, it's possible to specify a conversion of complex query results to POJOs.
 These result objects are then populated with the query result data.
-Those POJOs are easier to handle and might be use as Data Transfer Objects (DTOs) as they are not attached to a `Session` and don't participate in any lifecycle.
+Those POJOs are easier to handle and might be used as Data Transfer Objects (DTOs) as they are not attached to a `Session` and don't participate in any lifecycle.
 To take advantage of this feature, use a class annotated with `@QueryResult` as the method return type.
+
+The properties of your `@QueryResult` annotated class must have the same names as the returned values.
+Please keep in mind that Java and Cypher are case-sensitive.
 
 .Example of query result mapping
 [source,java,subs="-replacements"]
@@ -382,7 +385,7 @@ public interface MovieRepository extends Neo4jRepository<Movie, Long> {
 
     @Query("MATCH (movie:Movie)-[r:RATING]->(), (movie)<-[:ACTS_IN]-(actor:Actor) " +
            "WHERE movie.id={0} " +
-           "RETURN movie as movie, COLLECT(actor) AS 'cast', AVG(r.stars) AS 'averageRating'")
+           "RETURN movie as movie, COLLECT(actor) AS cast, AVG(r.stars) AS averageRating")
     MovieData getMovieData(String movieId);
 }
 

--- a/src/main/asciidoc/reference/neo4j-repositories.adoc
+++ b/src/main/asciidoc/reference/neo4j-repositories.adoc
@@ -376,7 +376,7 @@ Those POJOs are easier to handle and might be used as Data Transfer Objects (DTO
 To take advantage of this feature, use a class annotated with `@QueryResult` as the method return type.
 
 The properties of your `@QueryResult` annotated class must have the same names as the returned values.
-Please keep in mind that Java and Cypher are case-sensitive.
+Please keep in mind that Java attributes and the keys returned by Cypher statements are case-sensitive.
 
 .Example of query result mapping
 [source,java,subs="-replacements"]


### PR DESCRIPTION
The names of returned values and Java properties should be handled case-sensitive.

Target branches are master and 5.1.x.
This PR can only get merged in 
- master after upgrading to Neo4j-OGM 3.2.0-alpha03
- 5.1.x after upgrading to Neo4j-OGM 3.1.7