### PR TITLE
Support exists queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1197-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1197-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1197-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
@@ -28,15 +28,13 @@ import org.springframework.data.annotation.QueryAnnotation;
  *
  * @author Mark Angrish
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @QueryAnnotation
 @Documented
 public @interface Query {
-
-	static final String CLASS = "org.springframework.data.neo4j.annotation.Query";
-	static final String VALUE = "value";
 
 	/**
 	 * Defines the Cypher query to be executed when the annotated method is called.
@@ -47,4 +45,11 @@ public @interface Query {
 	 * @return simpler count-query to be executed for @{see Pageable}-support
 	 */
 	String countQuery() default "";
+
+	/**
+	 * Returns whether the defined query should be executed as an exists projection.
+	 *
+	 * @since 5.2
+	 */
+	boolean exists() default false;
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
@@ -75,6 +75,9 @@ public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 		if (isDeleteQuery()) {
 			return new GraphQueryExecution.DeleteByExecution(session, queryMethod, accessor);
 		}
+		if (isExistsQuery()) {
+			return new GraphQueryExecution.ExistsByExecution(session);
+		}
 		if (returnsOgmSpecificType()) {
 			return new GraphQueryExecution.QueryResultExecution(session, accessor);
 		}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
@@ -70,10 +70,10 @@ public abstract class AbstractGraphRepositoryQuery implements RepositoryQuery {
 			return new GraphQueryExecution.CollectionExecution(session, accessor);
 		}
 		if (isCountQuery()) {
-			return new GraphQueryExecution.CountByExecution(session, accessor);
+			return new GraphQueryExecution.CountByExecution(session);
 		}
 		if (isDeleteQuery()) {
-			return new GraphQueryExecution.DeleteByExecution(session, queryMethod, accessor);
+			return new GraphQueryExecution.DeleteByExecution(session, queryMethod);
 		}
 		if (isExistsQuery()) {
 			return new GraphQueryExecution.ExistsByExecution(session);

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
@@ -231,6 +231,20 @@ public interface GraphQueryExecution {
 		}
 	}
 
+	final class ExistsByExecution implements GraphQueryExecution {
+
+		private final Session session;
+
+		ExistsByExecution(Session session) {
+			this.session = session;
+		}
+
+		@Override
+		public Object execute(Query query, Class<?> type) {
+			return session.count(type, query.getFilters()) > 0;
+		}
+	}
+
 	final class DeleteByExecution implements GraphQueryExecution {
 
 		private final Session session;

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
@@ -191,38 +191,11 @@ public interface GraphQueryExecution {
 		}
 	}
 
-	final class StreamExecution implements GraphQueryExecution {
-
-		private final Session session;
-		private final GraphParameterAccessor accessor;
-
-		public StreamExecution(org.neo4j.ogm.session.Session session, GraphParameterAccessor accessor) {
-			this.session = session;
-			this.accessor = accessor;
-		}
-
-		@Override
-		@SuppressWarnings("unchecked")
-		public Object execute(Query query, Class<?> type) {
-
-			// not a real support for streaming. for that need that the stack all the way down
-			// supports streaming
-			List<?> result;
-			if (query.isFilterQuery()) {
-				result = (List<?>) session.loadAll(type, query.getFilters(), accessor.getOgmSort(), accessor.getDepth());
-			} else {
-				// TODO add support for QueryResults as above
-				result = (List<?>) session.query(type, query.getCypherQuery(accessor.getSort()), query.getParameters());
-			}
-			return result;
-		}
-	}
-
 	final class CountByExecution implements GraphQueryExecution {
 
 		private final Session session;
 
-		CountByExecution(Session session, GraphParameterAccessor accessor) {
+		CountByExecution(Session session) {
 			this.session = session;
 		}
 
@@ -255,7 +228,7 @@ public interface GraphQueryExecution {
 		private final Session session;
 		private final GraphQueryMethod graphQueryMethod;
 
-		DeleteByExecution(Session session, GraphQueryMethod graphQueryMethod, GraphParameterAccessor accessor) {
+		DeleteByExecution(Session session, GraphQueryMethod graphQueryMethod) {
 			this.session = session;
 			this.graphQueryMethod = graphQueryMethod;
 		}

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.LongSupplier;
 
+import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.session.Session;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.domain.Pageable;
@@ -241,7 +242,11 @@ public interface GraphQueryExecution {
 
 		@Override
 		public Object execute(Query query, Class<?> type) {
-			return session.count(type, query.getFilters()) > 0;
+			if (query.isFilterQuery()) {
+				return session.count(type, query.getFilters()) > 0;
+			}
+			Result result = session.query(query.getCypherQuery(), query.getParameters());
+			return result.iterator().hasNext();
 		}
 	}
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
@@ -43,6 +43,7 @@ public class GraphQueryMethod extends QueryMethod {
 	private final Method method;
 	private final Query queryAnnotation;
 	private final Integer queryDepthParamIndex;
+	private final boolean isExistsQuery;
 	private @Nullable MappingContext<Neo4jPersistentEntity<?>, Neo4jPersistentProperty> mappingContext;
 
 	public GraphQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory) {
@@ -50,6 +51,11 @@ public class GraphQueryMethod extends QueryMethod {
 
 		this.method = method;
 		this.queryAnnotation = method.getAnnotation(Query.class);
+		if (this.queryAnnotation != null) {
+			this.isExistsQuery = queryAnnotation.exists();
+		} else {
+			this.isExistsQuery = false;
+		}
 		this.queryDepthParamIndex = getQueryDepthParamIndex(method);
 		Integer queryDepth = getStaticQueryDepth(method);
 		if (queryDepth != null && queryDepthParamIndex != null) {
@@ -141,6 +147,10 @@ public class GraphQueryMethod extends QueryMethod {
 
 	public boolean hasAnnotatedQuery() {
 		return getAnnotatedQuery() != null;
+	}
+
+	boolean isAnnotatedExistsQuery() {
+		return isExistsQuery;
 	}
 
 	private String getAnnotatedQuery() {

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -46,6 +46,7 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 
 	private final QueryMethodEvaluationContextProvider evaluationContextProvider;
 	private final QueryResultInstantiator entityInstantiator;
+	private final boolean isExistsQuery;
 
 	private ParameterizedQuery parameterizedQuery;
 
@@ -57,6 +58,7 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 
 		this.evaluationContextProvider = evaluationContextProvider;
 		this.entityInstantiator = new QueryResultInstantiator(metaData, queryMethod.getMappingContext());
+		this.isExistsQuery = graphQueryMethod.isAnnotatedExistsQuery();
 	}
 
 	protected Object doExecute(Query query, Object[] parameters) {
@@ -138,7 +140,7 @@ public class GraphRepositoryQuery extends AbstractGraphRepositoryQuery {
 
 	@Override
 	protected boolean isExistsQuery() {
-		return false;
+		return isExistsQuery;
 	}
 
 	@Override

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -489,6 +489,14 @@ public class RestaurantTests {
 		assertEquals("Kuroda", results.get(0).getName());
 	}
 
+	@Test // DATAGRAPH-1197
+	public void shouldCheckExistenceForDerivedQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "good");
+		restaurantRepository.save(restaurant);
+
+		assertTrue(restaurantRepository.existsByDescription("good"));
+	}
+
 	@Configuration
 	@Neo4jIntegrationTest(domainPackages = "org.springframework.data.neo4j.examples.restaurants.domain",
 			repositoryPackages = "org.springframework.data.neo4j.examples.restaurants.repo")

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -498,11 +498,27 @@ public class RestaurantTests {
 	}
 
 	@Test // DATAGRAPH-1197
+	public void shouldCheckNonExistenceForDerivedQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "good");
+		restaurantRepository.save(restaurant);
+
+		assertFalse(restaurantRepository.existsByDescription("bad"));
+	}
+
+	@Test // DATAGRAPH-1197
 	public void shouldCheckExistenceForQueryMethod() {
 		Restaurant restaurant = new Restaurant("R1", "good");
 		restaurantRepository.save(restaurant);
 
 		assertTrue(restaurantRepository.existenceOfAGoodRestaurant());
+	}
+
+	@Test // DATAGRAPH-1197
+	public void shouldCheckNonExistenceForQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "bad");
+		restaurantRepository.save(restaurant);
+
+		assertFalse(restaurantRepository.existenceOfAGoodRestaurant());
 	}
 
 	@Configuration

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -497,6 +497,14 @@ public class RestaurantTests {
 		assertTrue(restaurantRepository.existsByDescription("good"));
 	}
 
+	@Test // DATAGRAPH-1197
+	public void shouldCheckExistenceForQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "good");
+		restaurantRepository.save(restaurant);
+
+		assertTrue(restaurantRepository.existenceOfAGoodRestaurant());
+	}
+
 	@Configuration
 	@Neo4jIntegrationTest(domainPackages = "org.springframework.data.neo4j.examples.restaurants.domain",
 			repositoryPackages = "org.springframework.data.neo4j.examples.restaurants.repo")

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -80,4 +80,5 @@ public interface RestaurantRepository extends Neo4jRepository<Restaurant, Long> 
 
 	List<Restaurant> findByNameNotContainingOrDescriptionIsNull(String nameContaining);
 
+	boolean existsByDescription(String description);
 }

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
+import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.examples.restaurants.domain.Restaurant;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
@@ -81,4 +82,7 @@ public interface RestaurantRepository extends Neo4jRepository<Restaurant, Long> 
 	List<Restaurant> findByNameNotContainingOrDescriptionIsNull(String nameContaining);
 
 	boolean existsByDescription(String description);
+
+	@Query(value = "MATCH (r:Restaurant) WHERE r.description = 'good' return r", exists = true)
+	boolean existenceOfAGoodRestaurant();
 }


### PR DESCRIPTION
An exists(By) keyword support for derived query methods, that does evaluate the non-zero positive result of a filter query.
For custom query checks provide an `exists` flag in the `@Query` annotation to mark it as eligible for boolean returns. If the statement produces any results, the returned value will be true.

Some thoughts for further improvement/alignment with previous behaviour:
We could think of also introducing a wrapping annotation like Spring Data Cassandra does: https://github.com/spring-projects/spring-data-cassandra/blob/e6b5c5e7a2af5c020526e6d998d5950b74163937/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/ExistsQuery.java#L37

Additionally this PR breaks with the previous convention in the count query of providing a String value but only flags the `value` of the `@Query` annotation with `exists = true/false`.