### PR TITLE
Provide @ExistsQuery for convenience

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1199-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1199-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1199-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
@@ -21,35 +21,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation to declare finder queries directly on repository methods.
+ * Annotation to declare a {@link Query} with a value contains an exists custom query. The result will then be used for
+ * boolean projection.
  *
- * @author Mark Angrish
- * @author Luanne Misquitta
  * @author Gerrit Meier
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
-@QueryAnnotation
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
-public @interface Query {
+@Query(exists = true)
+public @interface ExistsQuery {
 
 	/**
-	 * Defines the Cypher query to be executed when the annotated method is called.
-	 */
-	String value() default "";
-
-	/**
-	 * @return simpler count-query to be executed for @{see Pageable}-support
-	 */
-	String countQuery() default "";
-
-	/**
-	 * Returns whether the defined query should be executed as an exists projection.
-	 *
+	 * The cypher query.
+	 * 
+	 * @see Query#value()
 	 * @since 5.2
 	 */
-	boolean exists() default false;
+	@AliasFor(annotation = Query.class)
+	String value() default "";
 }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation to declare a {@link Query} with a value contains an exists custom query. The result will then be used for
+ * Annotation to declare a {@link Query} with a value containing an exists custom query. The result will then be used for
  * boolean projection.
  *
  * @author Gerrit Meier

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
@@ -50,7 +50,7 @@ public class GraphQueryMethod extends QueryMethod {
 		super(method, metadata, factory);
 
 		this.method = method;
-		this.queryAnnotation = method.getAnnotation(Query.class);
+		this.queryAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, Query.class);
 		if (this.queryAnnotation != null) {
 			this.isExistsQuery = queryAnnotation.exists();
 		} else {

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -521,6 +521,22 @@ public class RestaurantTests {
 		assertFalse(restaurantRepository.existenceOfAGoodRestaurant());
 	}
 
+	@Test // DATAGRAPH-1199
+	public void shouldCheckExistenceForExistsQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "good");
+		restaurantRepository.save(restaurant);
+
+		assertTrue(restaurantRepository.existenceOfAGoodRestaurantWithExistsQuery());
+	}
+
+	@Test // DATAGRAPH-1199
+	public void shouldCheckNonExistenceForExistsQueryMethod() {
+		Restaurant restaurant = new Restaurant("R1", "bad");
+		restaurantRepository.save(restaurant);
+
+		assertFalse(restaurantRepository.existenceOfAGoodRestaurantWithExistsQuery());
+	}
+
 	@Configuration
 	@Neo4jIntegrationTest(domainPackages = "org.springframework.data.neo4j.examples.restaurants.domain",
 			repositoryPackages = "org.springframework.data.neo4j.examples.restaurants.repo")

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
+import org.springframework.data.neo4j.annotation.ExistsQuery;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.examples.restaurants.domain.Restaurant;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -85,4 +86,7 @@ public interface RestaurantRepository extends Neo4jRepository<Restaurant, Long> 
 
 	@Query(value = "MATCH (r:Restaurant) WHERE r.description = 'good' return r", exists = true)
 	boolean existenceOfAGoodRestaurant();
+
+	@ExistsQuery("MATCH (r:Restaurant) WHERE r.description = 'good' return r")
+	boolean existenceOfAGoodRestaurantWithExistsQuery();
 }


### PR DESCRIPTION
Add an `@ExistsQuery` annotation that wraps a `@Query(exists =true)` to have a more convenient way to define custom queries that should get used for boolean projection.