### PR TITLE
Add support for Range type in derived queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-parent</artifactId>
-	<version>5.2.0.BUILD-SNAPSHOT</version>
+	<version>5.2.0.DATAGRAPH-1202-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Neo4j</name>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1202-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-neo4j-parent</artifactId>
-		<version>5.2.0.BUILD-SNAPSHOT</version>
+		<version>5.2.0.DATAGRAPH-1202-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BetweenComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BetweenComparisonBuilder.java
@@ -75,23 +75,19 @@ class BetweenComparisonBuilder extends FilterBuilder {
 	}
 
 	private Filter createLowerBoundFilter(Object value, boolean inclusive) {
-		Filter filter = createBoundFilter(Bound.LOWER, value, inclusive);
-		filter.setBooleanOperator(booleanOperator);
-		return filter;
+		return createBoundFilter(Bound.LOWER, value, inclusive, booleanOperator);
 	}
 
 	private Filter createUpperBoundFilter(Object value, boolean inclusive) {
-		Filter filter = createBoundFilter(Bound.UPPER, value, inclusive);
-		filter.setBooleanOperator(BooleanOperator.AND);
-		return filter;
+		return createBoundFilter(Bound.UPPER, value, inclusive, BooleanOperator.AND);
 	}
 
-	private Filter createBoundFilter(Bound bound, Object value, boolean inclusive) {
+	private Filter createBoundFilter(Bound bound, Object value, boolean inclusive, BooleanOperator operator) {
 		Filter filter = new Filter(propertyName(), deriveComparisonOperator(bound, inclusive), value);
 		filter.setOwnerEntityType(entityType);
 		filter.setNegated(isNegated());
 		filter.setFunction(new PropertyComparison(value));
-
+		filter.setBooleanOperator(operator);
 		return filter;
 	}
 

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
@@ -135,6 +136,86 @@ public class RestaurantTests {
 		List<Restaurant> results = restaurantRepository.findByScoreBetween(20.0, 80.6);
 		assertNotNull(results);
 		assertEquals(3, results.size());
+	}
+
+	@Test // DATAGRAPH-1202
+	public void shouldFindRestaurantsWithScoreBetweenRangeInclusiveBothBounds() {
+		Restaurant kuroda = new Restaurant("Kuroda", 72.4);
+		restaurantRepository.save(kuroda);
+
+		Restaurant cyma = new Restaurant("Cyma", 80.6);
+		restaurantRepository.save(cyma);
+
+		Restaurant awful = new Restaurant("Awful", 20.0);
+		restaurantRepository.save(awful);
+
+		Range.Bound<Double> lowerBoundInclusive = Range.Bound.inclusive(20.0);
+		Range.Bound<Double> upperBoundInclusive = Range.Bound.inclusive(80.6);
+		Range<Double> inclusiveBound = Range.of(lowerBoundInclusive, upperBoundInclusive);
+
+		List<Restaurant> results = restaurantRepository.findByScoreBetween(inclusiveBound);
+		assertNotNull(results);
+		assertEquals(3, results.size());
+	}
+
+	@Test // DATAGRAPH-1202
+	public void shouldFindRestaurantsWithScoreBetweenRangeExclusiveBothBounds() {
+		Restaurant kuroda = new Restaurant("Kuroda", 72.4);
+		restaurantRepository.save(kuroda);
+
+		Restaurant cyma = new Restaurant("Cyma", 80.6);
+		restaurantRepository.save(cyma);
+
+		Restaurant awful = new Restaurant("Awful", 20.0);
+		restaurantRepository.save(awful);
+
+		Range.Bound<Double> lowerBoundInclusive = Range.Bound.exclusive(20.0);
+		Range.Bound<Double> upperBoundInclusive = Range.Bound.exclusive(80.6);
+		Range<Double> inclusiveBound = Range.of(lowerBoundInclusive, upperBoundInclusive);
+
+		List<Restaurant> results = restaurantRepository.findByScoreBetween(inclusiveBound);
+		assertNotNull(results);
+		assertEquals(1, results.size());
+	}
+
+	@Test // DATAGRAPH-1202
+	public void shouldFindRestaurantsWithScoreBetweenRangeInclusiveLowerBounds() {
+		Restaurant kuroda = new Restaurant("Kuroda", 72.4);
+		restaurantRepository.save(kuroda);
+
+		Restaurant cyma = new Restaurant("Cyma", 80.6);
+		restaurantRepository.save(cyma);
+
+		Restaurant awful = new Restaurant("Awful", 20.0);
+		restaurantRepository.save(awful);
+
+		Range.Bound<Double> lowerBoundInclusive = Range.Bound.inclusive(20.0);
+		Range.Bound<Double> upperBoundInclusive = Range.Bound.exclusive(80.6);
+		Range<Double> inclusiveBound = Range.of(lowerBoundInclusive, upperBoundInclusive);
+
+		List<Restaurant> results = restaurantRepository.findByScoreBetween(inclusiveBound);
+		assertNotNull(results);
+		assertEquals(2, results.size());
+	}
+
+	@Test // DATAGRAPH-1202
+	public void shouldFindRestaurantsWithScoreBetweenRangeInclusiveUpperBounds() {
+		Restaurant kuroda = new Restaurant("Kuroda", 72.4);
+		restaurantRepository.save(kuroda);
+
+		Restaurant cyma = new Restaurant("Cyma", 80.6);
+		restaurantRepository.save(cyma);
+
+		Restaurant awful = new Restaurant("Awful", 20.0);
+		restaurantRepository.save(awful);
+
+		Range.Bound<Double> lowerBoundInclusive = Range.Bound.exclusive(20.0);
+		Range.Bound<Double> upperBoundInclusive = Range.Bound.inclusive(80.6);
+		Range<Double> inclusiveBound = Range.of(lowerBoundInclusive, upperBoundInclusive);
+
+		List<Restaurant> results = restaurantRepository.findByScoreBetween(inclusiveBound);
+		assertNotNull(results);
+		assertEquals(2, results.size());
 	}
 
 	@Test // DATAGRAPH-904

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.examples.restaurants.repo;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
 import org.springframework.data.neo4j.annotation.ExistsQuery;
@@ -35,6 +36,8 @@ public interface RestaurantRepository extends Neo4jRepository<Restaurant, Long> 
 	List<Restaurant> findByLocationNearAndName(Distance distance, Point point, String name);
 
 	List<Restaurant> findByScoreBetween(double min, double max);
+
+	List<Restaurant> findByScoreBetween(Range range);
 
 	List<Restaurant> findByScoreLessThan(double max);
 

--- a/src/main/asciidoc/reference/neo4j-repositories.adoc
+++ b/src/main/asciidoc/reference/neo4j-repositories.adoc
@@ -143,8 +143,11 @@ Just equip your method signature with a `Pageable` parameter and let the method 
 |`n.name IN names`
 
 |`Between`
-|`findByScoreBetween(double min, double max)`
-|`n.score >= min AND n.score \<= max`
+|`findByScoreBetween(double min, double max)` +
+`findByScoreBetween(Range<Double> range)`
+|`n.score >= min AND n.score \<= max` +
+Depending on the `Range` definition `n.score >= min AND n.score \<= max` or
+`n.score > min AND n.score < max`
 
 |`StartingWith`
 |`findByNameStartingWith(String nameStart)`


### PR DESCRIPTION
Additional to the two parameter (lower and upper bound) that uses a fixed inclusive pattern it is now possible to provide a `Range` to express inclusive or exclusive bounds explicitly.