### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -10,7 +10,7 @@
 
 	<name>Spring Data Neo4j - Parent</name>
 	<description>Neo4j support for Spring Data</description>
-	<url>http://www.springsource.org/spring-data/neo4j</url>
+	<url>https://www.springsource.org/spring-data/neo4j</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -83,7 +83,7 @@
 			<name>Michael Hunger</name>
 			<email>michael.hunger at neotechnology.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Project Lead</role>
 			</roles>
@@ -94,7 +94,7 @@
 			<name>Oliver Gierke</name>
 			<email>ogierke at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -105,7 +105,7 @@
 			<name>Thomas Risberg</name>
 			<email>trisberg at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -116,7 +116,7 @@
 			<name>Mark Pollack</name>
 			<email>mpollack at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -190,7 +190,7 @@
 		</repository>
 		<repository>
 			<id>neo4j</id>
-			<url>http://m2.neo4j.org/content/repositories/releases</url>
+			<url>https://m2.neo4j.org/content/repositories/releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -201,14 +201,14 @@
 		</repository>
 		<repository>
 			<id>geotools</id>
-			<url>http://download.osgeo.org/webdav/geotools</url>
+			<url>https://download.osgeo.org/webdav/geotools</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
 		<repository>
 			<id>ow2</id>
-			<url>http://repository.ow2.org/nexus/content/repositories/ow2-legacy</url>
+			<url>https://repository.ow2.org/nexus/content/repositories/ow2-legacy</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -217,7 +217,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-plugins-release</id>
-			<url>http://repo.spring.io/plugins-release</url>
+			<url>https://repo.spring.io/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/spring-data-neo4j-aspects/pom.xml
+++ b/spring-data-neo4j-aspects/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-neo4j-cross-store/pom.xml
+++ b/spring-data-neo4j-cross-store/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-neo4j-examples/backwardscompatibility/pom.xml
+++ b/spring-data-neo4j-examples/backwardscompatibility/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>org.neo4j.examples</groupId>
   <artifactId>backwardscompatibility</artifactId>
   <version>2.1.0.BUILD-SNAPSHOT</version>
@@ -66,7 +66,7 @@
     <repository>
       <id>neo4j-snapshot-repository</id>
       <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/snapshots</url>
+      <url>https://m2.neo4j.org/snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/spring-data-neo4j-examples/cineasts/pom.xml
+++ b/spring-data-neo4j-examples/cineasts/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.neo4j.examples</groupId>
@@ -22,11 +22,11 @@
 	    <repository>
 	      <id>neo4j-release-repository</id>
 	      <name>Neo4j Maven 2 release repository</name>
-	      <url>http://m2.neo4j.org/releases</url>
+	      <url>https://m2.neo4j.org/releases</url>
 	    </repository>
 		<repository>
 			<id>jboss-public-repo</id>
-			<url>http://repository.jboss.org/maven2/</url>
+			<url>https://repository.jboss.org/maven2/</url>
 			<name>JBoss public available repo</name>
 		</repository>
 	</repositories>

--- a/spring-data-neo4j-examples/hello-worlds-aspects/build.gradle
+++ b/spring-data-neo4j-examples/hello-worlds-aspects/build.gradle
@@ -15,7 +15,7 @@ configurations {
 repositories {
     mavenCentral()
     mavenLocal()
-    mavenRepo urls: "http://maven.springframework.org/release"
+    mavenRepo urls: "https://maven.springframework.org/release"
 }
 
 

--- a/spring-data-neo4j-examples/hello-worlds-aspects/pom.xml
+++ b/spring-data-neo4j-examples/hello-worlds-aspects/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework.data.examples</groupId>
@@ -26,7 +26,7 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-snapshot</id>
@@ -34,17 +34,17 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>neo4j-release-repository</id>
             <name>Neo4j Maven 2 release repository</name>
-            <url>http://m2.neo4j.org/releases</url>
+            <url>https://m2.neo4j.org/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -55,7 +55,7 @@
         <repository>
             <id>neo4j-snapshot-repository</id>
             <name>Neo4j Maven 2 snapshot repository</name>
-            <url>http://m2.neo4j.org/snapshots</url>
+            <url>https://m2.neo4j.org/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -69,12 +69,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/spring-data-neo4j-examples/hello-worlds/build.gradle
+++ b/spring-data-neo4j-examples/hello-worlds/build.gradle
@@ -15,7 +15,7 @@ configurations {
 repositories {
     mavenCentral()
 	mavenLocal()
-	mavenRepo urls: "http://maven.springframework.org/release"
+	mavenRepo urls: "https://maven.springframework.org/release"
 }
 
 

--- a/spring-data-neo4j-examples/hello-worlds/pom.xml
+++ b/spring-data-neo4j-examples/hello-worlds/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data.examples</groupId>
@@ -22,7 +22,7 @@
 		<repository>
 			<id>neo4j-release-repository</id>
 			<name>Neo4j Maven 2 release repository</name>
-			<url>http://m2.neo4j.org/releases</url>
+			<url>https://m2.neo4j.org/releases</url>
 		</repository>
 	</repositories>
 

--- a/spring-data-neo4j-examples/myrestaurants-original/pom.xml
+++ b/spring-data-neo4j-examples/myrestaurants-original/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.springone.myrestaurants</groupId>
 	<artifactId>myrestaurants-original</artifactId>
@@ -17,12 +17,12 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
 		<repository>
             <id>JBoss Repo</id>
@@ -34,12 +34,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
 	</pluginRepositories>
 	<dependencies>

--- a/spring-data-neo4j-examples/myrestaurants-social/pom.xml
+++ b/spring-data-neo4j-examples/myrestaurants-social/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.springone.myrestaurants</groupId>
 	<artifactId>myrestaurants-social</artifactId>
@@ -19,12 +19,12 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
 		<repository>
 			<id>spring-maven-snapshot</id>
@@ -32,7 +32,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 			<name>Springframework Maven SNAPSHOT Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
         </repository>
 		<repository>
             <id>JBoss Repo</id>
@@ -42,7 +42,7 @@
 	    <repository>
 	      <id>neo4j-release-repository</id>
 	      <name>Neo4j Maven 2 release repository</name>
-	      <url>http://m2.neo4j.org/releases</url>
+	      <url>https://m2.neo4j.org/releases</url>
 	      <releases>
 	        <enabled>true</enabled>
 	      </releases>
@@ -53,7 +53,7 @@
 	    <repository>
 	      <id>neo4j-snapshot-repository</id>
 	      <name>Neo4j Maven 2 snapshot repository</name>
-	      <url>http://m2.neo4j.org/snapshots</url>
+	      <url>https://m2.neo4j.org/snapshots</url>
 	      <snapshots>
 	        <enabled>true</enabled>
 	      </snapshots>
@@ -66,12 +66,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
 	</pluginRepositories>
 	<dependencies>

--- a/spring-data-neo4j-examples/todos/pom.xml
+++ b/spring-data-neo4j-examples/todos/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.neo4j.app</groupId>
@@ -22,16 +22,16 @@
 		<repository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</repository>
 		<repository>
 			<id>neo4j-public-repository</id>
-			<url>http://m2.neo4j.org/releases</url>
+			<url>https://m2.neo4j.org/releases</url>
 			<name>Publicly available Maven 2 repository for Neo4j</name>
 		</repository>
 		<repository>
 			<id>spring-maven-milestone</id>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<name>Spring Framework Maven MILESTONE Repository</name>
 			<snapshots>
 				<enabled>true</enabled>
@@ -39,7 +39,7 @@
 		</repository>
 		<repository>
 			<id>spring-maven-snapshot</id>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<name>Springframework Maven SNAPSHOT Repository</name>
 			<snapshots>
 				<enabled>true</enabled>
@@ -50,12 +50,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>spring-maven-milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</pluginRepository>
 	</pluginRepositories>
 	<dependencies>

--- a/spring-data-neo4j-rest/pom.xml
+++ b/spring-data-neo4j-rest/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	

--- a/spring-data-neo4j-tx/pom.xml
+++ b/spring-data-neo4j-tx/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	

--- a/src/deploy-docs.sh
+++ b/src/deploy-docs.sh
@@ -16,7 +16,7 @@ cd ../../../
 cat<<EOF >target/docpom.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j-docs</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://m2.neo4j.org/releases (404) with 5 occurrences migrated to:  
  https://m2.neo4j.org/releases ([https](https://m2.neo4j.org/releases) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 11 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repository.jboss.org/maven2/ with 1 occurrences migrated to:  
  https://repository.jboss.org/maven2/ ([https](https://repository.jboss.org/maven2/) result 200).
* http://download.osgeo.org/webdav/geotools with 1 occurrences migrated to:  
  https://download.osgeo.org/webdav/geotools ([https](https://download.osgeo.org/webdav/geotools) result 301).
* http://m2.neo4j.org/content/repositories/releases with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://m2.neo4j.org/snapshots with 3 occurrences migrated to:  
  https://m2.neo4j.org/snapshots ([https](https://m2.neo4j.org/snapshots) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.neotechnology.com with 1 occurrences migrated to:  
  https://www.neotechnology.com ([https](https://www.neotechnology.com) result 301).
* http://www.spring.io with 3 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://www.springsource.org/spring-data/neo4j with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/neo4j ([https](https://www.springsource.org/spring-data/neo4j) result 301).
* http://maven.springframework.org/milestone with 8 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release with 10 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot with 3 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repository.ow2.org/nexus/content/repositories/ow2-legacy with 1 occurrences migrated to:  
  https://repository.ow2.org/nexus/content/repositories/ow2-legacy ([https](https://repository.ow2.org/nexus/content/repositories/ow2-legacy) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 30 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 15 occurrences