### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework.data</groupId>
@@ -36,7 +36,7 @@
             <name>Vince Bickers</name>
             <email>vince at graphaware.com</email>
             <organization>GraphAware</organization>
-            <organizationUrl>http://www.graphaware.com</organizationUrl>
+            <organizationUrl>https://www.graphaware.com</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -47,7 +47,7 @@
             <name>Adam George</name>
             <email>adam at graphaware.com</email>
             <organization>GraphAware</organization>
-            <organizationUrl>http://www.graphaware.com</organizationUrl>
+            <organizationUrl>https://www.graphaware.com</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -58,7 +58,7 @@
             <name>Michal Bachman</name>
             <email>michal at graphaware.com</email>
             <organization>GraphAware</organization>
-            <organizationUrl>http://www.graphaware.com</organizationUrl>
+            <organizationUrl>https://www.graphaware.com</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -69,7 +69,7 @@
             <name>Luanne Misquitta</name>
             <email>luanne at graphaware.com</email>
             <organization>GraphAware</organization>
-            <organizationUrl>http://www.graphaware.com</organizationUrl>
+            <organizationUrl>https://www.graphaware.com</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -88,7 +88,7 @@
             <name>Michael Hunger</name>
             <email>michael.hunger at neotechnology.com</email>
             <organization>Neo Technology</organization>
-            <organizationUrl>http://www.neotechnology.com</organizationUrl>
+            <organizationUrl>https://www.neotechnology.com</organizationUrl>
             <roles>
                 <role>Project Lead</role>
             </roles>
@@ -99,7 +99,7 @@
             <name>Oliver Gierke</name>
             <email>ogierke at gopivotal.com</email>
             <organization>Pivotal</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -110,7 +110,7 @@
             <name>Thomas Risberg</name>
             <email>trisberg at gopivotal.com</email>
             <organization>Pivotal</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -121,7 +121,7 @@
             <name>Mark Pollack</name>
             <email>mpollack at gopivotal.com</email>
             <organization>Pivotal</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>
@@ -156,12 +156,12 @@
         <repository>
             <id>spring-libs-release</id>
             <name>Spring</name>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
         </repository>
 
         <repository>
             <id>neo4j</id>
-            <url>http://m2.neo4j.org/content/repositories/releases</url>
+            <url>https://m2.neo4j.org/content/repositories/releases</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -169,7 +169,7 @@
 
         <repository>
             <id>neo4j-snapshots</id>
-            <url>http://m2.neo4j.org/content/repositories/snapshots</url>
+            <url>https://m2.neo4j.org/content/repositories/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -180,7 +180,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>spring-plugins-release</id>
-            <url>http://repo.spring.io/plugins-release</url>
+            <url>https://repo.spring.io/plugins-release</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://m2.neo4j.org/content/repositories/releases with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://m2.neo4j.org/content/repositories/snapshots with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/snapshots ([https](https://m2.neo4j.org/content/repositories/snapshots) result 301).
* http://www.graphaware.com with 4 occurrences migrated to:  
  https://www.graphaware.com ([https](https://www.graphaware.com) result 301).
* http://www.neotechnology.com with 1 occurrences migrated to:  
  https://www.neotechnology.com ([https](https://www.neotechnology.com) result 301).
* http://www.spring.io with 3 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://repo.spring.io/libs-release with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences