### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
  | you may not use this file except in compliance with the License.
  | You may obtain a copy of the License at
  |
- |      http://www.apache.org/licenses/LICENSE-2.0
+ |      https://www.apache.org/licenses/LICENSE-2.0
  |
  | Unless required by applicable law or agreed to in writing, software
  | distributed under the License is distributed on an "AS IS" BASIS,
  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  | See the License for the specific language governing permissions and
  | limitations under the License.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -24,7 +24,7 @@
 
 	<name>Spring Data Neo4j</name>
 	<description>Neo4j support for Spring Data</description>
-	<url>http://projects.spring.io/spring-data-neo4j</url>
+	<url>https://projects.spring.io/spring-data-neo4j</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -54,7 +54,7 @@
 			<name>Vince Bickers</name>
 			<email>vince at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -65,7 +65,7 @@
 			<name>Adam George</name>
 			<email>adam at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -76,7 +76,7 @@
 			<name>Michal Bachman</name>
 			<email>michal at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -87,7 +87,7 @@
 			<name>Luanne Misquitta</name>
 			<email>luanne at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -98,7 +98,7 @@
 			<name>Mark Angrish</name>
 			<email>mark at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -109,7 +109,7 @@
 			<name>Jasper Blues</name>
 			<email>jasper at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -120,7 +120,7 @@
 			<name>Michael Hunger</name>
 			<email>michael.hunger at neotechnology.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Project Lead</role>
 			</roles>
@@ -131,7 +131,7 @@
 			<name>Oliver Gierke</name>
 			<email>ogierke at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -142,7 +142,7 @@
 			<name>Thomas Risberg</name>
 			<email>trisberg at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -153,7 +153,7 @@
 			<name>Mark Pollack</name>
 			<email>mpollack at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -164,7 +164,7 @@
 			<name>Gerrit Meier</name>
 			<email>gerrit.meier at neo4j.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -175,7 +175,7 @@
 			<name>Michael Simons</name>
 			<email>michael.simons at neo4j.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -201,7 +201,7 @@
 	<repositories>
 		<repository>
 			<id>neo4j</id>
-			<url>http://m2.neo4j.org/content/repositories/releases</url>
+			<url>https://m2.neo4j.org/content/repositories/releases</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>
@@ -209,7 +209,7 @@
 		</repository>
 		<repository>
 			<id>neo4j-snapshots</id>
-			<url>http://m2.neo4j.org/content/repositories/snapshots</url>
+			<url>https://m2.neo4j.org/content/repositories/snapshots</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -6,7 +6,7 @@
  | you may not use this file except in compliance with the License.
  | You may obtain a copy of the License at
  |
- |      http://www.apache.org/licenses/LICENSE-2.0
+ |      https://www.apache.org/licenses/LICENSE-2.0
  |
  | Unless required by applicable law or agreed to in writing, software
  | distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  | limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://m2.neo4j.org/content/repositories/releases with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://m2.neo4j.org/content/repositories/snapshots with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/snapshots ([https](https://m2.neo4j.org/content/repositories/snapshots) result 301).
* http://projects.spring.io/spring-data-neo4j with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-neo4j ([https](https://projects.spring.io/spring-data-neo4j) result 301).
* http://www.graphaware.com with 6 occurrences migrated to:  
  https://www.graphaware.com ([https](https://www.graphaware.com) result 301).
* http://www.neotechnology.com with 3 occurrences migrated to:  
  https://www.neotechnology.com ([https](https://www.neotechnology.com) result 301).
* http://www.spring.io with 3 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences