### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   ~ code for these subcomponents is subject to the terms and
   ~ conditions of the subcomponent's license, as noted in the LICENSE file.
   ~
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
 
 	<name>Spring Data Neo4j</name>
 	<description>Neo4j support for Spring Data</description>
-	<url>http://projects.spring.io/spring-data-neo4j</url>
+	<url>https://projects.spring.io/spring-data-neo4j</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -48,7 +48,7 @@
 			<name>Vince Bickers</name>
 			<email>vince at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -59,7 +59,7 @@
 			<name>Adam George</name>
 			<email>adam at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -70,7 +70,7 @@
 			<name>Michal Bachman</name>
 			<email>michal at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -81,7 +81,7 @@
 			<name>Luanne Misquitta</name>
 			<email>luanne at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -92,7 +92,7 @@
 			<name>Mark Angrish</name>
 			<email>mark at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -103,7 +103,7 @@
 			<name>Jasper Blues</name>
 			<email>jasper at graphaware.com</email>
 			<organization>GraphAware</organization>
-			<organizationUrl>http://www.graphaware.com</organizationUrl>
+			<organizationUrl>https://www.graphaware.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -114,7 +114,7 @@
 			<name>Michael Hunger</name>
 			<email>michael.hunger at neotechnology.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Project Lead</role>
 			</roles>
@@ -125,7 +125,7 @@
 			<name>Oliver Gierke</name>
 			<email>ogierke at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -136,7 +136,7 @@
 			<name>Thomas Risberg</name>
 			<email>trisberg at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -147,7 +147,7 @@
 			<name>Mark Pollack</name>
 			<email>mpollack at gopivotal.com</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -158,7 +158,7 @@
 			<name>Gerrit Meier</name>
 			<email>gerrit.meier at neo4j.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -169,7 +169,7 @@
 			<name>Michael Simons</name>
 			<email>michael.simons at neo4j.com</email>
 			<organization>Neo Technology</organization>
-			<organizationUrl>http://www.neotechnology.com</organizationUrl>
+			<organizationUrl>https://www.neotechnology.com</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -195,7 +195,7 @@
 	<repositories>
 		<repository>
 			<id>neo4j</id>
-			<url>http://m2.neo4j.org/content/repositories/releases</url>
+			<url>https://m2.neo4j.org/content/repositories/releases</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>
@@ -203,7 +203,7 @@
 		</repository>
 		<repository>
 			<id>neo4j-snapshots</id>
-			<url>http://m2.neo4j.org/content/repositories/snapshots</url>
+			<url>https://m2.neo4j.org/content/repositories/snapshots</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>

--- a/spring-data-neo4j-distribution/pom.xml
+++ b/spring-data-neo4j-distribution/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -13,7 +13,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://m2.neo4j.org/content/repositories/releases with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://m2.neo4j.org/content/repositories/snapshots with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/snapshots ([https](https://m2.neo4j.org/content/repositories/snapshots) result 301).
* http://projects.spring.io/spring-data-neo4j with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-neo4j ([https](https://projects.spring.io/spring-data-neo4j) result 301).
* http://www.graphaware.com with 6 occurrences migrated to:  
  https://www.graphaware.com ([https](https://www.graphaware.com) result 301).
* http://www.neotechnology.com with 3 occurrences migrated to:  
  https://www.neotechnology.com ([https](https://www.neotechnology.com) result 301).
* http://www.spring.io with 3 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences