### PR TITLE
URL Cleanup

### DIFF
--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/config/Neo4jAspectConfiguration.java
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/config/Neo4jAspectConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/GraphBacked.java
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/GraphBacked.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/NodeBacked.java
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/NodeBacked.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/RelationshipBacked.java
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/core/RelationshipBacked.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/node/Neo4jNodeBacking.aj
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/node/Neo4jNodeBacking.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/relationship/Neo4jRelationshipBacking.aj
+++ b/spring-data-neo4j-aspects/src/main/java/org/springframework/data/neo4j/aspects/support/relationship/Neo4jRelationshipBacking.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Attribute.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Attribute.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Car.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Car.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Developer.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Developer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Friendship.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Friendship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/FriendshipRepository.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/FriendshipRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Group.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/GroupRepository.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/GroupRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Mentorship.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Mentorship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Named.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Named.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/NonNullNamed.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/NonNullNamed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Person.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/PersonCreator.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/PersonCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/PersonRepository.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/PersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Personality.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Personality.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/SubGroup.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/SubGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Toyota.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Toyota.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Volvo.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/Volvo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/AttachEntityTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/AttachEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/DynamicPropertiesTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/DynamicPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityPropertyValidationTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityPropertyValidationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityTestBase.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityWithoutAspectSetupTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/EntityWithoutAspectSetupTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/FailingIndexTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/FailingIndexTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/FinderTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/FinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/GraphRepositoryTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/GraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/HasRelationshipMatcher.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/HasRelationshipMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/IndexTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/IndexTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ModificationOutsideOfTransactionTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ModificationOutsideOfTransactionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityInstantiationTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityInstantiationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityQueryTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityQueryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityRelationshipTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityRelationshipTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/NodeEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ProjectionTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ProjectionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/PropertyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/PropertyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/RelationshipEntityTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/RelationshipEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingEntityTestBase.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingEntityTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingTRSLabelBasedTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingTRSLabelBasedTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingTRSNonLabelBasedTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/SchemaIndexingTRSNonLabelBasedTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/TestTeam.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/TestTeam.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ThingHierarchy.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/ThingHierarchy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/TraversalTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/TraversalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account1.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account2.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/domain/Account2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/EntityMapperTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/EntityMapperTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/EntityPathTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/EntityPathTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/PathMappingIteratorTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/path/PathMappingIteratorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/query/QueryEngineTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/query/QueryEngineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/AbstractNodeTypeRepresentationStrategyTestBase.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/AbstractNodeTypeRepresentationStrategyTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexBasedNodeTypeRepresentationStrategyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexBasedNodeTypeRepresentationStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexBasedRelationshipTypeRepresentationStrategyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/IndexBasedRelationshipTypeRepresentationStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/LabelBasedNodeTypeRepresentationStrategyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/LabelBasedNodeTypeRepresentationStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/NoopTypeRepresentationStrategyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/NoopTypeRepresentationStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/SubReferenceNodeTypeRepresentationStrategyTests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/aspects/support/typerepresentation/SubReferenceNodeTypeRepresentationStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/illegal/aspects/index1/IllegalIndex1Tests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/illegal/aspects/index1/IllegalIndex1Tests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/illegal/aspects/index2/IllegalIndex2Tests.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/illegal/aspects/index2/IllegalIndex2Tests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidReadOnlyOneToNEntity.java
+++ b/spring-data-neo4j-aspects/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidReadOnlyOneToNEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/config/CrossStoreNeo4jConfiguration.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/config/CrossStoreNeo4jConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/fieldaccess/JpaIdFieldAccessListenerFactory.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/fieldaccess/JpaIdFieldAccessListenerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeDelegatingFieldAccessorFactory.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeDelegatingFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityInstantiator.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityState.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityStateFactory.java
+++ b/spring-data-neo4j-cross-store/src/main/java/org/springframework/data/neo4j/cross_store/support/node/CrossStoreNodeEntityStateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerCrossStoreTests.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerCrossStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/RecommendationConfigTests.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/RecommendationConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/RecommendationTests.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/RecommendationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Cuisine.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Cuisine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Recommendation.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Recommendation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Restaurant.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/Restaurant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/User.java
+++ b/spring-data-neo4j-cross-store/src/test/java/org/springframework/data/neo4j/partial/model/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringCypherRestGraphDatabase.java
+++ b/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringCypherRestGraphDatabase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringHandler.java
+++ b/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringRestCypherQueryEngine.java
+++ b/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringRestCypherQueryEngine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringRestGraphDatabase.java
+++ b/spring-data-neo4j-rest/src/main/java/org/springframework/data/neo4j/rest/SpringRestGraphDatabase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/client/CertificateValidationTest.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/client/CertificateValidationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestEntityPropertyValidationTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestEntityPropertyValidationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestFinderTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestFinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestGraphRepositoryTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestGraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestIndexTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestIndexTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeo4jTemplateApiTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeo4jTemplateApiTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeo4jTemplateTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeoTraversalTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNeoTraversalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityRelationshipTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityRelationshipTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestNodeEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestProjectionTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestProjectionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestPropertyTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestPropertyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestRelationshipEntityTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestRelationshipEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestRelationshipTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestRelationshipTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestTraversalTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestTraversalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestUniqueEntityTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/integration/RestUniqueEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/IsRelationshipToNodeMatcher.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/IsRelationshipToNodeMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/Neo4jDatabaseCleaner.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/Neo4jDatabaseCleaner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestEntityTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestGraphDbTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestGraphDbTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestIndexTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestIndexTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestQueryEngineTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestQueryEngineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTestBase.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTestHelper.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTestHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTraversalDescriptionTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTraversalDescriptionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTraversalExecutionTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/RestTraversalExecutionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/ServerPluginTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/ServerPluginTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/SpringPluginInitializerTests.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/SpringPluginInitializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/TestInterface.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/TestInterface.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/TestServerPlugin.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/TestServerPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/Type.java
+++ b/spring-data-neo4j-rest/src/test/java/org/springframework/data/neo4j/rest/support/Type.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j-tx/src/main/java/org/springframework/data/neo4j/transaction/Neo4jTransactional.java
+++ b/spring-data-neo4j-tx/src/main/java/org/springframework/data/neo4j/transaction/Neo4jTransactional.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EndNode.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EndNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Fetch.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Fetch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphId.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphId.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphTraversal.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/GraphTraversal.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Indexed.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Indexed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Labels.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Labels.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/MapResult.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/MapResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/NodeEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/NodeEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/QueryResult.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/QueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedTo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedTo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedToVia.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelatedToVia.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipType.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/RelationshipType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ResultColumn.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ResultColumn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/StartNode.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/StartNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/ConfigurationCheck.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/ConfigurationCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/DataGraphBeanDefinitionParser.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/DataGraphBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jRepositories.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/JtaTransactionManagerFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/JtaTransactionManagerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jAuditingBeanDefinitionParser.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jAuditingBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jNamespaceHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jRepositoriesRegistrar.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jRepositoriesRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jRepositoryConfigurationExtension.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/NullTransactionManager.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/NullTransactionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/ContainerConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/ContainerConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/DefaultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/DefaultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Handler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Handler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/QueryMapResultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/QueryMapResultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/QueryResultBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/QueryResultBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Result.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Result.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/ResultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/ResultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/EntityPath.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/EntityPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/EntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/EntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/FieldTraversalDescriptionBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/FieldTraversalDescriptionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/GraphDatabase.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/GraphDatabase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/NodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/NodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/RelationshipTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/RelationshipTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/TypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/TypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/UncategorizedGraphStoreException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/core/UncategorizedGraphStoreException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ConvertingNodePropertyFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ConvertingNodePropertyFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DefaultEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DefaultEntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DelegatingFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DelegatingFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DetachedEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DetachedEntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DirtyValue.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DirtyValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesContainer.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/DynamicPropertiesFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessListener.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactoryProviders.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorFactoryProviders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorListenerFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/FieldAccessorListenerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/GenericNodePropertyFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/GenericNodePropertyFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/GraphBackedEntityIterableWrapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/GraphBackedEntityIterableWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/IdFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/IdFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/IndexingPropertyFieldAccessorListenerFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/IndexingPropertyFieldAccessorListenerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/LabelFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/LabelFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedFieldAccessorSet.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedFieldAccessorSet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedPrefixedDynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ManagedPrefixedDynamicProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/Neo4jConversionServiceFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/Neo4jConversionServiceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/NodeDelegatingFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/NodeDelegatingFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PropertyConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PropertyConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PropertyFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/PropertyFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/QueryFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/QueryFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ReadOnlyRelatedToCollectionFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ReadOnlyRelatedToCollectionFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToCollectionFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToCollectionFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToFieldAccessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToFieldAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToSingleFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToSingleFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToViaCollectionFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToViaCollectionFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToViaSingleFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelatedToViaSingleFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipDelegatingFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipDelegatingFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipEntities.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipEntities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipHelper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipNodeFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/RelationshipNodeFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/TransientFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/TransientFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/TraversalFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/TraversalFieldAccessorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ValidatingPropertyFieldAccessorListenerFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/ValidatingPropertyFieldAccessorListenerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterDeleteEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterDeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterSaveEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AfterSaveEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AuditingEventListener.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/AuditingEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeDeleteEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeDeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/DeleteEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/DeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/Neo4jLifecycleEvent.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/lifecycle/Neo4jLifecycleEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/EntityInstantiator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/EntityInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/EntityPersister.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/EntityPersister.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/IndexInfo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/IndexInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/InvalidEntityTypeException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/InvalidEntityTypeException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/ManagedEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/ManagedEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MappingPolicy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MappingPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jEntityConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jEntityConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jNodeConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jNodeConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/PersistentEntityConversionException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/PersistentEntityConversionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipInfo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipProperties.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipResult.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/RelationshipResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/querydsl/SDNAnnotationProcessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/querydsl/SDNAnnotationProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/AbstractGraphRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CRUDRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CRUDRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CypherDslRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/CypherDslRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GeoConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GeoConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GeoQueries.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GeoQueries.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphEntityInformation.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphEntityInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphMetamodelEntityInformation.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphMetamodelEntityInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/GraphRepositoryFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/IndexRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/IndexRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NamedIndexRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NamedIndexRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NodeGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/NodeGraphRepositoryImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipGraphRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipGraphRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipOperationsRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/RelationshipOperationsRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SchemaIndexRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SchemaIndexRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SpatialRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/SpatialRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/TraversalRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/TraversalRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherGraphRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryDefinition.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/DerivedCypherRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/DerivedCypherRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/ExactIndexBasedStartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/ExactIndexBasedStartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/FullTextIndexBasedStartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/FullTextIndexBasedStartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphIdStartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphIdStartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IdPropertyWhereClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IdPropertyWhereClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IndexBasedStartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IndexBasedStartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IndexBasedTypeRestrictingWhereClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/IndexBasedTypeRestrictingWhereClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/LabelBasedTypeRestrictingWhereClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/LabelBasedTypeRestrictingWhereClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/MatchClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/MatchClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/ParameterResolver.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/ParameterResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartInfo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryTemplates.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryTemplates.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/RepositoryQueryException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/RepositoryQueryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/SpatialIndexStartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/SpatialIndexStartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/StartClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/StartClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/StartClauseFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/StartClauseFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/VariableContext.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/VariableContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/WhereClause.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/WhereClause.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/server/ProvidedClassPathXmlApplicationContext.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/server/ProvidedClassPathXmlApplicationContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/server/SpringPluginInitializer.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/server/SpringPluginInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DelegatingGraphDatabase.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DelegatingGraphDatabase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DoReturn.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/DoReturn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GenericTypeExtractor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GenericTypeExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GraphDatabaseFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GraphDatabaseFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Infrastructure.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Infrastructure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/MappingInfrastructure.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/MappingInfrastructure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/MappingInfrastructureFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/MappingInfrastructureFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jExceptionTranslator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jExceptionTranslator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jTemplate.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jTemplateAware.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/Neo4jTemplateAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/ParameterCheck.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/ParameterCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/ReferenceNodes.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/ReferenceNodes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/EntityResultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/EntityResultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/GenericObjectToObjectConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/GenericObjectToObjectConverter.java
@@ -7,7 +7,7 @@ package org.springframework.data.neo4j.support.conversion;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/NoSuchColumnFoundException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/NoSuchColumnFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/POJOResultBuildingException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/POJOResultBuildingException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/QueryResultProxy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/conversion/QueryResultProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/ClosableIndexHits.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/ClosableIndexHits.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/EmptyIndexHits.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/EmptyIndexHits.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProviderImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexProviderImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexType.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/IndexType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/NoSuchIndexException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/NoSuchIndexException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/NullReadableIndex.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/index/NullReadableIndex.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/AbstractConstructorEntityInstantiator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/AbstractConstructorEntityInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/ClassNameAlias.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/ClassNameAlias.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/DefaultEntityIndexCreator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/DefaultEntityIndexCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityAlias.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityAlias.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityCreatingClosableIterable.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityCreatingClosableIterable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityRemover.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityRemover.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityStateHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityStateHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityTools.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/EntityTools.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/HierarchicalTypeInformationMapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/HierarchicalTypeInformationMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4JPersistentPropertyImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4JPersistentPropertyImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityConverterImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityConverterImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityFetchHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityFetchHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityPersister.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jEntityPersister.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jMappingContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jPersistentEntityImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/Neo4jPersistentEntityImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/SourceStateTransmitter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/SourceStateTransmitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/StoredEntityType.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/StoredEntityType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/TRSTypeAliasAccessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/mapping/TRSTypeAliasAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/EntityStateFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/EntityStateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityInstantiator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityStateFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityStateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/ConvertingEntityPath.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/ConvertingEntityPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/DefaultRelationshipBacked.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/DefaultRelationshipBacked.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityEvaluator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityMapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityPathPathIterableWrapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/EntityPathPathIterableWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/IterationController.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/IterationController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/NodePath.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/NodePath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/PathMapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/PathMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/PathMappingIterator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/PathMappingIterator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/RelationshipPath.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/path/RelationshipPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/ConversionServiceQueryResultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/ConversionServiceQueryResultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/CypherQueryEngineImpl.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/CypherQueryEngineImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/CypherQueryExecutor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/CypherQueryExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryEngine.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryEngine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryOperations.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryParameterConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/query/QueryParameterConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityInstantiator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityStateFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityStateFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/AbstractIndexBasedTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/AbstractIndexBasedTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/ClassValueTypeInformationMapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/ClassValueTypeInformationMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/ClosableCombiningIterable.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/ClosableCombiningIterable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/EntityTypeCache.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/EntityTypeCache.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/IndexBasedNodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/IndexBasedNodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/IndexBasedRelationshipTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/IndexBasedRelationshipTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/LabelBasedNodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/LabelBasedNodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/NoopNodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/NoopNodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/NoopRelationshipTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/NoopRelationshipTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/SingleLabelBasedNodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/SingleLabelBasedNodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/SubReferenceNodeTypeRepresentationStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/SubReferenceNodeTypeRepresentationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategies.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategies.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategyFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/typerepresentation/TypeRepresentationStrategyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/template/GraphCallback.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/template/GraphCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/template/Neo4jOperations.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/template/Neo4jOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/persistence/StateBackedCreator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/persistence/StateBackedCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/persistence/StateProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/persistence/StateProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/persistence/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/persistence/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/SetHelper.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/SetHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/IdentifiableEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/IdentifiableEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/RelationshipDelegates.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/RelationshipDelegates.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/Artist.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/Artist.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/ArtistRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/ArtistRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/GraphPropertyAnnotationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/graphproperty/GraphPropertyAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Activity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Activity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ActivityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ActivityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Advisor.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Advisor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AdvisorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AdvisorRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Animal.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Animal.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AnimalRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AnimalRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Apple.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Apple.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleStore.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleStoreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/AppleStoreRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalMappingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaMappingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaWithCollectionFetchMappingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaWithCollectionFetchMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaWithSingleFetchMappingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BiDirectionalRelatedToViaWithSingleFetchMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BoardMember.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BoardMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BoardMemberRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BoardMemberRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Book.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BookRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/BookRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CareerProfile.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CareerProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CareerProfileRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CareerProfileRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Carnivore.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Carnivore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Chairman.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Chairman.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ChairmanRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ChairmanRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CoffeeMachine.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CoffeeMachine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CoffeeMachineRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CoffeeMachineRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Course.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Course.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CourseRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/CourseRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/DripBrew.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/DripBrew.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/DripBrewRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/DripBrewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/EspressoBasedCoffee.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/EspressoBasedCoffee.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/EspressoBasedCoffeeRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/EspressoBasedCoffeeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Experience.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Experience.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ExperienceRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ExperienceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Friend.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Friend.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FriendRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FriendRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FruitBowl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FruitBowl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FruitBowlRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/FruitBowlRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Herbivore.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Herbivore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Hero.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Hero.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/HeroRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/HeroRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Human.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Human.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/HumanRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/HumanRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Initiative.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Initiative.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/InitiativeRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/InitiativeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Job.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Job.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/JobRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/JobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MacBook.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MacBook.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MacBookRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MacBookRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MainHandWeapon.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MainHandWeapon.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MainHandWeaponRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MainHandWeaponRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MarvelCharacter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MarvelCharacter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MarvelCharacterRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MarvelCharacterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Mondrian.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Mondrian.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MondrianRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/MondrianRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OffHandWeapon.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OffHandWeapon.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OffHandWeaponRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OffHandWeaponRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Organisation.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Organisation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OrganisationRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/OrganisationRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Quadrilateral.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Quadrilateral.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Rectangle.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Rectangle.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RectangleRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RectangleRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RelatedToTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RelatedToTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Restaurant.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Restaurant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RestaurantRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RetinaMacBook.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RetinaMacBook.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RetinaMacBookRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/RetinaMacBookRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Shop.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Shop.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShopRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShopRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShoppingCenter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShoppingCenter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShoppingCenterRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ShoppingCenterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Square.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Square.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SquareRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SquareRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Student.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Student.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/StudentRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/StudentRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperHuman.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperHuman.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperHumanRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperHumanRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Superhero.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Superhero.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperheroRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/SuperheroRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Team.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Team.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/TeamRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/TeamRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Town.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Town.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/TownRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/TownRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Warchief.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Warchief.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WarchiefRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WarchiefRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Weapon.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Weapon.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WorldOfWarcraftCharacter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WorldOfWarcraftCharacter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WorldOfWarcraftCharacterRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/WorldOfWarcraftCharacterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Zoo.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/Zoo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ZooRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedto/ZooRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/City.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/City.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/CityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/CityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Country.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Country.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/CountryRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/CountryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/InterCountryRelationship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/InterCountryRelationship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Line.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Line.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/MetroLine.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/MetroLine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/MetroLineRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/MetroLineRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PerpetualRelations.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PerpetualRelations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Player.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Player.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PlayerRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PlayerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PlayerStatus.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/PlayerStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/RelatedToViaTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/RelatedToViaTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/SuperState.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/SuperState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/SuperStateRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/SuperStateRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Team.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/Team.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TeamRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TeamRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TransportInfrastructure.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TransportInfrastructure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TubeStation.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/TubeStation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/UndergroundRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/annotation/relatedtovia/UndergroundRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/AuditingIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/AuditingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/ConfigurationConfirmationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/ConfigurationConfirmationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/DataGraphNamespaceHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/Neo4jRepositoriesRegistrarIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/Neo4jRepositoriesRegistrarIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesJavaConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesJavaConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesNamspaceConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/NestedNeo4jRepositoriesNamspaceConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/model/TestEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/config/model/TestEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/QueryMapResultConverterTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/QueryMapResultConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/QueryResultBuilderTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/QueryResultBuilderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/equality/EqualityTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/equality/EqualityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/GenericPropertyFieldAccessorTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/GenericPropertyFieldAccessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicPropertyTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/PrefixedDynamicPropertyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/PropertyTypeConversionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/fieldaccess/PropertyTypeConversionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/InheritanceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/InheritanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/BasicEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/BasicEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/BasicRelationship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/BasicRelationship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/Project.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/Project.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/ProjectDetail.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/ProjectDetail.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/ProjectDetailRelationship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/model/ProjectDetailRelationship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/repository/ProjectDetailRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/repository/ProjectDetailRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/repository/ProjectRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/inheritance/repository/ProjectRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidMappingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidReadOnlyOneToNEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/InvalidReadOnlyOneToNEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/PrimitiveIdEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/model/PrimitiveIdEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidUniqueEntityTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/invalid/unique/InvalidUniqueEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterDeleteEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterDeleteEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterSaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AfterSaveEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AuditingEventListenerUnitTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/AuditingEventListenerUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeDeleteEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeDeleteEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/BeforeSaveEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/DeleteEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/DeleteEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/SaveEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/lifecycle/SaveEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/context/Neo4jMappingContextTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/context/Neo4jMappingContextTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/converter/Neo4jEntityConverterTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/converter/Neo4jEntityConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/persist/Neo4jEntityPersisterTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/persist/Neo4jEntityPersisterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/persist/Neo4jPersistentEntityTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/persist/Neo4jPersistentEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account1.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account2.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Account2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Attribute.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Attribute.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Being.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Being.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/BestFriend.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/BestFriend.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Car.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Car.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Friendship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Friendship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/FriendshipRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/FriendshipRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Group.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/GroupRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/GroupRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/IGroup.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/IGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Named.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Named.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/NonNullNamed.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/NonNullNamed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/PersonCreator.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/PersonCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/PersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Personality.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Personality.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/RootEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/RootEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Toyota.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Toyota.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Volvo.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/model/Volvo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/BeingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/BeingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/FriendshipRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/FriendshipRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/GroupRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/GroupRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepositoryFriendship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepositoryFriendship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/PersonRepositoryImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RedeclaringRepositoryMethodsRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RedeclaringRepositoryMethodsRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/AbstractEntityBasedGraphRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/AbstractEntityBasedGraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/CypherDslRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/CypherDslRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/DerivedFinderTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/DerivedFinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/GraphRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/GraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MatrixTeam.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MatrixTeam.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MemberData.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MemberData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MemberDataPOJO.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MemberDataPOJO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/NoIndexDerivedFinderTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/NoIndexDerivedFinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ReadWriteTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ReadWriteTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/RedeclaringRepositoryMethodsTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/RedeclaringRepositoryMethodsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerialTesters.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerialTesters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerializableEntityRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerializableEntityRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerializableGraphQueryRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SerializableGraphQueryRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SpatialGraphRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/SpatialGraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/TestTeam.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/TestTeam.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiExtensionIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiExtensionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository2.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository3.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository3.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiProducer.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/RepositoryClient.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/RepositoryClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepositoryCustom.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepositoryCustom.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepositoryImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractCypherQueryBuilderTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractCypherQueryBuilderTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractDerivedFinderMethodTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/AbstractDerivedFinderMethodTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilderForIndexBasedTRSUnitTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilderForIndexBasedTRSUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilderForLabelBasedTRSUnitTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/CypherQueryBuilderForLabelBasedTRSUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForIndexedBasedTRSTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForIndexedBasedTRSTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForIndexedBasedTRSViaJavaConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForIndexedBasedTRSViaJavaConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForLabelBasedTRSTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/DerivedFinderMethodForLabelBasedTRSTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Group.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/MatchClauseUnitTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/MatchClauseUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Pet.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/Pet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/ThingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/ThingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/VariableContextUnitTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/VariableContextUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByArrayOfSimpleTypeTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByArrayOfSimpleTypeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByDateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByDateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByEnumTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedByEnumTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedBySimpleTypeTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/InParameterisedBySimpleTypeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/ParameterisedInTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/cypher/ParameterisedInTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/DelegatingGraphDatabaseTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/DelegatingGraphDatabaseTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/EntityNeo4jTemplateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/EntityNeo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/EntityTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/EntityTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/ExceptionThrowingTypeSafetyNeo4jTemplateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/ExceptionThrowingTypeSafetyNeo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/GraphDatabaseFactoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/GraphDatabaseFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/NullReturningTypeSafetyNeo4jTemplateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/NullReturningTypeSafetyNeo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/node/Neo4jHelper.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/node/Neo4jHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/query/QueryParameterConverterTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/query/QueryParameterConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/FullNeo4jTemplateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/FullNeo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateApiTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateApiTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateApiTransactionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateApiTransactionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/Neo4jTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/NeoApiTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/NeoApiTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/NeoTraversalTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/NeoTraversalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/typerepresentation/TypeRepresentationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/typerepresentation/TypeRepresentationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueEntityTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueEntityTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueNumericIdClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/common/CommonUniqueNumericIdClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/UniqueLegacyIndexBasedEntityTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/UniqueLegacyIndexBasedEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/UniqueRelationshipTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/UniqueRelationshipTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/Club.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/Club.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/UniqueClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/UniqueClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/UniqueNumericIdClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/domain/UniqueNumericIdClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/ClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/ClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/UniqueClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/UniqueClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/UniqueNumericIdClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/legacy/repository/UniqueNumericIdClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/UniqueSchemaBasedEntityTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/UniqueSchemaBasedEntityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/Club.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/Club.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/UniqueClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/UniqueClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/UniqueNumericIdClub.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/domain/UniqueNumericIdClub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/ClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/ClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/UniqueClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/UniqueClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/UniqueNumericIdClubRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/unique/schemabased/repository/UniqueNumericIdClubRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/DocumentingTestBase.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/DocumentingTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/DocumentingTestBaseTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/DocumentingTestBaseTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/GroupRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/GroupRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/PersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/SnippetNeo4jTemplateMethodsTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/SnippetNeo4jTemplateMethodsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/SnippetRepositoryDerivedFinderTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/test/snippets/SnippetRepositoryDerivedFinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/test/context/CleanContextCacheTestExecutionListener.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/test/context/CleanContextCacheTestExecutionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 613 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).