### PR TITLE
URL Cleanup

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -7,7 +7,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/checkstyle/java-header.txt
+++ b/checkstyle/java-header.txt
@@ -5,7 +5,7 @@
 ^\Q * you may not use this file except in compliance with the License.\E$
 ^\Q * You may obtain a copy of the License at\E$
 ^\Q *\E$
-^\Q *      http://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
 ^\Q *\E$
 ^\Q * Unless required by applicable law or agreed to in writing, software\E$
 ^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Depth.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Depth.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EnableBookmarkManagement.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EnableBookmarkManagement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EnableNeo4jAuditing.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/EnableNeo4jAuditing.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/ExistsQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/Query.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/QueryResult.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/QueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/UseBookmark.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/UseBookmark.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/annotation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BeanFactoryBookmarkOperationAdvisor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BeanFactoryBookmarkOperationAdvisor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkInfo.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkInterceptor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkManagementConfiguration.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkManagementConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkManager.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkOperationPointcut.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkOperationPointcut.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkSupport.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/BookmarkSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/CaffeineBookmarkManager.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/CaffeineBookmarkManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/bookmark/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionService.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Neo4jOgmEntityInstantiatorAdapter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/Neo4jOgmEntityInstantiatorAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/PointConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/PointConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/conversion/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/Neo4jErrorStatusCodes.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/Neo4jErrorStatusCodes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/UncategorizedNeo4jException.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/UncategorizedNeo4jException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/exception/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/MetaDataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jMappingContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/Neo4jPersistentProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/mapping/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiRepositoryExtension.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/cdi/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jAuditingEventListener.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jAuditingEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jAuditingRegistrar.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jAuditingRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jMappingContextFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jOgmEntityInstantiatorConfigurationBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrar.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryNameSpaceHandler.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryNameSpaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/config/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/AbstractGraphRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CustomResultConverter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/CustomResultConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/FilterBuildersDefinition.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/FilterBuildersDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameterAccessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameterAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParametersParameterAccessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphParametersParameterAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryExecution.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryLookupStrategy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryLookupStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphQueryMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/GraphRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/NamedGraphRepositoryQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/Query.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/Query.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryResultInstantiator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryResultInstantiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryResultProxy.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/QueryResultProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/TemplatedQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/TemplatedQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/TemplatedQueryCreator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/TemplatedQueryCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BetweenComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BetweenComparisonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BooleanComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/BooleanComparisonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/ContainsComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/ContainsComparisonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/DistanceComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/DistanceComparisonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/ExistsFilterBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/ExistsFilterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/FilterBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/FilterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/IsNullFilterBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/IsNullFilterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/PropertyComparisonBuilder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/PropertyComparisonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/filter/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/Neo4jQueryPlaceholderSupplier.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/Neo4jQueryPlaceholderSupplier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/ParameterizedQuery.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/ParameterizedQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/PlaceholderSupplier.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/PlaceholderSupplier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/query/spel/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/GraphEntityInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jAuditingBeanPostProcessor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jAuditingBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jPersistenceExceptionTranslator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jPersistenceExceptionTranslator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/repository/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/Neo4jTransactionManager.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/Neo4jTransactionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SessionFactoryUtils.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SessionFactoryUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SessionHolder.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SessionHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SharedSessionCreator.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/SharedSessionCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/transaction/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/util/PagingAndSortingUtils.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/util/PagingAndSortingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/util/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/util/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/AsyncRequestInterceptor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/AsyncRequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/OpenSessionInViewFilter.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/OpenSessionInViewFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/OpenSessionInViewInterceptor.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/OpenSessionInViewInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/package-info.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/web/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/JavaConfigurationAuditingTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/JavaConfigurationAuditingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/repository/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/auditing/repository/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/bookmark/BookmarkManagementTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/bookmark/BookmarkManagementTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/bookmark/BookmarkWrapper.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/bookmark/BookmarkWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/MetaDataDrivenConversionServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/ConvertedClass.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/ConvertedClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/Converters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityWithConvertedAttributes.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/conversion/support/EntityWithConvertedAttributes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/EntityWithInvalidProperty.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/EntityWithInvalidProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/EntityWithInvalidPropertyRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/EntityWithInvalidPropertyRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/package-info.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/invalid/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/Address.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/Address.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/NodeWithUUIDAsId.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/NodeWithUUIDAsId.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/Role.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/Role.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/SampleEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/SampleEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/SpecialUser.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/SpecialUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/domain/sample/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/EventPublisher.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/EventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/ModificationEvent.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/ModificationEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/Neo4jModificationEventListener.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/Neo4jModificationEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PostDeleteEvent.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PostDeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PostSaveEvent.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PostSaveEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PreDeleteEvent.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PreDeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PreSaveEvent.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/events/PreSaveEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/FriendService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/FriendService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/FriendTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/FriendTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/domain/Friendship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/domain/Friendship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/domain/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/friends/repo/FriendshipRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/GalaxyContextConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/GalaxyContextConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/GalaxyServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/GalaxyServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/WorldRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/WorldRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/domain/World.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/domain/World.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/repo/WorldRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/service/GalaxyService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/galaxy/service/GalaxyService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/JSR303Tests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/JSR303Tests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/WebConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/WebConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/controller/AdultController.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/controller/AdultController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/domain/Adult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/domain/Adult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/repo/AdultRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/service/AdultService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/service/AdultService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/MoviesIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/MoviesIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/AbstractAnnotatedEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/AbstractAnnotatedEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/AbstractEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/AbstractEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Actor.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Actor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Cinema.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Cinema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/CinemaAndBlockbuster.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/CinemaAndBlockbuster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/CinemaAndBlockbusterName.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/CinemaAndBlockbusterName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Director.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Director.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Genre.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Genre.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Movie.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Movie.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Rating.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/Rating.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/ReleasedMovie.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/ReleasedMovie.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/TempMovie.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/TempMovie.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResultInterface.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResultInterface.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResultInterfaceImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/CinemaQueryResultInterfaceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/EntityWrappingQueryResult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/EntityWrappingQueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/Gender.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/Gender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/RichUserQueryResult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/RichUserQueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResult.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResultObject.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/UserQueryResultObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/YearConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/domain/queryresult/YearConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractAnnotatedEntityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/AbstractEntityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/ActorRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaStreamingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/CinemaStreamingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/DirectorRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/DirectorRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/GenreRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/PersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/RatingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/TempMovieRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UnmanagedUserPojo.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UnmanagedUserPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/repo/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/service/UserService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/service/UserService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/service/UserServiceImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/movies/service/UserServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/RestaurantTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/domain/Diner.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/domain/Diner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/domain/Restaurant.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/domain/Restaurant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/restaurants/repo/RestaurantRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomGraphRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomNeo4jRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/CustomNeo4jRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/extensions/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/PersistenceConstructorsTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/PersistenceConstructorsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Friendship.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Friendship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Group.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Person.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonMultipleConstructors.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonMultipleConstructors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonProjection.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonProjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithAnnotatedPersistenceConstructor.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithAnnotatedPersistenceConstructor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithCompositeAttribute.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithCompositeAttribute.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithFinalName.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithFinalName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithManyToOneRel.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/constructors/domain/PersonWithManyToOneRel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ConversionServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/JavaElementRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/PensionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldGracefullyHandleMultipleConversionServicesTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldGracefullyHandleMultipleConversionServicesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldPickPrimaryConversionServiceTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/ShouldPickPrimaryConversionServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SiteMemberRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringBigIntegerToBooleanConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringBigIntegerToBooleanConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringBooleanToBigIntegerConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringBooleanToBigIntegerConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringByteArrayToIntegerConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringByteArrayToIntegerConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringIntegerToByteArrayConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringIntegerToByteArrayConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringIntegerToMonetaryAmountConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringIntegerToMonetaryAmountConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringLongToMonetaryAmountConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringLongToMonetaryAmountConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToIntegerConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToIntegerConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToLongConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToLongConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToNumberConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToNumberConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToNumberConverterFactory.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringMonetaryAmountToNumberConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringNumberToMonetaryAmountConverter.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/SpringNumberToMonetaryAmountConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/JavaElement.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/JavaElement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/MonetaryAmount.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/MonetaryAmount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/PensionPlan.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/PensionPlan.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/SiteMember.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/integration/conversion/domain/SiteMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/mapping/Neo4jPersistentPropertyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/NamedQueryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/domain/SampleEntityForNamedQuery.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/domain/SampleEntityForNamedQuery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/repo/SampleEntityForNamedQueryRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/namedquery/repo/SampleEntityForNamedQueryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/NativeTypesContextConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/NativeTypesContextConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialConversionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialConversionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialDomain.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialDomain.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialDomainRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialDomainRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialFindByTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialFindByTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialNearTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialNearTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialPersistenceContextConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/SpatialPersistenceContextConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeDomain.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeDomain.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeDomainRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeDomainRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeFindByTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/nativetypes/TimeFindByTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedQueryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedRelationshipEntityQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/DerivedRelationshipEntityQueryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/Java8SupportTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/Java8SupportTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/MoviesContextConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/MoviesContextConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/PagedQueryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/PagedQueryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/ProjectionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/ProjectionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryReturnTypesTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/QueryReturnTypesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/StoredProceduresTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/StoredProceduresTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/stored_procedures/DocumentEntity.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/stored_procedures/DocumentEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/stored_procedures/DocumentRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/queries/stored_procedures/DocumentRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/ProgrammaticRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/ProgrammaticRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RepoScanningTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RepoScanningTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RepositoryDefinitionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/RepositoryDefinitionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/domain/Movie.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/domain/Movie.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/MovieRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/MovieRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/repo/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repositories/support/GraphRepositoryFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Contact.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Contact.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ContactRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/ContactRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/MultipleSessionFactorySupportTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/Neo4jRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiExtensionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiExtensionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/CdiPersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiProducer.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jCdiProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jRepositoryExtensionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/Neo4jRepositoryExtensionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/OtherQualifier.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/OtherQualifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/PersonDB.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/PersonDB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/QualifiedPersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/QualifiedPersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/RepositoryClient.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/RepositoryClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonFragment.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonFragment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonFragmentImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonFragmentImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/cdi/SamplePersonRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrarTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrarTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtensionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtensionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/RepositoriesJavaConfigTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/config/RepositoriesJavaConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/GraphQueryExecutionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/GraphQueryExecutionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/filter/DistanceComparisonBuilderTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/query/filter/DistanceComparisonBuilderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/sample/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/DefaultTransactionDisablingIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/DefaultTransactionDisablingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jPersistenceExceptionTranslatorIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jPersistenceExceptionTranslatorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/TransactionalRepositoryTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/repository/support/TransactionalRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/TemplateApplicationEventTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/TemplateApplicationEventTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/TestNeo4jEventListener.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/template/TestNeo4jEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/GraphDatabaseServiceAssert.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/GraphDatabaseServiceAssert.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jIntegrationTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jTestServerConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jTestServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/NodeAssert.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/NodeAssert.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/SessionFactoryRegistrar.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/SessionFactoryRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/package-info.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/BookmarkTransactionTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/BookmarkTransactionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/Neo4jTransactionManagerTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/Neo4jTransactionManagerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/SessionFactoryUtilsTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/SessionFactoryUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/SharedSessionCreatorTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/SharedSessionCreatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/TransactionalEventListenerTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transaction/TransactionalEventListenerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/ExtendedTransactionsTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/ExtendedTransactionsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/TransactionIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/TransactionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/TransactionRollbackTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/TransactionRollbackTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/repo/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/BusinessService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/BusinessService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/ServiceA.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/ServiceA.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/ServiceB.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/ServiceB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/WrapperService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/transactions/service/WrapperService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/WebIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/WebIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/XmlApplicationContextWebIntegrationTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/XmlApplicationContextWebIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/controller/UserController.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/controller/UserController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Cinema.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Cinema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Genre.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/Genre.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/User.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/domain/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/GenreRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/repo/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserService.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserServiceImpl.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/service/UserServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/support/OpenSessionInViewTests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/web/support/OpenSessionInViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/kotlin/org/springframework/data/neo4j/integration/constructors/domain/KotlinFriendship.kt
+++ b/spring-data-neo4j/src/test/kotlin/org/springframework/data/neo4j/integration/constructors/domain/KotlinFriendship.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/kotlin/org/springframework/data/neo4j/integration/constructors/domain/KotlinPerson.kt
+++ b/spring-data-neo4j/src/test/kotlin/org/springframework/data/neo4j/integration/constructors/domain/KotlinPerson.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-neo4j/src/test/resources/logback-test.xml
+++ b/spring-data-neo4j/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
  | you may not use this file except in compliance with the License.
  | You may obtain a copy of the License at
  |
- |      http://www.apache.org/licenses/LICENSE-2.0
+ |      https://www.apache.org/licenses/LICENSE-2.0
  |
  | Unless required by applicable law or agreed to in writing, software
  | distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 315 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).