### PR TITLE
Explicitly stop the embedded test server after test class.

### DIFF
--- a/spring-data-neo4j/pom.xml
+++ b/spring-data-neo4j/pom.xml
@@ -39,7 +39,7 @@
 		<caffeine.version>2.6.2</caffeine.version>
 		<el-api.version>2.2</el-api.version>
 		<javax-jaxb.version>2.3.1</javax-jaxb.version>
-		<neo4j.version>3.5.2</neo4j.version>
+		<neo4j.version>3.5.18</neo4j.version>
 		<ogm.properties>ogm-bolt.properties</ogm.properties>
 		<spotbugs-maven-plugin.version>3.1.3</spotbugs-maven-plugin.version>
 		<spotbugs.version>3.1.3</spotbugs.version>

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/JSR303Tests.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/examples/jsr303/JSR303Tests.java
@@ -18,7 +18,6 @@ package org.springframework.data.neo4j.examples.jsr303;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +34,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Vince Bickers

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/CloseServerControlsAfterTestClassTestExecutionListener.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/CloseServerControlsAfterTestClassTestExecutionListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.test;
+
+import static org.springframework.data.neo4j.test.Neo4jTestServerConfiguration.*;
+
+import org.neo4j.harness.ServerControls;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+/**
+ * This tests execution listener takes care of closing Neo4j when the test context gets removed.
+ * The shutdown hook will not apply until the JVM ends, so the tests won't close Neo4j even with
+ * {@link org.springframework.test.annotation.DirtiesContext} on them. Therefor we do this manually.
+ * As our doing actually also does dirty the context, we mark it accordingly.
+ *
+ * @author Michael J. Simons
+ */
+class CloseServerControlsAfterTestClassTestExecutionListener extends AbstractTestExecutionListener {
+
+	@Override
+	public void afterTestClass(TestContext testContext) {
+
+		ApplicationContext applicationContext = testContext.getApplicationContext();
+		if (applicationContext.containsBean(NEO4J_TEST_SERVER_BEAN_NAME)) {
+			((ServerControls) applicationContext.getBean(NEO4J_TEST_SERVER_BEAN_NAME)).close();
+			testContext.markApplicationContextDirty(null);
+		}
+	}
+}

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jTestServerConfiguration.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/test/Neo4jTestServerConfiguration.java
@@ -45,7 +45,9 @@ import org.springframework.transaction.support.TransactionTemplate;
 @EnableTransactionManagement
 class Neo4jTestServerConfiguration {
 
-	@Bean
+	static final String NEO4J_TEST_SERVER_BEAN_NAME = "neo4jTestServer";
+
+	@Bean(name = NEO4J_TEST_SERVER_BEAN_NAME)
 	ServerControls neo4jTestServer() {
 		return TestServerBuilders.newInProcessBuilder().newServer();
 	}

--- a/spring-data-neo4j/src/test/resources/META-INF/spring.factories
+++ b/spring-data-neo4j/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.test.context.TestExecutionListener=org.springframework.data.neo4j.test.CloseServerControlsAfterTestClassTestExecutionListener


### PR DESCRIPTION
This introduces a `TestExecutionListener` that explicitly checks for the presence of a `ServerControls` bean and stops it.

We noted some very old Jackson imports in one test and fixed them along the way.