### PR TITLE
DATAGRAPH-1350 - Incoming relationships are not treated correctly when using custom queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,6 @@
 	</developers>
 
 	<properties>
-		<wurstsalat>ja</wurstsalat>
-
 		<apiguardian.version>1.1.0</apiguardian.version>
 		<asciidoctorj-diagram.version>2.0.1</asciidoctorj-diagram.version>
 		<asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConverter.java
@@ -282,7 +282,7 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 			concreteNodeDescription.doWithAssociations(
 					populateFrom(queryResult, propertyAccessor, isConstructorParameter, relationships, knownObjects));
 		}
-		return instance;
+		return propertyAccessor.getBean();
 	}
 
 	/**
@@ -429,11 +429,13 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 				return Optional.empty();
 			}
 
+			Function<Relationship, Long> targetIdSelector = relationshipDescription.isOutgoing() ? Relationship::endNodeId : Relationship::startNodeId;
+
 			for (Node possibleValueNode : allNodesWithMatchingLabelInResult) {
 				long nodeId = possibleValueNode.id();
 
 				for (Relationship possibleRelationship : allMatchingTypeRelationshipsInResult) {
-					if (possibleRelationship.endNodeId() == nodeId) {
+					if (targetIdSelector.apply(possibleRelationship) == nodeId) {
 						Object mappedObject = map(possibleValueNode, concreteTargetNodeDescription, knownObjects);
 						if (relationshipDescription.hasRelationshipProperties()) {
 

--- a/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/RepositoryIT.java
@@ -44,11 +44,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 // end::testing.reactivedataneo4jtest[]
-// tag::testing.reactivedataneo4jtest[]
-// end::testing.reactivedataneo4jtest[]
-// tag::testing.reactivedataneo4jtest[]
-
-// end::testing.reactivedataneo4jtest[]
 
 /**
  * @author Michael J. Simons

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -994,6 +994,27 @@ class ReactiveRepositoryIT {
 			}).verifyComplete();
 
 		}
+
+		@Test // DATAGRAPH-1350
+		void loadEntityWithRelationshipWithPropertiesFromCustomQueryIncoming(
+				@Autowired ReactiveHobbyithRelationshipWithPropertiesRepository repository) {
+
+			long personId;
+
+			try (Session session = createSession()) {
+				Record record = session.run("CREATE (n:AltPerson{name:'Freddie'}), (n)-[l1:LIKED_BY {rating: 5}]->(h1:AltHobby{name:'Music'}) RETURN n, h1").single();
+				personId = record.get("n").asNode().id();
+			}
+
+			StepVerifier.create(repository.loadFromCustomQuery(personId)).assertNext(hobby -> {
+				assertThat(hobby.getName()).isEqualTo("Music");
+				assertThat(hobby.getLikedBy()).hasSize(1);
+				assertThat(hobby.getLikedBy().entrySet()).first().satisfies(entry -> {
+					assertThat(entry.getKey().getId()).isEqualTo(personId);
+					assertThat(entry.getValue().getRating()).isEqualTo(5);
+				});
+			}).verifyComplete();
+		}
 	}
 
 	@Nested
@@ -2051,6 +2072,14 @@ class ReactiveRepositoryIT {
 		Mono<PersonWithRelationshipWithProperties> findByHobbiesSinceOrHobbiesActive(int since1, boolean active);
 
 		Mono<PersonWithRelationshipWithProperties> findByHobbiesSinceAndHobbiesActive(int since1, boolean active);
+	}
+
+	interface ReactiveHobbyithRelationshipWithPropertiesRepository
+			extends ReactiveNeo4jRepository<AltHobby, Long> {
+
+		// @Query("MATCH (h:AltHobby)<-[l:LIKED_BY]->(p:AltPerson) return h, collect(l), collect(p)")
+		@Query("MATCH (p:AltPerson)-[l:LIKED_BY]->(h:AltHobby) WHERE id(p) = $personId RETURN h, collect(l), collect(p)")
+		Flux<AltHobby> loadFromCustomQuery(@Param("personId") Long personId);
 	}
 
 	interface ReactivePetRepository extends ReactiveNeo4jRepository<Pet, Long> {}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/AltHobby.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/AltHobby.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared;
+
+import static org.springframework.data.neo4j.core.schema.Relationship.Direction.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+/**
+ * @@author Michael J. Simons
+ */
+@Node
+public class AltHobby {
+	@Id @GeneratedValue private Long id;
+
+	private String name;
+
+	@Relationship(type = "LIKED_BY", direction = INCOMING)
+	private Map<AltPerson, AltLikedByPersonRelationship> likedBy = new HashMap<>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Map<AltPerson, AltLikedByPersonRelationship> getLikedBy() {
+		return likedBy;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/AltLikedByPersonRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/AltLikedByPersonRelationship.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @@author Michael J. Simons
+ */
+@RelationshipProperties
+public class AltLikedByPersonRelationship {
+
+	private Integer rating;
+
+	public Integer getRating() {
+		return rating;
+	}
+
+	public void setRating(Integer rating) {
+		this.rating = rating;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/AltPerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/AltPerson.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @@author Michael J. Simons
+ */
+@Node
+public class AltPerson {
+
+	@Id @GeneratedValue private Long id;
+
+	private final String name;
+
+	public AltPerson(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}


### PR DESCRIPTION
This change checks the direction of the relationship definition and based on that selects the corresponding target node id.

It also uses the property accessor to retrieve the changed instance.

Furthermore the opportunity is used for some polishing in the pom.