### PR TITLE
DATAGRAPH-1359 - Run Checkstyle in verify phase.

### DIFF
--- a/etc/checkstyle/config.xml
+++ b/etc/checkstyle/config.xml
@@ -23,6 +23,11 @@
     <module name="NewlineAtEndOfFile"/>
     <module name="SuppressWarningsFilter" />
 
+    <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck">
+        <!-- XML requires double escaping, config gets XML-processed twice -->
+        <property name="allowlist" value="http://www\.querydsl\.com.*&amp;#10;http://www\.prowaveconsulting\.com.*&amp;#10;http://www\.scispike\.com.*&amp;#10;http://.*.icu-project\.org.*" />
+    </module>
+
     <module name="com.puppycrawl.tools.checkstyle.TreeWalker">
         <module name="SuppressWarningsHolder" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,21 +69,25 @@
 
 	<properties>
 		<apiguardian.version>1.1.0</apiguardian.version>
-		<asciidoctorj-diagram.version>2.0.1</asciidoctorj-diagram.version>
 		<asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
+		<asciidoctorj-diagram.version>2.0.1</asciidoctorj-diagram.version>
+
+		<!-- For whatever reason, redeclaring those dependencies in our managed dependencies doesn't have any affect... -->
+		<assertj>${assertj.version}</assertj>
 		<assertj.version>3.15.0</assertj.version>
 		<byte-buddy.version>1.10.9</byte-buddy.version>
+		<cdi>2.0</cdi>
 		<changelist>-SNAPSHOT</changelist>
 		<checkstyle.version>8.29</checkstyle.version>
 		<cypher-dsl.version>2020.0.1</cypher-dsl.version>
-		<cdi>2.0</cdi>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-		<java.version>1.8</java.version>
 		<java-module-name>spring.data.neo4j</java-module-name>
-		<jaxb.version>2.3.1</jaxb.version> <!-- Align with testcontainers' version -->
+		<java.version>1.8</java.version>
+		<jaxb.version>2.3.1</jaxb.version>
+		<!-- Align with testcontainers' version -->
 		<jqassistant-dashboard-plugin.version>1.8.0</jqassistant-dashboard-plugin.version>
 		<jqassistant.plugin.version>1.8.0</jqassistant.plugin.version>
 		<jqassistant.version>1.8.0</jqassistant.version>
@@ -92,19 +96,21 @@
 		<maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
 		<maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
 		<maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<mockito>${mockito.version}</mockito>
 		<mockito.version>3.2.4</mockito.version>
 		<neo4j-java-driver.version>4.0.1</neo4j-java-driver.version>
 		<neo4j.version>4.0.3</neo4j.version>
-		<objenesis.version>3.0.1</objenesis.version> <!-- mockk requires objenesis >= 3 -->
+		<objenesis.version>3.0.1</objenesis.version>
+		<!-- mockk requires objenesis >= 3 -->
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<r2dbc.releasetrain>Arabba-SR5</r2dbc.releasetrain>
@@ -112,40 +118,28 @@
 		<revision>1.1</revision>
 		<rxjava.version>1.3.8</rxjava.version>
 		<rxjava2.version>2.2.5</rxjava2.version>
-		<springdata.commons>2.4.0-SNAPSHOT</springdata.commons>
-		<testcontainers.version>1.13.0</testcontainers.version>
+		<skipArchitectureTests>${skipTests}</skipArchitectureTests>
+		<skipIntegrationTests>${skipTests}</skipIntegrationTests>
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
-		<skipIntegrationTests>${skipTests}</skipIntegrationTests>
-		<skipArchitectureTests>${skipTests}</skipArchitectureTests>
-
-		<!-- For whatever reason, redeclaring those dependencies in our managed dependencies doesn't have any affect... -->
-		<assertj>${assertj.version}</assertj>
-		<mockito>${mockito.version}</mockito>
+		<springdata.commons>2.4.0-SNAPSHOT</springdata.commons>
+		<testcontainers.version>1.13.0</testcontainers.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>net.bytebuddy</groupId>
-				<artifactId>byte-buddy</artifactId>
-				<version>${byte-buddy.version}</version>
+				<groupId>eu.michael-simons.neo4j</groupId>
+				<artifactId>junit-jupiter-causal-cluster-testcontainer-extension</artifactId>
+				<version>${junit-cc-testcontainer}</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>net.bytebuddy</groupId>
-				<artifactId>byte-buddy-agent</artifactId>
-				<version>${byte-buddy.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.objenesis</groupId>
-				<artifactId>objenesis</artifactId>
-				<version>${objenesis.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.xml.bind</groupId>
-				<artifactId>jaxb-api</artifactId>
-				<version>${jaxb.version}</version>
-				<scope>provided</scope>
+				<groupId>io.r2dbc</groupId>
+				<artifactId>r2dbc-bom</artifactId>
+				<version>${r2dbc.releasetrain}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>io.reactivex</groupId>
@@ -163,9 +157,20 @@
 				<version>${rxjava2.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.neo4j</groupId>
-				<artifactId>neo4j-cypher-dsl</artifactId>
-				<version>${cypher-dsl.version}</version>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>net.bytebuddy</groupId>
+				<artifactId>byte-buddy</artifactId>
+				<version>${byte-buddy.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.bytebuddy</groupId>
+				<artifactId>byte-buddy-agent</artifactId>
+				<version>${byte-buddy.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apiguardian</groupId>
@@ -182,13 +187,6 @@
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
 				<version>${junit-jupiter.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>io.r2dbc</groupId>
-				<artifactId>r2dbc-bom</artifactId>
-				<version>${r2dbc.releasetrain}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -210,6 +208,11 @@
 				<version>${neo4j.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-cypher-dsl</artifactId>
+				<version>${cypher-dsl.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.neo4j.driver</groupId>
 				<artifactId>neo4j-java-driver</artifactId>
 				<version>${neo4j-java-driver.version}</version>
@@ -218,6 +221,11 @@
 				<groupId>org.neo4j.test</groupId>
 				<artifactId>neo4j-harness</artifactId>
 				<version>${neo4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.objenesis</groupId>
+				<artifactId>objenesis</artifactId>
+				<version>${objenesis.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
@@ -236,8 +244,8 @@
 				<scope>test</scope>
 				<exclusions>
 					<exclusion>
-						<groupId>org.jetbrains</groupId>
 						<artifactId>annotations</artifactId>
+						<groupId>org.jetbrains</groupId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -247,16 +255,26 @@
 				<version>${testcontainers.version}</version>
 				<scope>test</scope>
 			</dependency>
-			<dependency>
-				<groupId>eu.michael-simons.neo4j</groupId>
-				<artifactId>junit-jupiter-causal-cluster-testcontainer-extension</artifactId>
-				<version>${junit-cc-testcontainer}</version>
-				<scope>test</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>eu.michael-simons.neo4j</groupId>
+			<artifactId>junit-jupiter-causal-cluster-testcontainer-extension</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.mockk</groupId>
+			<artifactId>mockk</artifactId>
+			<version>${mockk}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
@@ -267,6 +285,11 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-h2</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>
@@ -283,26 +306,18 @@
 			<artifactId>rxjava</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+			<version>${cdi}</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>javax.transaction</groupId>
 			<artifactId>jta</artifactId>
 			<version>1.1</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-r2dbc</artifactId>
-			<version>1.0.0.RELEASE</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.r2dbc</groupId>
-			<artifactId>r2dbc-h2</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.neo4j</groupId>
-			<artifactId>neo4j-cypher-dsl</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apiguardian</groupId>
@@ -312,6 +327,32 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.weld.se</groupId>
+			<artifactId>weld-se-core</artifactId>
+			<version>3.1.4.Final</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactor</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -329,8 +370,20 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.neo4j.driver</groupId>
 			<artifactId>neo4j-java-driver</artifactId>
+		</dependency>
+		<!-- Reduce scope of Lombok to test (it is defined by Spring Data Parent) -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok}</version>
+			<scope>test</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -353,29 +406,9 @@
 			<artifactId>spring-data-commons</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-stdlib-jdk8</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-reflect</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlinx</groupId>
-			<artifactId>kotlinx-coroutines-core</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlinx</groupId>
-			<artifactId>kotlinx-coroutines-reactor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>io.mockk</groupId>
-			<artifactId>mockk</artifactId>
-			<version>${mockk}</version>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-r2dbc</artifactId>
+			<version>1.0.0.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -388,39 +421,26 @@
 			<artifactId>neo4j</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>eu.michael-simons.neo4j</groupId>
-			<artifactId>junit-jupiter-causal-cluster-testcontainer-extension</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- Reduce scope of Lombok to test (it is defined by Spring Data Parent) -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>${lombok}</version>
-			<optional>true</optional>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.enterprise</groupId>
-			<artifactId>cdi-api</artifactId>
-			<version>${cdi}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.weld.se</groupId>
-			<artifactId>weld-se-core</artifactId>
-			<version>3.1.4.Final</version>
-			<scope>test</scope>
-		</dependency>
 
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-plugins-release</id>
+			<url>https://repo.spring.io/plugins-release</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-libs-milestone</id>
+			<url>https://repo.spring.io/libs-milestone</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<build>
 		<pluginManagement>
@@ -428,7 +448,7 @@
 				<plugin>
 					<groupId>com.github.ekryd.sortpom</groupId>
 					<artifactId>sortpom-maven-plugin</artifactId>
-					<version>2.8.0</version>
+					<version>2.12.0</version>
 					<executions>
 						<execution>
 							<phase>verify</phase>
@@ -444,28 +464,29 @@
 						<sortProperties>true</sortProperties>
 						<sortDependencies>groupId,artifactId</sortDependencies>
 						<createBackupFile>false</createBackupFile>
+						<expandEmptyElements>false</expandEmptyElements>
 					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>com.buschmais.jqassistant</groupId>
 					<artifactId>jqassistant-maven-plugin</artifactId>
 					<version>${jqassistant.version}</version>
-					<configuration>
-						<rulesDirectory>etc/jqassistant</rulesDirectory>
-						<skip>${skipArchitectureTests}</skip>
-					</configuration>
 					<dependencies>
-						<dependency>
-							<groupId>org.jqassistant.contrib.plugin</groupId>
-							<artifactId>jqassistant-dashboard-plugin</artifactId>
-							<version>${jqassistant-dashboard-plugin.version}</version>
-						</dependency>
 						<dependency>
 							<groupId>de.kontext-e.jqassistant.plugin</groupId>
 							<artifactId>jqassistant.plugin.git</artifactId>
 							<version>${jqassistant.version}</version>
 						</dependency>
+						<dependency>
+							<groupId>org.jqassistant.contrib.plugin</groupId>
+							<artifactId>jqassistant-dashboard-plugin</artifactId>
+							<version>${jqassistant-dashboard-plugin.version}</version>
+						</dependency>
 					</dependencies>
+					<configuration>
+						<rulesDirectory>etc/jqassistant</rulesDirectory>
+						<skip>${skipArchitectureTests}</skip>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.jacoco</groupId>
@@ -526,8 +547,8 @@
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
+						<id>verify</id>
+						<phase>verify</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>
@@ -585,7 +606,7 @@
 						</goals>
 						<configuration>
 							<rules>
-								<DependencyConvergence/>
+								<DependencyConvergence />
 								<requireMavenVersion>
 									<version>3.6.0</version>
 								</requireMavenVersion>
@@ -610,9 +631,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<configuration>
-					<skipTests>${skipIntegrationTests}</skipTests>
-				</configuration>
 				<executions>
 					<execution>
 						<goals>
@@ -621,14 +639,13 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<skipTests>${skipIntegrationTests}</skipTests>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
-				<configuration>
-					<updatePomFile>true</updatePomFile>
-					<flattenMode>resolveCiFriendliesOnly</flattenMode>
-				</configuration>
 				<executions>
 					<execution>
 						<id>flatten</id>
@@ -645,6 +662,10 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -666,6 +687,15 @@
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
 				<version>${asciidoctor-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>generate-docs</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>process-asciidoc</goal>
+						</goals>
+					</execution>
+				</executions>
 				<dependencies>
 					<dependency>
 						<groupId>org.asciidoctor</groupId>
@@ -683,24 +713,15 @@
 					<attributes>
 						<icons>font</icons>
 						<toc>left</toc>
-						<setanchors/>
-						<idprefix/>
-						<idseparator/>
+						<setanchors />
+						<idprefix />
+						<idseparator />
 					</attributes>
 					<requires>
 						<require>asciidoctor-diagram</require>
 					</requires>
 					<outputDirectory>${project.build.docs}</outputDirectory>
 				</configuration>
-				<executions>
-					<execution>
-						<id>generate-docs</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>process-asciidoc</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.buschmais.jqassistant</groupId>
@@ -745,22 +766,23 @@
 
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-plugins-release</id>
-			<url>https://repo.spring.io/plugins-release</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-libs-milestone</id>
-			<url>https://repo.spring.io/libs-milestone</url>
-		</pluginRepository>
-	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>ci</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>none</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>


### PR DESCRIPTION
Checkstyle is configured to run in the validation phase in spring-data-parent, spring-data-neo4j used to use validate as well. Also, spring-data-neo4j has checkstyle configured to check the test sources as well. The later is done in test-compile.

So checkstyle was executed indeed twice during validation, once for the sources and once for the test-compile.

This commit changes spring-data-neo4j’s configuration to run in verify, after tests ran. This makes checkstyle only run once.

For a quick look if all sources are correct, one can use ` ./mvnw checkstyle:check@verify` before running a full blown `./mvnw verify`. While the Java compiler now can flag invalid code immediate, checkstyle will discover the rest only afterwards.

While working on this a flaw in the combine.self="override" attribute was discovered: It works of course only for the maven configurational attributes, not for the checkstyle rules themselve. Therefor the `io.spring.nohttp.checkstyle.check.NoHttpCheck` has been added to the local configuration as well.

In the process of the bug fix, the sort pom plugin has been applied with the configuration as already available.