### PR TITLE
DATAGRAPH-1376 - Make DefaultNeo4jClient compatible with GraalVM native.

### DIFF
--- a/src/main/resources/META-INF/native-image/org.springframework.data/spring-data-neo4j/native-image.properties
+++ b/src/main/resources/META-INF/native-image/org.springframework.data/spring-data-neo4j/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/src/main/resources/META-INF/native-image/org.springframework.data/spring-data-neo4j/reflection-config.json
+++ b/src/main/resources/META-INF/native-image/org.springframework.data/spring-data-neo4j/reflection-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name" : "org.neo4j.driver.QueryRunner",
+    "allDeclaredMethods" : true
+  }
+]


### PR DESCRIPTION
- Remove the usage of MethodHandles
- Allow reflective access to the query runner interface.