### PR TITLE
Result of findByExample includes relationships

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0-DATAGRAPH-1384-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/support/SimpleQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/SimpleQueryByExampleExecutor.java
@@ -63,7 +63,8 @@ class SimpleQueryByExampleExecutor<T> implements QueryByExampleExecutor<T> {
 	public <S extends T> Optional<S> findOne(Example<S> example) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.build();
 
 		return this.neo4jOperations.findOne(statement, predicate.getParameters(), example.getProbeType());
@@ -73,7 +74,8 @@ class SimpleQueryByExampleExecutor<T> implements QueryByExampleExecutor<T> {
 	public <S extends T> List<S> findAll(Example<S> example) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.build();
 
 		return this.neo4jOperations.findAll(statement, predicate.getParameters(), example.getProbeType());
@@ -83,7 +85,8 @@ class SimpleQueryByExampleExecutor<T> implements QueryByExampleExecutor<T> {
 	public <S extends T> List<S> findAll(Example<S> example, Sort sort) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.orderBy(CypherAdapterUtils.toSortItems(predicate.getNeo4jPersistentEntity(), sort)).build();
 
 		return this.neo4jOperations.findAll(statement, predicate.getParameters(), example.getProbeType());
@@ -109,7 +112,8 @@ class SimpleQueryByExampleExecutor<T> implements QueryByExampleExecutor<T> {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
 		StatementBuilder.OngoingReadingAndReturn returning = predicate
-				.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk());
+				.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()));
 
 		BuildableStatement returningWithPaging = CypherAdapterUtils.addPagingParameter(predicate.getNeo4jPersistentEntity(),
 				pageable, returning);

--- a/src/main/java/org/springframework/data/neo4j/repository/support/SimpleReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/SimpleReactiveQueryByExampleExecutor.java
@@ -57,7 +57,8 @@ class SimpleReactiveQueryByExampleExecutor<T> implements ReactiveQueryByExampleE
 	public <S extends T> Mono<S> findOne(Example<S> example) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.build();
 
 		return this.neo4jOperations.findOne(statement, predicate.getParameters(), example.getProbeType());
@@ -67,7 +68,8 @@ class SimpleReactiveQueryByExampleExecutor<T> implements ReactiveQueryByExampleE
 	public <S extends T> Flux<S> findAll(Example<S> example) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.build();
 
 		return this.neo4jOperations.findAll(statement, predicate.getParameters(), example.getProbeType());
@@ -77,7 +79,8 @@ class SimpleReactiveQueryByExampleExecutor<T> implements ReactiveQueryByExampleE
 	public <S extends T> Flux<S> findAll(Example<S> example, Sort sort) {
 
 		Predicate predicate = Predicate.create(mappingContext, example);
-		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf).returning(asterisk())
+		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
+				.returning(cypherGenerator.createReturnStatementForMatch(predicate.getNeo4jPersistentEntity()))
 				.orderBy(CypherAdapterUtils.toSortItems(predicate.getNeo4jPersistentEntity(), sort)).build();
 
 		return this.neo4jOperations.findAll(statement, predicate.getParameters(), example.getProbeType());

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -1951,6 +1951,174 @@ class RepositoryIT {
 			assertThat(count).isEqualTo(1);
 		}
 
+		@Test
+		void findEntityWithRelationshipByFindOneByExample(@Autowired RelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			PersonWithRelationship loadedPerson = repository.findOne(Example.of(probe)).get();
+			assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+			assertThat(loadedPerson.getId()).isEqualTo(personId);
+			Hobby hobby = loadedPerson.getHobbies();
+			assertThat(hobby).isNotNull();
+			assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+			assertThat(hobby.getName()).isEqualTo("Music");
+
+			List<Pet> pets = loadedPerson.getPets();
+			Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+			Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+			assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+
+		}
+
+		@Test
+		void findEntityWithRelationshipByFindAllByExample(@Autowired RelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			PersonWithRelationship loadedPerson = repository.findAll(Example.of(probe)).get(0);
+			assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+			assertThat(loadedPerson.getId()).isEqualTo(personId);
+			Hobby hobby = loadedPerson.getHobbies();
+			assertThat(hobby).isNotNull();
+			assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+			assertThat(hobby.getName()).isEqualTo("Music");
+
+			List<Pet> pets = loadedPerson.getPets();
+			Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+			Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+			assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+
+		}
+
+		@Test
+		void findEntityWithRelationshipByFindAllByExampleWithSort(@Autowired RelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			PersonWithRelationship loadedPerson = repository.findAll(Example.of(probe), Sort.by("name")).get(0);
+			assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+			assertThat(loadedPerson.getId()).isEqualTo(personId);
+			Hobby hobby = loadedPerson.getHobbies();
+			assertThat(hobby).isNotNull();
+			assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+			assertThat(hobby.getName()).isEqualTo("Music");
+
+			List<Pet> pets = loadedPerson.getPets();
+			Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+			Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+			assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+
+		}
+
+		@Test
+		void findEntityWithRelationshipByFindAllByExampleWithPageable(@Autowired RelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			PersonWithRelationship loadedPerson = repository.findAll(Example.of(probe),  PageRequest.of(0, 1, Sort.by("name"))).toList().get(0);
+			assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+			assertThat(loadedPerson.getId()).isEqualTo(personId);
+			Hobby hobby = loadedPerson.getHobbies();
+			assertThat(hobby).isNotNull();
+			assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+			assertThat(hobby.getName()).isEqualTo("Music");
+
+			List<Pet> pets = loadedPerson.getPets();
+			Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+			Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+			assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+
+		}
+
 	}
 
 	@Nested

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -325,6 +325,138 @@ class ReactiveRepositoryIT {
 		}
 
 		@Test
+		void findEntityWithRelationshipByFindOneByExample(@Autowired ReactiveRelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			StepVerifier.create(repository.findOne(Example.of(probe)))
+				.assertNext(loadedPerson -> {
+					assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+					assertThat(loadedPerson.getId()).isEqualTo(personId);
+					Hobby hobby = loadedPerson.getHobbies();
+					assertThat(hobby).isNotNull();
+					assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+					assertThat(hobby.getName()).isEqualTo("Music");
+
+					List<Pet> pets = loadedPerson.getPets();
+					Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+					Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+					assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+				})
+				.verifyComplete();
+		}
+
+		@Test
+		void findEntityWithRelationshipByFindAllByExample(@Autowired ReactiveRelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			StepVerifier.create(repository.findAll(Example.of(probe)))
+				.assertNext(loadedPerson -> {
+					assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+					assertThat(loadedPerson.getId()).isEqualTo(personId);
+					Hobby hobby = loadedPerson.getHobbies();
+					assertThat(hobby).isNotNull();
+					assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+					assertThat(hobby.getName()).isEqualTo("Music");
+
+					List<Pet> pets = loadedPerson.getPets();
+					Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+					Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+					assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+				})
+				.verifyComplete();
+		}
+
+		@Test
+		void findEntityWithRelationshipByFindAllByExampleWithSort(@Autowired ReactiveRelationshipRepository repository) {
+
+			long personId;
+			long hobbyNodeId;
+			long petNode1Id;
+			long petNode2Id;
+
+			try (Session session = createSession()) {
+				Record record = session
+						.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}), "
+								+ "(n)-[:Has]->(p1:Pet{name: 'Jerry'}), (n)-[:Has]->(p2:Pet{name: 'Tom'}) " + "RETURN n, h1, p1, p2")
+						.single();
+
+				Node personNode = record.get("n").asNode();
+				Node hobbyNode1 = record.get("h1").asNode();
+				Node petNode1 = record.get("p1").asNode();
+				Node petNode2 = record.get("p2").asNode();
+
+				personId = personNode.id();
+				hobbyNodeId = hobbyNode1.id();
+				petNode1Id = petNode1.id();
+				petNode2Id = petNode2.id();
+			}
+
+			PersonWithRelationship probe = new PersonWithRelationship();
+			probe.setName("Freddie");
+			StepVerifier.create(repository.findAll(Example.of(probe), Sort.by("name")))
+				.assertNext(loadedPerson -> {
+					assertThat(loadedPerson.getName()).isEqualTo("Freddie");
+					assertThat(loadedPerson.getId()).isEqualTo(personId);
+					Hobby hobby = loadedPerson.getHobbies();
+					assertThat(hobby).isNotNull();
+					assertThat(hobby.getId()).isEqualTo(hobbyNodeId);
+					assertThat(hobby.getName()).isEqualTo("Music");
+
+					List<Pet> pets = loadedPerson.getPets();
+					Pet comparisonPet1 = new Pet(petNode1Id, "Jerry");
+					Pet comparisonPet2 = new Pet(petNode2Id, "Tom");
+					assertThat(pets).containsExactlyInAnyOrder(comparisonPet1, comparisonPet2);
+				})
+				.verifyComplete();
+		}
+
+		@Test
 		void existsById(@Autowired ReactivePersonRepository repository) {
 			StepVerifier.create(repository.existsById(id1)).expectNext(true).verifyComplete();
 		}


### PR DESCRIPTION
Currently the finder methods using `Example` do not query for the related nodes.
This commit fixes the behaviour for imperative and reactive parts of the framework.