### PR TITLE
 DATAGRAPH-1389 - Adopt to changes in Spring Data Commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0-DATAGRAPH-1389-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
@@ -35,6 +35,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Gerrit Meier
  * @author Michael J. Simons
+ * @author Mark Paluch
  * @since 6.0
  */
 class Neo4jQueryMethod extends QueryMethod {
@@ -59,7 +60,7 @@ class Neo4jQueryMethod extends QueryMethod {
 	}
 
 	boolean isCollectionLikeQuery() {
-		return super.isCollectionQuery() || super.isStreamQuery();
+		return isCollectionQuery() || isStreamQuery();
 	}
 
 	/**


### PR DESCRIPTION
Check for collection-like return types in `ReactiveNeo4jQueryMethod` to determine whether the defined method return type is multi-valued. Also, make sure to call the overridden methods instead of defaulting to the superclass implementation.

Enable reusable testcontainers to reduce build time from ~ 8 minutes to ~ 3 minutes. Use a manual container lifecycle to avoid closing the container by the test so Ryuk takes care of the shutdown when the reuse feature isn't enabled via `~/.testcontainers.properties` (`testcontainers.reuse.enable=true`).

- DATAGRAPH-1389 - Prepare issue branch.
- DATAGRAPH-1389 - Adopt to changes in Spring Data Commons.
- DATAGRAPH-1389 - Polishing.
