### PR TITLE
Support for TargetNode in constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0-DATAGRAPH-1395-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -238,7 +238,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			Collection<RelationshipDescription> relationships = concreteNodeDescription.getRelationships();
 
 			ET instance = instantiate(concreteNodeDescription, queryResult, knownObjects, relationships,
-					nodeDescriptionAndLabels.getDynamicLabels(), processedSegments);
+					nodeDescriptionAndLabels.getDynamicLabels(), lastMappedEntity, processedSegments);
 
 			PersistentPropertyAccessor<ET> propertyAccessor = concreteNodeDescription.getPropertyAccessor(instance);
 
@@ -294,7 +294,8 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 	}
 
 	private <ET> ET instantiate(Neo4jPersistentEntity<ET> nodeDescription, MapAccessor values, KnownObjects knownObjects,
-			Collection<RelationshipDescription> relationships, Collection<String> surplusLabels, Set<Path.Segment> processedSegments) {
+			Collection<RelationshipDescription> relationships, Collection<String> surplusLabels, Object lastMappedEntity,
+								Set<Path.Segment> processedSegments) {
 
 		ParameterValueProvider<Neo4jPersistentProperty> parameterValueProvider = new ParameterValueProvider<Neo4jPersistentProperty>() {
 			@Override
@@ -306,6 +307,8 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 					return createInstanceOfRelationships(matchingProperty, values, knownObjects, relationships, processedSegments).orElse(null);
 				} else if (matchingProperty.isDynamicLabels()) {
 					return createDynamicLabelsProperty(matchingProperty.getTypeInformation(), surplusLabels);
+				} else if (matchingProperty.isEntity() && matchingProperty.isEntityInRelationshipWithProperties()) {
+					return lastMappedEntity;
 				}
 				return conversionService.readValue(extractValueOf(matchingProperty, values), parameter.getType(), matchingProperty.getOptionalReadingConverter());
 			}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -307,7 +307,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 					return createInstanceOfRelationships(matchingProperty, values, knownObjects, relationships, processedSegments).orElse(null);
 				} else if (matchingProperty.isDynamicLabels()) {
 					return createDynamicLabelsProperty(matchingProperty.getTypeInformation(), surplusLabels);
-				} else if (matchingProperty.isEntity() && matchingProperty.isEntityInRelationshipWithProperties()) {
+				} else if (matchingProperty.isEntityInRelationshipWithProperties()) {
 					return lastMappedEntity;
 				}
 				return conversionService.readValue(extractValueOf(matchingProperty, values), parameter.getType(), matchingProperty.getOptionalReadingConverter());

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -46,7 +46,6 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 	private final Lazy<String> graphPropertyName;
 	private final Lazy<Boolean> isAssociation;
-	private final boolean isEntityInRelationshipWithProperties;
 
 	private final Neo4jMappingContext mappingContext;
 
@@ -60,11 +59,9 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 	 * @param simpleTypeHolder type holder
 	 */
 	DefaultNeo4jPersistentProperty(Property property, PersistentEntity<?, Neo4jPersistentProperty> owner,
-			Neo4jMappingContext mappingContext, SimpleTypeHolder simpleTypeHolder,
-			boolean isEntityInRelationshipWithProperties) {
+			Neo4jMappingContext mappingContext, SimpleTypeHolder simpleTypeHolder) {
 
 		super(property, owner, simpleTypeHolder);
-		this.isEntityInRelationshipWithProperties = isEntityInRelationshipWithProperties;
 		this.mappingContext = mappingContext;
 
 		this.graphPropertyName = Lazy.of(this::computeGraphPropertyName);
@@ -183,7 +180,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 	@Override
 	public boolean isEntity() {
-		return super.isEntity() && isAssociation() || (super.isEntity() && isEntityInRelationshipWithProperties() && !isComposite());
+		return super.isEntity() && isAssociation() || (isEntityInRelationshipWithProperties() && !isComposite());
 	}
 
 	private static Function<Object, Value> nullSafeWrite(Function<Object, Value> delegate) {
@@ -206,7 +203,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 	@Override
 	public boolean isEntityInRelationshipWithProperties() {
-		return isEntityInRelationshipWithProperties;
+		return super.isEntity() && ((Neo4jPersistentEntity<?>) getOwner()).isRelationshipPropertiesEntity();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
@@ -194,7 +194,7 @@ public final class Neo4jMappingContext extends AbstractMappingContext<Neo4jPersi
 	protected Neo4jPersistentProperty createPersistentProperty(Property property, Neo4jPersistentEntity<?> owner,
 			SimpleTypeHolder simpleTypeHolder) {
 
-		return new DefaultNeo4jPersistentProperty(property, owner, this, simpleTypeHolder, owner.isRelationshipPropertiesEntity());
+		return new DefaultNeo4jPersistentProperty(property, owner, this, simpleTypeHolder);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/schema/GeneratedValue.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/GeneratedValue.java
@@ -78,7 +78,6 @@ public @interface GeneratedValue {
 	 * This generator is automatically applied when a field of type {@link java.util.UUID} is annotated with
 	 * {@link Id @Id} and {@link GeneratedValue @GeneratedValue}.
 	 *
-	 * @since 6.0.1
 	 */
 	final class UUIDGenerator implements IdGenerator<UUID> {
 

--- a/src/main/kotlin/org/springframework/data/neo4j/core/cypher/Parameters.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/cypher/Parameters.kt
@@ -24,7 +24,7 @@ package org.springframework.data.neo4j.core.cypher
  * @author Michael J. Simons
  * @since 6.0
  */
-inline fun String.asParam() = "\$" + this
+fun String.asParam() = "\$" + this
 
 /**
  * Extension on [String]'s companion object returning the string passed to it prefixed with an escaped `$`.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -182,7 +182,8 @@ class RepositoryIT {
 			transaction.run("CREATE (n:PersonWithNoConstructor) SET n.name = $name, n.first_name = $firstName",
 					Values.parameters("name", TEST_PERSON1_NAME, "firstName", TEST_PERSON1_FIRST_NAME));
 			transaction.run("CREATE (n:PersonWithWither) SET n.name = '" + TEST_PERSON1_NAME + "'");
-			transaction.run("CREATE (n:KotlinPerson) SET n.name = '" + TEST_PERSON1_NAME + "'");
+			transaction.run("CREATE (n:KotlinPerson), "
+					+ " (n)-[:WORKS_IN{since: 2019}]->(:KotlinClub{name: 'Golf club'}) SET n.name = '" + TEST_PERSON1_NAME + "'");
 			transaction.run("CREATE (a:Thing {theId: 'anId', name: 'Homer'})-[:Has]->(b:Thing2{theId: 4711, name: 'Bart'})");
 
 			IntStream.rangeClosed(1, 20)
@@ -1087,7 +1088,7 @@ class RepositoryIT {
 			club.setName("BlubbClub");
 			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002, club);
 			PersonWithRelationshipWithProperties person =
-					new PersonWithRelationshipWithProperties(null, "Freddie clone", hobbies, worksInClub);
+					new PersonWithRelationshipWithProperties("Freddie clone", hobbies, worksInClub);
 
 			// when
 			PersonWithRelationshipWithProperties shouldBeDifferentPerson = repository.save(person);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -1080,16 +1080,14 @@ class RepositoryIT {
 			rel2.setHobby(h2);
 
 			List<LikesHobbyRelationship> hobbies = new ArrayList<>();
-			PersonWithRelationshipWithProperties person = new PersonWithRelationshipWithProperties("Freddie clone");
 			hobbies.add(rel1);
 			hobbies.add(rel2);
-			person.setHobbies(hobbies);
 
-			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002);
 			Club club = new Club();
 			club.setName("BlubbClub");
-			worksInClub.setClub(club);
-			person.setClub(worksInClub);
+			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002, club);
+			PersonWithRelationshipWithProperties person =
+					new PersonWithRelationshipWithProperties(null, "Freddie clone", hobbies, worksInClub);
 
 			// when
 			PersonWithRelationshipWithProperties shouldBeDifferentPerson = repository.save(person);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
@@ -94,13 +94,13 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 	@Query("MATCH (n:PersonWithWither{name:'Test'}) return n")
 	Optional<PersonWithWither> getOptionalPersonWithWitherViaQuery();
 
-	@Query("MATCH (n:KotlinPerson) return n")
+	@Query("MATCH (n:KotlinPerson)-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
 	List<KotlinPerson> getAllKotlinPersonsViaQuery();
 
-	@Query("MATCH (n:KotlinPerson{name:'Test'}) return n")
+	@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
 	KotlinPerson getOneKotlinPersonViaQuery();
 
-	@Query("MATCH (n:KotlinPerson{name:'Test'}) return n")
+	@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
 	Optional<KotlinPerson> getOptionalKotlinPersonViaQuery();
 
 	// Derived finders, should be extracted into another repo.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -1062,7 +1062,7 @@ class ReactiveRepositoryIT {
 			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002, club);
 
 			PersonWithRelationshipWithProperties person =
-					new PersonWithRelationshipWithProperties(null, "Freddie clone", hobbies, worksInClub);
+					new PersonWithRelationshipWithProperties("Freddie clone", hobbies, worksInClub);
 
 			// when
 			Mono<PersonWithRelationshipWithProperties> operationUnderTest = repository.save(person);

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -1056,14 +1056,13 @@ class ReactiveRepositoryIT {
 			List<LikesHobbyRelationship> hobbies = new ArrayList<>();
 			hobbies.add(rel1);
 			hobbies.add(rel2);
-			PersonWithRelationshipWithProperties person = new PersonWithRelationshipWithProperties("Freddie clone");
-			person.setHobbies(hobbies);
 
-			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002);
 			Club club = new Club();
 			club.setName("BlubbClub");
-			worksInClub.setClub(club);
-			person.setClub(worksInClub);
+			WorksInClubRelationship worksInClub = new WorksInClubRelationship(2002, club);
+
+			PersonWithRelationshipWithProperties person =
+					new PersonWithRelationshipWithProperties(null, "Freddie clone", hobbies, worksInClub);
 
 			// when
 			Mono<PersonWithRelationshipWithProperties> operationUnderTest = repository.save(person);

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
@@ -16,8 +16,8 @@
 package org.springframework.data.neo4j.integration.shared;
 
 import java.util.List;
-import java.util.Set;
 
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
@@ -30,20 +30,24 @@ import org.springframework.data.neo4j.core.schema.Relationship;
 @Node
 public class PersonWithRelationshipWithProperties {
 
-	@Id @GeneratedValue private Long id;
+	@Id @GeneratedValue private final Long id;
 
 	private final String name;
 
-	@Relationship("LIKES") private List<LikesHobbyRelationship> hobbies;
+	@Relationship("LIKES") private final List<LikesHobbyRelationship> hobbies;
 
-	@Relationship("WORKS_IN") private WorksInClubRelationship club;
+	@Relationship("WORKS_IN") private final WorksInClubRelationship club;
 
 	@Relationship("OWNS") private Set<Pet> pets;
 
 	@Relationship("OWNS") private List<ClubRelationship> clubs;
 
-	public PersonWithRelationshipWithProperties(String name) {
+	@PersistenceConstructor
+	public PersonWithRelationshipWithProperties(Long id, String name, List<LikesHobbyRelationship> hobbies, WorksInClubRelationship club) {
+		this.id = id;
 		this.name = name;
+		this.hobbies = hobbies;
+		this.club = club;
 	}
 
 	public String getName() {
@@ -52,14 +56,6 @@ public class PersonWithRelationshipWithProperties {
 
 	public List<LikesHobbyRelationship> getHobbies() {
 		return hobbies;
-	}
-
-	public void setHobbies(List<LikesHobbyRelationship> hobbies) {
-		this.hobbies = hobbies;
-	}
-
-	public void setClub(WorksInClubRelationship club) {
-		this.club = club;
 	}
 
 	public WorksInClubRelationship getClub() {

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
@@ -30,7 +30,7 @@ import org.springframework.data.neo4j.core.schema.Relationship;
 @Node
 public class PersonWithRelationshipWithProperties {
 
-	@Id @GeneratedValue private final Long id;
+	@Id @GeneratedValue private Long id;
 
 	private final String name;
 
@@ -48,6 +48,16 @@ public class PersonWithRelationshipWithProperties {
 		this.name = name;
 		this.hobbies = hobbies;
 		this.club = club;
+	}
+
+	public PersonWithRelationshipWithProperties(String name, List<LikesHobbyRelationship> hobbies, WorksInClubRelationship club) {
+		this.name = name;
+		this.hobbies = hobbies;
+		this.club = club;
+	}
+
+	public PersonWithRelationshipWithProperties withId(Long newId) {
+		return new PersonWithRelationshipWithProperties(newId, this.name, this.hobbies, this.club);
 	}
 
 	public String getName() {

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/PersonWithRelationshipWithProperties.java
@@ -16,6 +16,7 @@
 package org.springframework.data.neo4j.integration.shared;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
@@ -26,6 +27,7 @@ import org.springframework.data.neo4j.core.schema.Relationship;
 /**
  * @author Gerrit Meier
  * @author Philipp Tölle
+ * @author Michael J. Simons
  */
 @Node
 public class PersonWithRelationshipWithProperties {

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/WorksInClubRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/WorksInClubRelationship.java
@@ -27,10 +27,11 @@ public class WorksInClubRelationship {
 	private final Integer since;
 
 	@TargetNode
-	private Club club;
+	private final Club club;
 
-	public WorksInClubRelationship(Integer since) {
+	public WorksInClubRelationship(Integer since, Club club) {
 		this.since = since;
+		this.club = club;
 	}
 
 	public Integer getSince() {
@@ -39,9 +40,5 @@ public class WorksInClubRelationship {
 
 	public Club getClub() {
 		return club;
-	}
-
-	public void setClub(Club club) {
-		this.club = club;
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensionsTest.kt
@@ -49,6 +49,7 @@ class Neo4jClientExtensionsTest {
 
         val runnableSpec = mockk<Neo4jClient.RunnableSpecTightToDatabase>(relaxed = true)
 
+        @Suppress("UNUSED_VARIABLE")
         val mappingSpec: KRecordFetchSpec<String> =
                 runnableSpec.mappedBy { _, _ -> "Foo" }
 

--- a/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensionsTest.kt
@@ -57,6 +57,7 @@ class ReactiveNeo4jClientExtensionsTest {
 
         val runnableSpec = mockk<ReactiveNeo4jClient.RunnableSpecTightToDatabase>(relaxed = true)
 
+        @Suppress("UNUSED_VARIABLE")
         val mappingSpec: ReactiveNeo4jClient.MappingSpec<String> = runnableSpec.fetchAs()
 
         verify(exactly = 1) { runnableSpec.fetchAs(String::class.java) }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
@@ -65,7 +65,7 @@ class ImmutableRelationshipsIT @Autowired constructor(
         assertThat(device.phoneNumber).isEqualTo("some number")
 
         assertThat(device.location!!.latitude).isEqualTo(20.0)
-        assertThat(device.location!!.longitude).isEqualTo(20.0)
+        assertThat(device.location.longitude).isEqualTo(20.0)
     }
 
     @Test
@@ -84,9 +84,9 @@ class ImmutableRelationshipsIT @Autowired constructor(
         assertThat(device.phoneNumber).isEqualTo("some number")
 
         assertThat(device.location!!.latitude).isEqualTo(10.0)
-        assertThat(device.location!!.longitude).isEqualTo(20.0)
-        assertThat(device.location!!.previousLocation!!.latitude).isEqualTo(30.0)
-        assertThat(device.location!!.previousLocation!!.longitude).isEqualTo(40.0)
+        assertThat(device.location.longitude).isEqualTo(20.0)
+        assertThat(device.location.previousLocation!!.latitude).isEqualTo(30.0)
+        assertThat(device.location.previousLocation.longitude).isEqualTo(40.0)
     }
 
     @Test

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/KotlinPerson.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/KotlinPerson.kt
@@ -16,12 +16,17 @@
 
 package org.springframework.data.neo4j.integration.shared
 
-import org.springframework.data.neo4j.core.schema.GeneratedValue
-import org.springframework.data.neo4j.core.schema.Id
-import org.springframework.data.neo4j.core.schema.Node
+import org.springframework.data.neo4j.core.schema.*
 
 /**
  * @author Gerrit Meier
  */
 @Node
-data class KotlinPerson(@Id @GeneratedValue val id: Long, val name: String)
+data class KotlinPerson(@Id @GeneratedValue val id: Long, val name: String,
+                        @Relationship("WORKS_IN") val clubs:List<KotlinClubRelationship>)
+
+@RelationshipProperties
+data class KotlinClubRelationship(val since: Int, @TargetNode val club: KotlinClub)
+
+@Node
+data class KotlinClub(@Id @GeneratedValue val id: Long, val name: String)

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/KotlinPerson.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/KotlinPerson.kt
@@ -16,10 +16,16 @@
 
 package org.springframework.data.neo4j.integration.shared
 
-import org.springframework.data.neo4j.core.schema.*
+import org.springframework.data.neo4j.core.schema.GeneratedValue
+import org.springframework.data.neo4j.core.schema.Id
+import org.springframework.data.neo4j.core.schema.Node
+import org.springframework.data.neo4j.core.schema.Relationship
+import org.springframework.data.neo4j.core.schema.RelationshipProperties
+import org.springframework.data.neo4j.core.schema.TargetNode
 
 /**
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 @Node
 data class KotlinPerson(@Id @GeneratedValue val id: Long, val name: String,


### PR DESCRIPTION
There was a limitation in the relationship properties mapping when it came to mapping the related entity as a constructor parameter in the `@RelationshipProperties` class.