### PR TITLE
DATAGRAPH-1400 - Use the correct domain type before creating DTO projections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0-DATAGRAPH-1400-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,8 @@
 		<skipUnitTests>${skipTests}</skipUnitTests>
 		<springdata.commons>2.4.0-SNAPSHOT</springdata.commons>
 		<testcontainers.version>1.13.0</testcontainers.version>
+
+		<spring-data-commons-docs.dir>../../../../../spring-data-commons/src/main/asciidoc</spring-data-commons-docs.dir>
 	</properties>
 
 	<dependencyManagement>
@@ -716,6 +718,7 @@
 						<setanchors/>
 						<idprefix/>
 						<idseparator/>
+						<spring-data-commons-docs>${spring-data-commons-docs.dir}</spring-data-commons-docs>
 					</attributes>
 					<requires>
 						<require>asciidoctor-diagram</require>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -19,12 +19,12 @@ endif::[]
 
 include::{manualIncludeDir}/README.adoc[tags=properties]
 
-:gh-base: https://github.com/neo4j/SDN
+:gh-base: https://github.com/spring-projects/spring-data-neo4j
 :java-driver-starter-href: https://github.com/neo4j/neo4j-java-driver-spring-boot-starter
-:springVersion: 5.2.0.RELEASE
+:springVersion: 5.3.0-RC1
 :spring-framework-docs: https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference
 :spring-framework-javadoc: https://docs.spring.io/spring/docs/{springVersion}/javadoc-api
-:spring-data-commons-docs: ../../../../../other-spring-data/spring-data-commons/src/main/asciidoc
+:spring-data-commons-docs: ../../../../../spring-data-commons/src/main/asciidoc
 
 (C) 2008-2020 The original authors.
 
@@ -52,6 +52,8 @@ include::getting-started/index.adoc[]
 include::object-mapping/index.adoc[]
 
 include::{spring-data-commons-docs}/repository-projections.adoc[leveloffset=+1]
+
+include::object-mapping/projections.adoc[leveloffset=+1,lines=5..]
 
 include::testing/index.adoc[]
 

--- a/src/main/asciidoc/object-mapping/projections.adoc
+++ b/src/main/asciidoc/object-mapping/projections.adoc
@@ -1,0 +1,136 @@
+[[projections]]
+= Projections
+
+[[projections.general-remarks]]
+== General remarks
+
+As stated above, projections come in two flavors: Interface and DTO based projections.
+In Spring Data Neo4j both types of projections have a direct influence which properties and relationships are transferred
+over the wire.
+Therefore, both approaches can reduce the load on your database in case you are dealing with nodes and entities containing
+lots of properties which might not be needed in all usage scenarios in your application.
+
+For both interface and DTO based projections, Spring Data Neo4j will use the repository's domain type for building the
+query. All annotations on all attributes that might change the query will be taken in consideration.
+The domain type is the type that has been defined through the repository declaration
+(Given a declaration like `interface TestRepository extends CrudRepository<TestEntity, Long>` the domain type would be
+`TestEntity`).
+
+Interface based projections will always be dynamic proxies to the underlying domain type. The names of the accessors defined
+on such interfaces (like `getName`) must resolve to properties (here: `name`) that are present on the projected entity.
+Whether those properties have accessors or not on the domain type is not relevant, as long as they can be accessed through
+the common Spring Data infrastructure. The later is ensure already, as the domain type wouldn't be a persistent entity in
+the first place.
+
+DTO based projections are somewhat more flexible when used with custom queries. While the standard query is derived from
+the original domain type and therefore only the properties and relationship beeing defined there can be used, custom queries
+can add additional properties.
+
+The rules are as follows: First, the properties of the domain type are used to populate the DTO. In case the DTO declare
+additional properties - via accessors or fields - Spring Data Neo4j looks in the resulting record for matching properties.
+Properties must match exactly by name and can be of simple types (as defined in `org.springframework.data.neo4j.core.convert.Neo4jSimpleTypes`)
+or of known persistent entites. Collections of those are supported, but no maps.
+
+=== A full example
+
+Given the following entities, projections and the corresponding repository:
+
+[[projections.simple-entity]]
+[source,java]
+.A simple entity
+----
+import org.springframework.data.neo4j.core.schema.Property;@Node
+class TestEntity {
+    @Id @GeneratedValue private Long id;
+
+    private String name;
+
+    @Property("a_property") // <.>
+    private String aProperty;
+}
+----
+<.> This property has a different name in the Graph
+
+[[projections.simple-entity-extended]]
+[source,java]
+.A derived entity, inheriting from `TestEntity`
+----
+@Node
+class ExtendedTestEntity extends TestEntity {
+
+    private String otherAttribute;
+}
+----
+
+[[projections.simple-entity-interface-projected]]
+[source,java]
+.Interface projection of `TestEntity`
+----
+interface TestEntityInterfaceProjection {
+
+    String getName();
+}
+----
+
+[[projections.simple-entity-dto-projected]]
+[source,java]
+.DTO projection of `TestEntity`, including one additional attribute
+----
+class TestEntityDTOProjection {
+
+    private String name;
+
+    private Long numberOfRelations; // <.>
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getNumberOfRelations() {
+        return numberOfRelations;
+    }
+
+    public void setNumberOfRelations(Long numberOfRelations) {
+        this.numberOfRelations = numberOfRelations;
+    }
+}
+----
+<.> This attribute doesn't exist on the projected entity
+
+A repository for `TestEntity` is shown below and it will behave as explained with the listing.
+
+[[projections.simple-entity-repository]]
+[source,java]
+.A repository for the `TestEntity`
+----
+interface TestRepository extends CrudRepository<TestEntity, Long> { // <.>
+
+    List<TestEntity> findAll(); // <.>
+
+    List<ExtendedTestEntity> findAllExtendedEntites(); // <.>
+
+    List<TestEntityInterfaceProjection> findAllInterfaceProjections(); // <.>
+
+    List<TestEntityDTOProjection> findAllDTOProjections(); // <.>
+
+    @Query("MATCH (t:TestEntity) - [r:RELATED_TO] -> () RETURN t, COUNT(r) AS numberOfRelations") // <.>
+    List<TestEntityDTOProjection> findAllDTOProjectionsWithCustomQuery();
+}
+----
+<.> The domain type of the repository is `TestEntity`
+<.> Methods returning one or more `TestEntity` will just return instances of it, as it matches the domain type
+<.> Methods returning one or more instances of class that extend the domain type will just return instances
+    of the extending class. The domain type of the method in question will the extended class, which
+    still satifies the domain type of the repository itself
+<.> This method returns an interface projection, the return type of the method is therefore different
+    from the repository's domain type. The interface can only access properties defined in the domain type
+<.> This method returns a DTO projection. Executing it will cause SDN to issue a warning, as the DTO defines
+    `numberOfRelations` as additional attribute, which is not in the contract of the domain type.
+    The annotated attribute `aProperty` in `TestEntity` will be correctly translated to `a_property` in the query.
+    As above, the return type is different from the repositories domain type.
+<.> This method also returns a DTO projection. However, no warning will be issued, as the query contains a fitting
+    value for the additional attributes defined in the projection.

--- a/src/main/asciidoc/object-mapping/projections.adoc
+++ b/src/main/asciidoc/object-mapping/projections.adoc
@@ -39,7 +39,7 @@ Given the following entities, projections and the corresponding repository:
 [source,java]
 .A simple entity
 ----
-import org.springframework.data.neo4j.core.schema.Property;@Node
+@Node
 class TestEntity {
     @Id @GeneratedValue private Long id;
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.core.mapping;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +34,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.commons.logging.LogFactory;
-import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.MapAccessor;
@@ -86,19 +86,20 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 	}
 
 	@Override
-	public <R> R read(Class<R> targetType, Record record) {
+	public <R> R read(Class<R> targetType, MapAccessor mapAccessor) {
 
 		Neo4jPersistentEntity<R> rootNodeDescription = (Neo4jPersistentEntity) nodeDescriptionStore
 				.getNodeDescription(targetType);
 
 		try {
-			List<Value> recordValues = record.values();
+			Iterable<Value> recordValues = mapAccessor instanceof Value && ((Value) mapAccessor).hasType(typeSystem.NODE()) ?
+					Collections.singletonList((Value) mapAccessor) : mapAccessor.values();
 			String nodeLabel = rootNodeDescription.getPrimaryLabel();
 			MapAccessor queryRoot = null;
 			for (Value value : recordValues) {
 				if (value.hasType(typeSystem.NODE()) && value.asNode().hasLabel(nodeLabel)) {
-					if (recordValues.size() > 1) {
-						queryRoot = mergeRootNodeWithRecord(value.asNode(), record);
+					if (mapAccessor.size() > 1) {
+						queryRoot = mergeRootNodeWithRecord(value.asNode(), mapAccessor);
 					} else {
 						queryRoot = value.asNode();
 					}
@@ -115,14 +116,12 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			}
 
 			if (queryRoot == null) {
-				log.warn(() -> String.format("Could not find mappable nodes or relationships inside %s for %s", record,
-						rootNodeDescription));
-				return null; // todo should not be null because of the @nonnullapi annotation in the EntityReader. Fail?
+				throw new MappingException(String.format("Could not find mappable nodes or relationships inside %s for %s", mapAccessor, rootNodeDescription));
 			} else {
 				return map(queryRoot, rootNodeDescription, new KnownObjects(), new HashSet<>());
 			}
 		} catch (Exception e) {
-			throw new MappingException("Error mapping " + record.toString(), e);
+			throw new MappingException("Error mapping " + mapAccessor.toString(), e);
 		}
 	}
 
@@ -185,7 +184,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 	 * @param record Record that should be merged
 	 * @return
 	 */
-	private static MapAccessor mergeRootNodeWithRecord(Node node, Record record) {
+	private static MapAccessor mergeRootNodeWithRecord(Node node, MapAccessor record) {
 		Map<String, Object> mergedAttributes = new HashMap<>(node.size() + record.size() + 1);
 
 		mergedAttributes.put(Constants.NAME_OF_INTERNAL_ID, node.id());

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -68,22 +68,19 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 
 	private static final LogAccessor log = new LogAccessor(LogFactory.getLog(DefaultNeo4jEntityConverter.class));
 
-	/**
-	 * The shared entity instantiators of this context. Those should not be recreated for each entity or even not for each
-	 * query, as otherwise the cache of Spring's org.springframework.data.convert.ClassGeneratingEntityInstantiator won't
-	 * apply
-	 */
-	private static final EntityInstantiators INSTANTIATORS = new EntityInstantiators();
-
+	private final EntityInstantiators entityInstantiators;
 	private final NodeDescriptionStore nodeDescriptionStore;
 	private final Neo4jConversionService conversionService;
 
 	private TypeSystem typeSystem;
 
-	DefaultNeo4jEntityConverter(Neo4jConversionService conversionService, NodeDescriptionStore nodeDescriptionStore) {
+	DefaultNeo4jEntityConverter(EntityInstantiators entityInstantiators, Neo4jConversionService conversionService, NodeDescriptionStore nodeDescriptionStore) {
 
+		Assert.notNull(entityInstantiators, "EntityInstantiators must not be null!");
 		Assert.notNull(conversionService, "Neo4jConversionService must not be null!");
+		Assert.notNull(nodeDescriptionStore, "NodeDescriptionStore must not be null!");
 
+		this.entityInstantiators = entityInstantiators;
 		this.conversionService = conversionService;
 		this.nodeDescriptionStore = nodeDescriptionStore;
 	}
@@ -314,7 +311,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			}
 		};
 
-		return INSTANTIATORS.getInstantiatorFor(nodeDescription).createInstance(nodeDescription, parameterValueProvider);
+		return entityInstantiators.getInstantiatorFor(nodeDescription).createInstance(nodeDescription, parameterValueProvider);
 	}
 
 	private PropertyHandler<Neo4jPersistentProperty> populateFrom(MapAccessor queryResult,

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Statement;

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/RecordMapAccessor.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/RecordMapAccessor.java
@@ -77,4 +77,9 @@ final class RecordMapAccessor implements MapAccessor {
 	public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
 		return this.delegate.asMap(mapFunction);
 	}
+
+	@Override
+	public String toString() {
+		return this.delegate.toString();
+	}
 }

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/RecordMapAccessor.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/RecordMapAccessor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.mapping;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.types.MapAccessor;
+
+/**
+ * A shim to adapt between {@link Record} (respectively {@link org.neo4j.driver.types.MapAccessorWithDefaultValue}
+ * and {@link MapAccessor}.
+ *
+ * @author Michael J. Simons
+ * @soundtrack The Prodigy - Music For The Jilted Generation
+ */
+final class RecordMapAccessor implements MapAccessor {
+
+	private final Record delegate;
+
+	RecordMapAccessor(Record delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Iterable<String> keys() {
+		return this.delegate.keys();
+	}
+
+	@Override
+	public boolean containsKey(String key) {
+		return this.delegate.containsKey(key);
+	}
+
+	@Override
+	public Value get(String key) {
+		return this.delegate.get(key);
+	}
+
+	@Override
+	public int size() {
+		return this.delegate.size();
+	}
+
+	@Override
+	public Iterable<Value> values() {
+		return this.delegate.values();
+	}
+
+	@Override
+	public <T> Iterable<T> values(Function<Value, T> mapFunction) {
+		return this.delegate.values().stream().map(mapFunction).collect(Collectors.toList());
+	}
+
+	@Override
+	public Map<String, Object> asMap() {
+		return this.delegate.asMap();
+	}
+
+	@Override
+	public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
+		return this.delegate.asMap(mapFunction);
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
@@ -92,7 +92,7 @@ public interface Schema {
 		if (nodeDescription == null) {
 			throw new UnknownEntityException(targetClass);
 		}
-		return (typeSystem, record) -> getEntityConverter().read(targetClass, record);
+		return (typeSystem, record) -> getEntityConverter().read(targetClass, new RecordMapAccessor(record));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
@@ -80,8 +80,8 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 			DtoInstantiatingConverter converter = new DtoInstantiatingConverter(returnedType.getReturnedType(), mappingContext);
 
 			// Neo4jQuerySupport ensure we will get an EntityInstanceWithSource in the projecting case
-			preparingConverter = source -> OptionalUnwrappingConverter.INSTANCE.convert(
-					converter.convert((EntityInstanceWithSource) source));
+			preparingConverter = source -> converter.convert(
+					(EntityInstanceWithSource) OptionalUnwrappingConverter.INSTANCE.convert(source));
 		}
 
 		Object processedResult = resultProcessor.processResult(rawResult, preparingConverter);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
@@ -68,7 +68,7 @@ class DtoInstantiatingConverter implements Converter<EntityInstanceWithSource, O
 	public Object convert(EntityInstanceWithSource entityInstanceAndSource) {
 
 		final Object entityInstance = entityInstanceAndSource.getEntityInstance();
-		if (targetType.isInterface()) {
+		if (targetType.isInterface() || targetType.isInstance(entityInstance)) {
 			return entityInstance;
 		}
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.query;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.PreferredConstructor.Parameter;
+import org.springframework.data.mapping.SimplePropertyHandler;
+import org.springframework.data.mapping.model.ParameterValueProvider;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Converter} to instantiate DTOs from fully equipped domain objects.
+ * The original idea of this converter and it's usage is to be found in Spring Data Mongo. Thanks to the original
+ * authors Oliver Drotbohm and Mark Paluch.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Gustavo Santaolalla - The Last Of Us
+ */
+class DtoInstantiatingConverter implements Converter<Object, Object> {
+
+	private final Class<?> targetType;
+	private final Neo4jMappingContext context;
+
+	/**
+	 * Creates a new {@link Converter} to instantiate DTOs.
+	 *
+	 * @param dtoType must not be {@literal null}.
+	 * @param context must not be {@literal null}.
+	 */
+	DtoInstantiatingConverter(Class<?> dtoType, Neo4jMappingContext context) {
+
+		Assert.notNull(dtoType, "DTO type must not be null!");
+		Assert.notNull(context, "MappingContext must not be null!");
+
+		this.targetType = dtoType;
+		this.context = context;
+	}
+
+	@Override
+	public Object convert(Object source) {
+
+		if (targetType.isInterface()) {
+			return source;
+		}
+
+		final PersistentEntity<?, ?> sourceEntity = context.getRequiredPersistentEntity(source.getClass());
+		final PersistentPropertyAccessor sourceAccessor = sourceEntity.getPropertyAccessor(source);
+		final PersistentEntity<?, ?> targetEntity = context.getRequiredPersistentEntity(targetType);
+		final PreferredConstructor<?, ? extends PersistentProperty<?>> constructor = targetEntity
+				.getPersistenceConstructor();
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		Object dto = context.getInstantiatorFor(targetEntity)
+				.createInstance(targetEntity, new ParameterValueProvider() {
+
+					@Override
+					public Object getParameterValue(Parameter parameter) {
+						return sourceAccessor.getProperty(sourceEntity.getPersistentProperty(parameter.getName()));
+					}
+				});
+
+		final PersistentPropertyAccessor dtoAccessor = targetEntity.getPropertyAccessor(dto);
+
+		targetEntity.doWithProperties((SimplePropertyHandler) property -> {
+
+			if (constructor.isConstructorParameter(property)) {
+				return;
+			}
+
+			dtoAccessor.setProperty(property,
+					sourceAccessor.getProperty(sourceEntity.getPersistentProperty(property.getName())));
+		});
+
+		return dto;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
@@ -67,15 +67,15 @@ class DtoInstantiatingConverter implements Converter<EntityInstanceWithSource, O
 	@Override
 	public Object convert(EntityInstanceWithSource entityInstanceAndSource) {
 
-		final Object entityInstance = entityInstanceAndSource.getEntityInstance();
+		Object entityInstance = entityInstanceAndSource.getEntityInstance();
 		if (targetType.isInterface() || targetType.isInstance(entityInstance)) {
 			return entityInstance;
 		}
 
-		final PersistentEntity<?, ?> sourceEntity = context.getRequiredPersistentEntity(entityInstance.getClass());
-		final PersistentPropertyAccessor sourceAccessor = sourceEntity.getPropertyAccessor(entityInstance);
-		final PersistentEntity<?, ?> targetEntity = context.getRequiredPersistentEntity(targetType);
-		final PreferredConstructor<?, ? extends PersistentProperty<?>> constructor = targetEntity
+		PersistentEntity<?, ?> sourceEntity = context.getRequiredPersistentEntity(entityInstance.getClass());
+		PersistentPropertyAccessor sourceAccessor = sourceEntity.getPropertyAccessor(entityInstance);
+		PersistentEntity<?, ?> targetEntity = context.getRequiredPersistentEntity(targetType);
+		PreferredConstructor<?, ? extends PersistentProperty<?>> constructor = targetEntity
 				.getPersistenceConstructor();
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -93,7 +93,7 @@ class DtoInstantiatingConverter implements Converter<EntityInstanceWithSource, O
 					}
 				});
 
-		final PersistentPropertyAccessor dtoAccessor = targetEntity.getPropertyAccessor(dto);
+		PersistentPropertyAccessor dtoAccessor = targetEntity.getPropertyAccessor(dto);
 		targetEntity.doWithProperties((SimplePropertyHandler) property -> {
 
 			if (constructor.isConstructorParameter(property)) {
@@ -110,8 +110,8 @@ class DtoInstantiatingConverter implements Converter<EntityInstanceWithSource, O
 	Object getPropertyValueFor(PersistentProperty<?> targetProperty, PersistentEntity<?, ?> sourceEntity,
 			PersistentPropertyAccessor sourceAccessor, EntityInstanceWithSource entityInstanceAndSource) {
 
-		final TypeSystem typeSystem = entityInstanceAndSource.getTypeSystem();
-		final Record sourceRecord = entityInstanceAndSource.getSourceRecord();
+		TypeSystem typeSystem = entityInstanceAndSource.getTypeSystem();
+		Record sourceRecord = entityInstanceAndSource.getSourceRecord();
 
 		String targetPropertyName = targetProperty.getName();
 		PersistentProperty<?> sourceProperty = sourceEntity.getPersistentProperty(targetPropertyName);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/EntityInstanceWithSource.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/EntityInstanceWithSource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.query;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.types.TypeSystem;
+
+/**
+ * Used to keep the raw result around in case of a DTO based projection so that missing properties can be filled later on.
+ *
+ * @author Michael J. Simons
+ * @soundtrack The Prodigy - Music For The Jilted Generation
+ */
+final class EntityInstanceWithSource {
+
+	/**
+	 * An instance of the original {@link org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity source entity}
+	 */
+	private final Object entityInstance;
+
+	/**
+	 * The type system used to extract data.
+	 */
+	private final TypeSystem typeSystem;
+
+	/**
+	 * The record from which the source above was hydrated and which might contain top level properties that are elligable to mapping.
+	 */
+	private final Record sourceRecord;
+
+	EntityInstanceWithSource(Object entityInstance, TypeSystem typeSystem, Record sourceRecord) {
+
+		this.entityInstance = entityInstance;
+		this.typeSystem = typeSystem;
+		this.sourceRecord = sourceRecord;
+	}
+
+	public Object getEntityInstance() {
+		return entityInstance;
+	}
+
+	public TypeSystem getTypeSystem() {
+		return typeSystem;
+	}
+
+	public Record getSourceRecord() {
+		return sourceRecord;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
@@ -130,9 +130,4 @@ class Neo4jQueryMethod extends QueryMethod {
 			return this.getName().orElseGet(() -> Integer.toString(this.getIndex()));
 		}
 	}
-
-	@Override
-	public Class<?> getDomainClass() {
-		return super.getDomainClass();
-	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -95,16 +95,6 @@ abstract class Neo4jQuerySupport {
 			// Clients automatically selects a single value mapping function.
 			// It will thrown an error if the query contains more than one column.
 			mappingFunction = null;
-		} else if (resultProcessor.getReturnedType().isProjecting()) {
-
-			if (returnedType.isInterface()) {
-				mappingFunction = this.mappingContext.getRequiredMappingFunctionFor(domainType);
-			} else if (this.mappingContext.hasPersistentEntityFor(returnedType)) {
-				mappingFunction = this.mappingContext.getRequiredMappingFunctionFor(returnedType);
-			} else {
-				this.mappingContext.addPersistentEntity(returnedType);
-				mappingFunction = this.mappingContext.getRequiredMappingFunctionFor(returnedType);
-			}
 		} else {
 			mappingFunction = this.mappingContext.getRequiredMappingFunctionFor(domainType);
 		}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -37,7 +37,7 @@ import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.neo4j.core.convert.Neo4jSimpleTypes;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
-import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.data.util.ClassTypeInformation;
@@ -56,13 +56,24 @@ abstract class Neo4jQuerySupport {
 
 	protected final Neo4jMappingContext mappingContext;
 	protected final Neo4jQueryMethod queryMethod;
-	protected final Class<?> domainType;
 	/**
 	 * The query type.
 	 */
 	protected final Neo4jQueryType queryType;
 
 	static final LogAccessor REPOSITORY_QUERY_LOG = new LogAccessor(LogFactory.getLog(Neo4jQuerySupport.class));
+
+	/**
+	 * Centralizes inquiry of the domain type to use the result processor of the query method as the point of truth.
+	 * While this could be exposed on the query method itself, we would risk working with another type if at some point
+	 * we osk the result processor only.
+	 *
+	 * @param queryMethod The query method whose domain type is requested
+	 * @return The domain type of the given query method.
+	 */
+	static Class<?> getDomainType(QueryMethod queryMethod) {
+		return queryMethod.getResultProcessor().getReturnedType().getDomainType();
+	}
 
 	Neo4jQuerySupport(Neo4jMappingContext mappingContext, Neo4jQueryMethod queryMethod, Neo4jQueryType queryType) {
 
@@ -72,7 +83,6 @@ abstract class Neo4jQuerySupport {
 
 		this.mappingContext = mappingContext;
 		this.queryMethod = queryMethod;
-		this.domainType = queryMethod.getDomainClass();
 		this.queryType = queryType;
 	}
 
@@ -81,13 +91,11 @@ abstract class Neo4jQuerySupport {
 				actualParameters);
 	}
 
-	protected final ResultProcessor getResultProcessor(ParameterAccessor parameterAccessor) {
-		return queryMethod.getResultProcessor().withDynamicProjection(parameterAccessor);
-	}
-
 	protected final BiFunction<TypeSystem, Record, ?> getMappingFunction(final ResultProcessor resultProcessor) {
 
-		final Class<?> returnedType = resultProcessor.getReturnedType().getReturnedType();
+		final ReturnedType returnedTypeMetadata = resultProcessor.getReturnedType();
+		final Class<?> returnedType = returnedTypeMetadata.getReturnedType();
+		final Class<?> domainType = returnedTypeMetadata.getDomainType();
 
 		final BiFunction<TypeSystem, Record, ?> mappingFunction;
 
@@ -95,7 +103,7 @@ abstract class Neo4jQuerySupport {
 			// Clients automatically selects a single value mapping function.
 			// It will thrown an error if the query contains more than one column.
 			mappingFunction = null;
-		} else if (resultProcessor.getReturnedType().isProjecting()) {
+		} else if (returnedTypeMetadata.isProjecting()) {
 			BiFunction<TypeSystem, Record, ?> target = this.mappingContext.getRequiredMappingFunctionFor(domainType);
 			mappingFunction = (t, r) -> new EntityInstanceWithSource(target.apply(t, r), t, r);
 		} else {

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -43,7 +43,7 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 	public static RepositoryQuery create(Neo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
 			Neo4jQueryMethod queryMethod) {
 		return new PartTreeNeo4jQuery(neo4jOperations, mappingContext, queryMethod,
-				new PartTree(queryMethod.getName(), queryMethod.getDomainClass()));
+				new PartTree(queryMethod.getName(), getDomainType(queryMethod)));
 	}
 
 	private PartTreeNeo4jQuery(Neo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
@@ -61,7 +61,7 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
 			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
 
-		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, domainType,
+		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,
 				includedProperties, this::convertParameter);
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
@@ -26,13 +26,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import org.apache.commons.logging.LogFactory;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Conditions;
 import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.StatementBuilder;
-import org.springframework.core.log.LogAccessor;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.neo4j.core.mapping.Constants;
@@ -55,8 +53,6 @@ import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
  * @since 6.0
  */
 final class Predicate {
-
-	private static final LogAccessor log = new LogAccessor(LogFactory.getLog(Predicate.class));
 
 	static <S> Predicate create(Neo4jMappingContext mappingContext, Example<S> example) {
 
@@ -96,7 +92,7 @@ final class Predicate {
 			Neo4jConversionService conversionService = mappingContext.getConversionService();
 
 			if (graphProperty.isRelationship()) {
-				log.error("Querying by example does not support traversing of relationships.");
+				Neo4jQuerySupport.REPOSITORY_QUERY_LOG.error("Querying by example does not support traversing of relationships.");
 			} else if (graphProperty.isIdProperty() && probeNodeDescription.isUsingInternalIds()) {
 				predicate.add(mode,
 						predicate.neo4jPersistentEntity.getIdExpression().isEqualTo(literalOf(optionalValue.get())));

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
@@ -43,7 +43,7 @@ final class ReactivePartTreeNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	public static RepositoryQuery create(ReactiveNeo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
 			Neo4jQueryMethod queryMethod) {
 		return new ReactivePartTreeNeo4jQuery(neo4jOperations, mappingContext, queryMethod,
-				new PartTree(queryMethod.getName(), queryMethod.getDomainClass()));
+				new PartTree(queryMethod.getName(), getDomainType(queryMethod)));
 	}
 
 	private ReactivePartTreeNeo4jQuery(ReactiveNeo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
@@ -61,7 +61,7 @@ final class ReactivePartTreeNeo4jQuery extends AbstractReactiveNeo4jQuery {
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
 			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
 
-		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, domainType,
+		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,
 				includedProperties, this::convertParameter);
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -445,21 +445,21 @@ class RepositoryIT {
 		}
 
 		@Test
-		void loadAllKotlinPersons(@Autowired PersonRepository repository) {
+		void loadAllKotlinPersons(@Autowired KotlinPersonRepository repository) {
 
 			List<KotlinPerson> persons = repository.getAllKotlinPersonsViaQuery();
 			assertThat(persons).anyMatch(person -> person.getName().equals(TEST_PERSON1_NAME));
 		}
 
 		@Test
-		void loadOneKotlinPerson(@Autowired PersonRepository repository) {
+		void loadOneKotlinPerson(@Autowired KotlinPersonRepository repository) {
 
 			KotlinPerson person = repository.getOneKotlinPersonViaQuery();
 			assertThat(person.getName()).isEqualTo(TEST_PERSON1_NAME);
 		}
 
 		@Test
-		void loadOptionalKotlinPerson(@Autowired PersonRepository repository) {
+		void loadOptionalKotlinPerson(@Autowired KotlinPersonRepository repository) {
 
 			Optional<KotlinPerson> person = repository.getOptionalKotlinPersonViaQuery();
 			assertThat(person).isPresent();
@@ -3184,6 +3184,18 @@ class RepositoryIT {
 	}
 
 	interface FriendRepository extends Neo4jRepository<Friend, Long> {}
+
+	interface KotlinPersonRepository extends Neo4jRepository<KotlinPerson, Long> {
+
+		@Query("MATCH (n:KotlinPerson)-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
+		List<KotlinPerson> getAllKotlinPersonsViaQuery();
+
+		@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
+		KotlinPerson getOneKotlinPersonViaQuery();
+
+		@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
+		Optional<KotlinPerson> getOptionalKotlinPersonViaQuery();
+	}
 
 	@SpringJUnitConfig(Config.class)
 	static abstract class IntegrationTestBase {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -90,6 +90,7 @@ import org.springframework.data.neo4j.integration.shared.Club;
 import org.springframework.data.neo4j.integration.shared.ClubRelationship;
 import org.springframework.data.neo4j.integration.shared.DeepRelationships;
 import org.springframework.data.neo4j.integration.shared.DtoPersonProjection;
+import org.springframework.data.neo4j.integration.shared.DtoPersonProjectionContainingAdditionalFields;
 import org.springframework.data.neo4j.integration.shared.EntityWithConvertedId;
 import org.springframework.data.neo4j.integration.shared.Friend;
 import org.springframework.data.neo4j.integration.shared.FriendshipRelationship;
@@ -99,7 +100,6 @@ import org.springframework.data.neo4j.integration.shared.Inheritance;
 import org.springframework.data.neo4j.integration.shared.KotlinPerson;
 import org.springframework.data.neo4j.integration.shared.LikesHobbyRelationship;
 import org.springframework.data.neo4j.integration.shared.MultipleLabels;
-import org.springframework.data.neo4j.integration.shared.PersonProjection;
 import org.springframework.data.neo4j.integration.shared.PersonWithAllConstructor;
 import org.springframework.data.neo4j.integration.shared.PersonWithNoConstructor;
 import org.springframework.data.neo4j.integration.shared.PersonWithRelationship;
@@ -2608,6 +2608,24 @@ class RepositoryIT {
 			assertThat(repository.loadAllProjectionsWithNodeReturn()).hasSize(2);
 		}
 
+		@Test
+		void mapsInterfaceProjectionWithCustomQueryAndNodeReturn2(@Autowired PersonRepository repository) {
+
+			List<DtoPersonProjectionContainingAdditionalFields> projectedPeople = repository
+					.findAllDtoProjectionsWithAdditionalProperties(TEST_PERSON1_NAME);
+
+			assertThat(projectedPeople).hasSize(1)
+					.first()
+					.satisfies(dto -> {
+						assertThat(dto.getFirstName()).isEqualTo(TEST_PERSON1_FIRST_NAME);
+						assertThat(dto.getSomeLongValue()).isEqualTo(4711L);
+						assertThat(dto.getSomeDoubles()).containsExactly(21.42, 42.21);
+						assertThat(dto.getOtherPeople()).hasSize(1)
+								.first()
+								.extracting(PersonWithAllConstructor::getFirstName)
+								.isEqualTo(TEST_PERSON2_FIRST_NAME);
+					});
+		}
 	}
 
 	@Nested

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -89,6 +89,7 @@ import org.springframework.data.neo4j.integration.shared.BidirectionalStart;
 import org.springframework.data.neo4j.integration.shared.Club;
 import org.springframework.data.neo4j.integration.shared.ClubRelationship;
 import org.springframework.data.neo4j.integration.shared.DeepRelationships;
+import org.springframework.data.neo4j.integration.shared.DtoPersonProjection;
 import org.springframework.data.neo4j.integration.shared.EntityWithConvertedId;
 import org.springframework.data.neo4j.integration.shared.Friend;
 import org.springframework.data.neo4j.integration.shared.FriendshipRelationship;
@@ -98,6 +99,7 @@ import org.springframework.data.neo4j.integration.shared.Inheritance;
 import org.springframework.data.neo4j.integration.shared.KotlinPerson;
 import org.springframework.data.neo4j.integration.shared.LikesHobbyRelationship;
 import org.springframework.data.neo4j.integration.shared.MultipleLabels;
+import org.springframework.data.neo4j.integration.shared.PersonProjection;
 import org.springframework.data.neo4j.integration.shared.PersonWithAllConstructor;
 import org.springframework.data.neo4j.integration.shared.PersonWithNoConstructor;
 import org.springframework.data.neo4j.integration.shared.PersonWithRelationship;
@@ -2563,12 +2565,18 @@ class RepositoryIT {
 		@Test
 		void mapsInterfaceProjectionWithDerivedFinderMethod(@Autowired PersonRepository repository) {
 
-			assertThat(repository.findByName(TEST_PERSON1_NAME).getName()).isEqualTo(TEST_PERSON1_NAME);
+			assertThat(repository.findByName(TEST_PERSON1_NAME)).satisfies(projection -> {
+				assertThat(projection.getName()).isEqualTo(TEST_PERSON1_NAME);
+				assertThat(projection.getFirstName()).isEqualTo(TEST_PERSON1_FIRST_NAME);
+			});
 		}
 
 		@Test
 		void mapsDtoProjectionWithDerivedFinderMethod(@Autowired PersonRepository repository) {
-			assertThat(repository.findByFirstName(TEST_PERSON1_FIRST_NAME)).hasSize(1);
+			assertThat(repository.findByFirstName(TEST_PERSON1_FIRST_NAME))
+					.hasSize(1)
+					.extracting(DtoPersonProjection::getFirstName)
+					.first().isEqualTo(TEST_PERSON1_FIRST_NAME);
 		}
 
 		@Test

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
@@ -32,7 +32,6 @@ import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.neo4j.integration.shared.DtoPersonProjection;
 import org.springframework.data.neo4j.integration.shared.DtoPersonProjectionContainingAdditionalFields;
-import org.springframework.data.neo4j.integration.shared.KotlinPerson;
 import org.springframework.data.neo4j.integration.shared.PersonProjection;
 import org.springframework.data.neo4j.integration.shared.PersonWithAllConstructor;
 import org.springframework.data.neo4j.integration.shared.PersonWithNoConstructor;
@@ -94,15 +93,6 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 
 	@Query("MATCH (n:PersonWithWither{name:'Test'}) return n")
 	Optional<PersonWithWither> getOptionalPersonWithWitherViaQuery();
-
-	@Query("MATCH (n:KotlinPerson)-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
-	List<KotlinPerson> getAllKotlinPersonsViaQuery();
-
-	@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
-	KotlinPerson getOneKotlinPersonViaQuery();
-
-	@Query("MATCH (n:KotlinPerson{name:'Test'})-[w:WORKS_IN]->(c:KotlinClub) return n, collect(w), collect(c)")
-	Optional<KotlinPerson> getOptionalKotlinPersonViaQuery();
 
 	// Derived finders, should be extracted into another repo.
 	Optional<PersonWithAllConstructor> findOneByNameAndFirstName(String name, String firstName);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
@@ -31,6 +31,7 @@ import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.neo4j.integration.shared.DtoPersonProjection;
+import org.springframework.data.neo4j.integration.shared.DtoPersonProjectionContainingAdditionalFields;
 import org.springframework.data.neo4j.integration.shared.KotlinPerson;
 import org.springframework.data.neo4j.integration.shared.PersonProjection;
 import org.springframework.data.neo4j.integration.shared.PersonWithAllConstructor;
@@ -241,6 +242,12 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 	List<PersonProjection> findBySameValue(String sameValue);
 
 	List<DtoPersonProjection> findByFirstName(String firstName);
+
+	@Query(""
+			+ "MATCH (n:PersonWithAllConstructor) where n.name = $name "
+			+ "WITH n MATCH(m:PersonWithAllConstructor) WHERE id(n) <> id(m) "
+			+ "RETURN n, collect(m) AS otherPeople, 4711 AS someLongValue, [21.42, 42.21] AS someDoubles")
+	List<DtoPersonProjectionContainingAdditionalFields> findAllDtoProjectionsWithAdditionalProperties(@Param("name") String name);
 
 	@Query("MATCH (n:PersonWithAllConstructor) where n.name = $name return n{.name}")
 	PersonProjection findByNameWithCustomQueryAndMapProjection(@Param("name") String name);

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/DtoPersonProjectionContainingAdditionalFields.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/DtoPersonProjectionContainingAdditionalFields.java
@@ -13,22 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.neo4j.core.mapping;
+package org.springframework.data.neo4j.integration.shared;
 
-import java.util.Map;
+import lombok.Value;
 
-import org.apiguardian.api.API;
-import org.neo4j.driver.types.MapAccessor;
-import org.springframework.data.convert.EntityReader;
-import org.springframework.data.convert.EntityWriter;
+import java.util.List;
 
 /**
- * This orchestrates the build-in store conversions and any additional Spring converters.
- *
  * @author Michael J. Simons
- * @soundtrack The Kleptones - A Night At The Hip-Hopera
- * @since 6.0
  */
-@API(status = API.Status.INTERNAL, since = "6.0")
-public interface Neo4jEntityConverter extends EntityReader<Object, MapAccessor>, EntityWriter<Object, Map<String, Object>> {
+@Value
+public class DtoPersonProjectionContainingAdditionalFields {
+
+	String name;
+	String sameValue;
+	String firstName;
+
+	List<PersonWithAllConstructor> otherPeople;
+
+	Long someLongValue;
+
+	List<Double> someDoubles;
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/ExtendedParentNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/ExtendedParentNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Toten Hosen - Zurück zum Glück
+ */
+@Node
+public class ExtendedParentNode extends ParentNode {
+
+	private String someOtherAttribute;
+
+	@Relationship("CONNECTED_TO")
+	private List<PersonWithAllConstructor> people;
+
+	public String getSomeOtherAttribute() {
+		return someOtherAttribute;
+	}
+
+	public void setSomeOtherAttribute(String someOtherAttribute) {
+		this.someOtherAttribute = someOtherAttribute;
+	}
+
+	public List<PersonWithAllConstructor> getPeople() {
+		return people;
+	}
+
+	public void setPeople(List<PersonWithAllConstructor> people) {
+		this.people = people;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/ParentNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/ParentNode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Toten Hosen - Zurück zum Glück
+ */
+@Node
+public class ParentNode {
+	@Id @GeneratedValue
+	private Long id;
+
+	private String someAttribute;
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getSomeAttribute() {
+		return someAttribute;
+	}
+
+	public void setSomeAttribute(String someAttribute) {
+		this.someAttribute = someAttribute;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/PersonProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/PersonProjection.java
@@ -17,10 +17,13 @@ package org.springframework.data.neo4j.integration.shared;
 
 /**
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 public interface PersonProjection {
 
 	String getName();
+
+	String getFirstName();
 
 	String getSameValue();
 }


### PR DESCRIPTION
This change makes sure we use the correct domain type before we create DTO based projections. Without taking the underlying domain type into consideration, annotated attributes, explicit relationship types etc. won't be taken into consideration when generating the Cypher query.

The DTO is than generated in two steps: First the domain type is instantiated and populated with the set of properties defined by the DTO and than the DTO is created from it. The creation is not part of the entity converter but a later step. In a future version of SDN this might change.

In addition to this changes, we allow additional attributes in a DTO projection. For them to be hydrated, custom queries must be supplied, containing the corresponding attributes.

Included with the commit is documentation of the defined behavior as well as a couple of tests to make sure the behavior of Spring Data Commons with regard to what is considered to be a projection or not keeps the way it is now.