### PR TITLE
Allow aggregating into 1 single collection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-DATAGRAPH-1429-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -301,16 +301,8 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 		Function<T, Map<String, Object>> binderFunction = neo4jMappingContext.getRequiredBinderFunctionFor(domainClass);
 		return getDatabaseName().flatMapMany(databaseName -> Flux.fromIterable(entities)
-				.flatMap(eventSupport::maybeCallBeforeBind).collectList().flatMapMany(entitiesToBeSaved -> Mono.defer(() -> { // Defer
-																																																											// the
-																																																											// actual
-																																																											// save
-																																																											// statement
-																																																											// until
-																																																											// the
-																																																											// previous
-																																																											// flux
-																																																											// completes
+				.flatMap(eventSupport::maybeCallBeforeBind).collectList().flatMapMany(entitiesToBeSaved -> Mono.defer(() -> {
+					// Defer the actual save statement until the previous flux completes
 					List<Map<String, Object>> boundedEntityList = entitiesToBeSaved.stream().map(binderFunction)
 							.collect(Collectors.toList());
 

--- a/src/main/java/org/springframework/data/neo4j/core/RecordMapAccessor.java
+++ b/src/main/java/org/springframework/data/neo4j/core/RecordMapAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.neo4j.core.mapping;
+package org.springframework.data.neo4j.core;
 
 import java.util.Map;
 import java.util.function.Function;

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
@@ -22,7 +22,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.apiguardian.api.API;
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.neo4j.core.schema.IdGenerator;
@@ -87,12 +87,12 @@ public interface Schema {
 	 * @return The default, stateless and reusable mapping function for the given target class
 	 * @throws UnknownEntityException When {@code targetClass} is not a managed class
 	 */
-	default <T> BiFunction<TypeSystem, Record, T> getRequiredMappingFunctionFor(Class<T> targetClass) {
+	default <T> BiFunction<TypeSystem, MapAccessor, T> getRequiredMappingFunctionFor(Class<T> targetClass) {
 		NodeDescription<?> nodeDescription = getNodeDescription(targetClass);
 		if (nodeDescription == null) {
 			throw new UnknownEntityException(targetClass);
 		}
-		return (typeSystem, record) -> getEntityConverter().read(targetClass, new RecordMapAccessor(record));
+		return (typeSystem, record) -> getEntityConverter().read(targetClass, record);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +33,7 @@ import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
-import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -109,7 +109,7 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 	protected abstract <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType,
 			List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
 			@Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction);
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction);
 
 	protected Optional<PreparedQuery<Long>> getCountQuery(Neo4jParameterAccessor parameterAccessor) {
 		return Optional.empty();

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
@@ -18,7 +18,7 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.neo4j.core.PreparedQuery;
@@ -83,5 +83,5 @@ abstract class AbstractReactiveNeo4jQuery extends Neo4jQuerySupport implements R
 
 	protected abstract <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType,
 			List<String> includedProperties, Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction);
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction);
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/DtoInstantiatingConverter.java
@@ -19,8 +19,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
-import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.converter.Converter;
@@ -112,7 +112,7 @@ class DtoInstantiatingConverter implements Converter<EntityInstanceWithSource, O
 			PersistentPropertyAccessor sourceAccessor, EntityInstanceWithSource entityInstanceAndSource) {
 
 		TypeSystem typeSystem = entityInstanceAndSource.getTypeSystem();
-		Record sourceRecord = entityInstanceAndSource.getSourceRecord();
+		MapAccessor sourceRecord = entityInstanceAndSource.getSourceRecord();
 
 		String targetPropertyName = targetProperty.getName();
 		PersistentProperty<?> sourceProperty = sourceEntity.getPersistentProperty(targetPropertyName);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/EntityInstanceWithSource.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/EntityInstanceWithSource.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.neo4j.repository.query;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 
 /**
@@ -39,9 +39,9 @@ final class EntityInstanceWithSource {
 	/**
 	 * The record from which the source above was hydrated and which might contain top level properties that are elligable to mapping.
 	 */
-	private final Record sourceRecord;
+	private final MapAccessor sourceRecord;
 
-	EntityInstanceWithSource(Object entityInstance, TypeSystem typeSystem, Record sourceRecord) {
+	EntityInstanceWithSource(Object entityInstance, TypeSystem typeSystem, MapAccessor sourceRecord) {
 
 		this.entityInstance = entityInstance;
 		this.typeSystem = typeSystem;
@@ -56,7 +56,7 @@ final class EntityInstanceWithSource {
 		return typeSystem;
 	}
 
-	public Record getSourceRecord() {
+	public MapAccessor getSourceRecord() {
 		return sourceRecord;
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -25,9 +25,9 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
-import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.data.domain.Range;
@@ -91,20 +91,20 @@ abstract class Neo4jQuerySupport {
 				actualParameters);
 	}
 
-	protected final BiFunction<TypeSystem, Record, ?> getMappingFunction(final ResultProcessor resultProcessor) {
+	protected final BiFunction<TypeSystem, MapAccessor, ?> getMappingFunction(final ResultProcessor resultProcessor) {
 
 		final ReturnedType returnedTypeMetadata = resultProcessor.getReturnedType();
 		final Class<?> returnedType = returnedTypeMetadata.getReturnedType();
 		final Class<?> domainType = returnedTypeMetadata.getDomainType();
 
-		final BiFunction<TypeSystem, Record, ?> mappingFunction;
+		final BiFunction<TypeSystem, MapAccessor, ?> mappingFunction;
 
 		if (Neo4jSimpleTypes.HOLDER.isSimpleType(returnedType)) {
 			// Clients automatically selects a single value mapping function.
 			// It will thrown an error if the query contains more than one column.
 			mappingFunction = null;
 		} else if (returnedTypeMetadata.isProjecting()) {
-			BiFunction<TypeSystem, Record, ?> target = this.mappingContext.getRequiredMappingFunctionFor(domainType);
+			BiFunction<TypeSystem, MapAccessor, ?> target = this.mappingContext.getRequiredMappingFunctionFor(domainType);
 			mappingFunction = (t, r) -> new EntityInstanceWithSource(target.apply(t, r), t, r);
 		} else {
 			mappingFunction = this.mappingContext.getRequiredMappingFunctionFor(domainType);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.data.neo4j.core.Neo4jOperations;
 import org.springframework.data.neo4j.core.PreparedQuery;
@@ -59,7 +59,7 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, List<String> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
 
 		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.data.neo4j.core.PreparedQuery;
 import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
@@ -59,7 +59,7 @@ final class ReactivePartTreeNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, List<String> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
 
 		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.neo4j.core.PreparedQuery;
@@ -138,7 +138,7 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, List<String> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
 
 		return PreparedQuery.queryFor(returnedType).withCypherQuery(cypherQuery)
 				.withParameters(bindParameters(parameterAccessor)).usingMappingFunction(mappingFunction).build();

--- a/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import org.neo4j.driver.Record;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mapping.MappingException;
@@ -135,7 +135,7 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, List<String> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
+			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
 
 		return PreparedQuery.queryFor(returnedType).withCypherQuery(cypherQuery)
 				.withParameters(bindParameters(parameterAccessor)).usingMappingFunction(mappingFunction).build();

--- a/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
@@ -107,12 +107,10 @@ class Neo4jClientTest {
 		parameters.put("bikeName", "M.*");
 		parameters.put("location", "Sweden");
 
-		String cypher = "MATCH (o:User {name: $name}) - [:OWNS] -> (b:Bike) - [:USED_ON] -> (t:Trip) "
-				+ "WHERE t.takenOn > $aDate " + "  AND b.name =~ $bikeName " + "  AND t.location = $location " + // TODO Nice
-																																																					// place to
-																																																					// add
-																																																					// coordinates
-				"RETURN b";
+		String cypher = ""
+						+ "MATCH (o:User {name: $name}) - [:OWNS] -> (b:Bike) - [:USED_ON] -> (t:Trip) "
+						+ "WHERE t.takenOn > $aDate " + "  AND b.name =~ $bikeName " + "  AND t.location = $location "
+						+ "RETURN b";
 
 		Collection<Map<String, Object>> usedBikes = client.query(cypher).bind("michael").to("name").bindAll(parameters)
 				.bind(LocalDate.of(2019, 1, 1)).to("aDate").fetch().all();

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
@@ -41,6 +41,9 @@ public interface ReactivePersonRepository extends ReactiveNeo4jRepository<Person
 	@Query("MATCH (n:PersonWithAllConstructor) return n")
 	Flux<PersonWithAllConstructor> getAllPersonsViaQuery();
 
+	@Query("MATCH (n:PersonWithAllConstructor) return collect(n)")
+	Flux<PersonWithAllConstructor> aggregateAllPeople();
+
 	@Query("MATCH (n:PersonWithAllConstructor{name:'Test'}) return n")
 	Mono<PersonWithAllConstructor> getOnePersonViaQuery();
 


### PR DESCRIPTION
We have everything in place to call our entity reader several times. The biggest change here is to pass in the map accessor from the outside, not the record, which I should have done when I changed the entity reader to work on the map accessor in the first place.

This allows the flight scenario and a couple of other things to work.

I would not go as far to support maps as we did in OGM as return type (that can be solved by the user in a custom streamable).

This PR has a couple of todos that needs to be implemented.