### PR TITLE
Fix query generation for same label derived finders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-DATAGRAPH-1436-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -534,7 +534,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 		Neo4jPersistentEntity<?> owner = (Neo4jPersistentEntity<?>) leafProperty.getOwner();
 		Expression expression;
 
-		if (owner.equals(this.nodeDescription)) {
+		if (owner.equals(this.nodeDescription) && path.getLength() == 1) {
 			expression = Cypher.property(Constants.NAME_OF_ROOT_NODE, leafProperty.getPropertyName());
 		} else {
 			PropertyPathWrapper propertyPathWrapper = propertyPathWrappers.stream()

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -789,6 +789,19 @@ class RepositoryIT {
 		}
 
 		@Test
+		void findBySameLabelRelationshipPropertyMultipleLevels(@Autowired PetRepository repository) {
+			try (Session session = createSession()) {
+				session.run(
+						"CREATE (p1:Pet{name: 'Pet1'})-[:Has]->(p2:Pet{name: 'Pet2'})-[:Has]->(p3:Pet{name: 'Pet3'})");
+			}
+
+			Pet pet = repository.findByFriendsFriendsName("Pet3");
+			assertThat(pet).isNotNull();
+			assertThat(pet.getFriends()).isNotEmpty();
+			assertThat(pet.getFriends().get(0).getFriends()).isNotEmpty();
+		}
+
+		@Test
 		void findLoopingDeepRelationships(@Autowired LoopingRelationshipRepository loopingRelationshipRepository) {
 
 			long type1Id;
@@ -3373,6 +3386,8 @@ class RepositoryIT {
 		Page<Pet> pagedPetsWithParameter(@Param("petName") String petName, Pageable pageable);
 
 		Pet findByFriendsName(String friendName);
+
+		Pet findByFriendsFriendsName(String friendName);
 
 	}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -778,6 +778,17 @@ class RepositoryIT {
 		}
 
 		@Test
+		void findBySameLabelRelationshipProperty(@Autowired PetRepository repository) {
+			try (Session session = createSession()) {
+				session.run("CREATE (p1:Pet{name: 'Pet1'})-[:Has]->(p2:Pet{name: 'Pet2'})");
+			}
+
+			Pet pet = repository.findByFriendsName("Pet2");
+			assertThat(pet).isNotNull();
+			assertThat(pet.getFriends()).isNotEmpty();
+		}
+
+		@Test
 		void findLoopingDeepRelationships(@Autowired LoopingRelationshipRepository loopingRelationshipRepository) {
 
 			long type1Id;
@@ -3360,6 +3371,8 @@ class RepositoryIT {
 		@Query(value = "MATCH (p:Pet) where p.name=$petName return p SKIP $skip LIMIT $limit",
 				countQuery = "MATCH (p:Pet) return count(p)")
 		Page<Pet> pagedPetsWithParameter(@Param("petName") String petName, Pageable pageable);
+
+		Pet findByFriendsName(String friendName);
 
 	}
 


### PR DESCRIPTION
This fixes the problem for a scenario where `(:Person)-[:KNOWS]->(:Person)` and a derived finder method like `Person findByFriendName(String name)`.
The resulting query creation would not put the `name` onto the related person but on the root entity.