### PR TITLE
Fix naming of relationships in query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-DATAGRAPH-1434-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -492,8 +492,10 @@ public enum CypherGenerator {
 
 		String relationshipType = relationshipDescription.getType();
 		String relationshipTargetName = relationshipDescription.generateRelatedNodesCollectionName();
+		String sourcePrimaryLabel = relationshipDescription.getSource().getPrimaryLabel();
 		String targetPrimaryLabel = relationshipDescription.getTarget().getPrimaryLabel();
 		List<String> targetAdditionalLabels = relationshipDescription.getTarget().getAdditionalLabels();
+		String relationshipSymbolicName = sourcePrimaryLabel + RelationshipDescription.NAME_OF_RELATIONSHIP + targetPrimaryLabel;
 
 		Node startNode = anyNode(nodeName);
 		SymbolicName relationshipFieldName = nodeName.concat("_" + fieldName);
@@ -512,7 +514,7 @@ public enum CypherGenerator {
 					new ArrayList<>(processedRelationships));
 
 			if (relationshipDescription.hasRelationshipProperties()) {
-				relationship = relationship.named(RelationshipDescription.NAME_OF_RELATIONSHIP);
+				relationship = relationship.named(relationshipSymbolicName);
 				mapProjection = mapProjection.and(relationship);
 			}
 
@@ -530,7 +532,7 @@ public enum CypherGenerator {
 					new ArrayList<>(processedRelationships));
 
 			if (relationshipDescription.hasRelationshipProperties()) {
-				relationship = relationship.named(RelationshipDescription.NAME_OF_RELATIONSHIP);
+				relationship = relationship.named(relationshipSymbolicName);
 				mapProjection = mapProjection.and(relationship);
 			}
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -356,6 +356,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				.filter(r -> r.getFieldName().equals(persistentProperty.getName())).findFirst().get();
 
 		String relationshipType = relationshipDescription.getType();
+		String sourceLabel = relationshipDescription.getSource().getPrimaryLabel();
 		String targetLabel = relationshipDescription.getTarget().getPrimaryLabel();
 
 		Neo4jPersistentEntity<?> genericTargetNodeDescription = (Neo4jPersistentEntity<?>) relationshipDescription
@@ -491,7 +492,9 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				Object valueEntry = map(relatedEntity, allValues, concreteTargetNodeDescription, knownObjects, processedSegments);
 
 				if (relationshipDescription.hasRelationshipProperties()) {
-					Relationship relatedEntityRelationship = relatedEntity.get(RelationshipDescription.NAME_OF_RELATIONSHIP)
+					String relationshipSymbolicName = sourceLabel
+							+ RelationshipDescription.NAME_OF_RELATIONSHIP + targetLabel;
+					Relationship relatedEntityRelationship = relatedEntity.get(relationshipSymbolicName)
 							.asRelationship();
 
 					Object relationshipProperties = map(relatedEntityRelationship, allValues,

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithRelationshipPropertiesPath.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithRelationshipPropertiesPath.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.common;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class EntityWithRelationshipPropertiesPath {
+
+	@Id @GeneratedValue private Long id;
+
+	@Relationship("RelationshipA")
+	private RelationshipPropertyA relationshipA;
+
+	public RelationshipPropertyA getRelationshipA() {
+		return relationshipA;
+	}
+
+	/**
+	 * From EntityWithRelationshipPropertiesPath to EntityA
+	 */
+	@RelationshipProperties
+	public static class RelationshipPropertyA {
+
+		@TargetNode
+		private EntityA entityA;
+
+		public EntityA getEntityA() {
+			return entityA;
+		}
+	}
+
+	/**
+	 * From EntityA to EntityB
+	 */
+	@RelationshipProperties
+	public static class RelationshipPropertyB {
+
+		@TargetNode
+		private EntityB entityB;
+
+		public EntityB getEntityB() {
+			return entityB;
+		}
+	}
+
+	/**
+	 * EntityA
+	 */
+	@Node
+	public static class EntityA {
+		@Id @GeneratedValue private Long id;
+
+		@Relationship("RelationshipB")
+		private RelationshipPropertyB relationshipB;
+
+		public RelationshipPropertyB getRelationshipB() {
+			return relationshipB;
+		}
+	}
+
+	/**
+	 * EntityB
+	 */
+	@Node
+	public static class EntityB {
+		@Id @GeneratedValue private Long id;
+
+	}
+
+
+}


### PR DESCRIPTION
The queries for relationships with properties created a repetitive `__relationship__` definition.
I thought this will be nested and only visible in its scope. Turns out the inner scope gets the outer scope added and the database did not return any result.