### PR TITLE
Avoid redundant statements for relationships.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-DATAGRAPH-1442-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -462,7 +462,8 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 			// break recursive procession and deletion of previously created relationships
 			ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-			if (processState == ProcessState.PROCESSED_BOTH) {
+			if (processState == ProcessState.PROCESSED_ALL_VALUES) {
+//			if (processState == ProcessState.PROCESSED_ONLY_RELATIONSHIP) {
 				return;
 			}
 

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -462,7 +462,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 			// break recursive procession and deletion of previously created relationships
 			ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-			if (processState == ProcessState.PROCESSED_ONLY_RELATIONSHIP) {
+			if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS) {
 				return;
 			}
 

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -462,8 +462,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 			// break recursive procession and deletion of previously created relationships
 			ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-			if (processState == ProcessState.PROCESSED_ALL_VALUES) {
-//			if (processState == ProcessState.PROCESSED_ONLY_RELATIONSHIP) {
+			if (processState == ProcessState.PROCESSED_ONLY_RELATIONSHIP) {
 				return;
 			}
 

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -461,7 +461,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 				// break recursive procession and deletion of previously created relationships
 				ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-				if (processState == ProcessState.PROCESSED_BOTH) {
+				if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS) {
 					return;
 				}
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.springframework.lang.Nullable;
 
 /**
  * @author Michael J. Simons
@@ -41,7 +40,6 @@ public final class MappingSupport {
 	 * @return A unified collection (Either a collection of Map.Entry for dynamic and relationships with properties or a
 	 *         list of related values)
 	 */
-	@Nullable
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
 		if (property.isDynamicAssociation()) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -38,7 +38,7 @@ public final class NestedRelationshipProcessingStateMachine {
 	 * Valid processing states.
 	 */
 	public enum ProcessState {
-		PROCESSED_NONE, PROCESSED_BOTH, PROCESSED_ONLY_RELATIONSHIP, PROCESSED_ALL_VALUES
+		PROCESSED_NONE, PROCESSED_BOTH, PROCESSED_ALL_RELATIONSHIPS, PROCESSED_ALL_VALUES
 	}
 
 	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -70,7 +70,7 @@ public final class NestedRelationshipProcessingStateMachine {
 				return ProcessState.PROCESSED_BOTH;
 			}
 			if (hasProcessedRelationship) {
-				return ProcessState.PROCESSED_ONLY_RELATIONSHIP;
+				return ProcessState.PROCESSED_ALL_RELATIONSHIPS;
 			}
 			if (hasProcessedAllValues) {
 				return ProcessState.PROCESSED_ALL_VALUES;

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -920,17 +920,6 @@ class RepositoryIT {
 		}
 
 		@Test
-		void asdfasdf(@Autowired BidirectionalStartRepository repository) {
-			BidirectionalEnd end = new BidirectionalEnd("Bla");
-			Set<BidirectionalEnd> ends = new HashSet<>();
-			ends.add(end);
-			BidirectionalStart start = new BidirectionalStart("Blubb", ends);
-			end.setStart(start);
-
-			repository.save(start);
-		}
-
-		@Test
 		void findEntityWithSelfReferencesInBothDirections(@Autowired PetRepository repository) {
 			long petId;
 			try (Session session = createSession()) {
@@ -2076,6 +2065,24 @@ class RepositoryIT {
 
 			assertThat(people).hasSize(4);
 
+		}
+
+		@Test
+		void saveBidirectionalRelationship(@Autowired BidirectionalStartRepository repository) {
+			BidirectionalEnd end = new BidirectionalEnd("End");
+			Set<BidirectionalEnd> ends = new HashSet<>();
+			ends.add(end);
+			BidirectionalStart start = new BidirectionalStart("Start", ends);
+			end.setStart(start);
+
+			repository.save(start);
+
+			try (Session session = createSession()) {
+				List<Record> records = session.run("MATCH (end:BidirectionalEnd)<-[r:CONNECTED]-(start:BidirectionalStart)" +
+								" RETURN start, r, end").list();
+
+				assertThat(records).hasSize(1);
+			}
 		}
 	}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -29,9 +29,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -915,6 +917,17 @@ class RepositoryIT {
 			assertThat(end.getAnotherStart()).isNotNull();
 			assertThat(end.getAnotherStart().getName()).isEqualTo("Elmo");
 
+		}
+
+		@Test
+		void asdfasdf(@Autowired BidirectionalStartRepository repository) {
+			BidirectionalEnd end = new BidirectionalEnd("Bla");
+			Set<BidirectionalEnd> ends = new HashSet<>();
+			ends.add(end);
+			BidirectionalStart start = new BidirectionalStart("Blubb", ends);
+			end.setStart(start);
+
+			repository.save(start);
 		}
 
 		@Test

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -32,9 +32,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -1959,6 +1961,24 @@ class ReactiveRepositoryIT {
 				assertThat(record.get("luna").asNode().get("name").asString()).isEqualTo("Luna");
 				assertThat(record.get("daphne").asNode().get("name").asString()).isEqualTo("Daphne");
 				assertThat(record.get("luna2").asNode().get("name").asString()).isEqualTo("Luna");
+			}
+		}
+
+		@Test
+		void saveBidirectionalRelationship(@Autowired BidirectionalStartRepository repository) {
+			BidirectionalEnd end = new BidirectionalEnd("End");
+			Set<BidirectionalEnd> ends = new HashSet<>();
+			ends.add(end);
+			BidirectionalStart start = new BidirectionalStart("Start", ends);
+			end.setStart(start);
+
+			StepVerifier.create(repository.save(start)).expectNextCount(1).verifyComplete();
+
+			try (Session session = createSession()) {
+				List<Record> records = session.run("MATCH (end:BidirectionalEnd)<-[r:CONNECTED]-(start:BidirectionalStart)" +
+						" RETURN start, r, end").list();
+
+				assertThat(records).hasSize(1);
 			}
 		}
 	}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalEnd.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalEnd.java
@@ -46,4 +46,8 @@ public class BidirectionalEnd {
 	public BidirectionalStart getAnotherStart() {
 		return anotherStart;
 	}
+
+	public void setStart(BidirectionalStart start) {
+		this.start = start;
+	}
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -29,7 +29,7 @@
     <logger name="OutboundMessageHandler" level="info"/>
     <logger name="InboundMessageDispatcher" level="info"/>
 
-    <logger name="org.springframework.data.neo4j.cypher" level="debug"/>
+    <logger name="org.springframework.data.neo4j.cypher" level="info"/>
     <logger name="org.springframework.data.neo4j" level="info"/>
     <logger name="org.springframework.data.neo4j.test" level="info"/>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -29,7 +29,7 @@
     <logger name="OutboundMessageHandler" level="info"/>
     <logger name="InboundMessageDispatcher" level="info"/>
 
-    <logger name="org.springframework.data.neo4j.cypher" level="info"/>
+    <logger name="org.springframework.data.neo4j.cypher" level="debug"/>
     <logger name="org.springframework.data.neo4j" level="info"/>
     <logger name="org.springframework.data.neo4j.test" level="info"/>
 


### PR DESCRIPTION
If bidirectional relationships are defined and set on both ends,
SDN created multiple create and delete statements.
This should happen only once for the very same relationship.