### PR TITLE
Register Neo4jEvaluationContextExtension only once.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.2-SNAPSHOT</version>
+	<version>6.0.2-DATAGRAPH-1460-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -95,10 +95,14 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 	@Override
 	public void registerBeansForRoot(BeanDefinitionRegistry registry, RepositoryConfigurationSource configurationSource) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
+		registerIfNotAlreadyRegistered(() -> BeanDefinitionBuilder
 				.rootBeanDefinition(Neo4jEvaluationContextExtension.class)
-				.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-		registry.registerBeanDefinition(Neo4jEvaluationContextExtension.class.getName(), builder.getBeanDefinition());
+				.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+				.getBeanDefinition(),
+				registry,
+				Neo4jEvaluationContextExtension.class.getName(),
+				configurationSource.getSource()
+		);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -95,10 +95,14 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 	@Override
 	public void registerBeansForRoot(BeanDefinitionRegistry registry, RepositoryConfigurationSource configurationSource) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.rootBeanDefinition(Neo4jEvaluationContextExtension.class)
-				.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-		registry.registerBeanDefinition(Neo4jEvaluationContextExtension.class.getName(), builder.getBeanDefinition());
+		registerIfNotAlreadyRegistered(() -> BeanDefinitionBuilder
+						.rootBeanDefinition(Neo4jEvaluationContextExtension.class)
+						.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+						.getBeanDefinition(),
+				registry,
+				Neo4jEvaluationContextExtension.class.getName(),
+				configurationSource.getSource()
+		);
 	}
 
 	@Override


### PR DESCRIPTION
This is now wrapped in a `registerIfNotAlreadyRegistered` block to ensure that it will get at most once registered.

@mp911de could you please give me a sanity check on this? I think it's the right way to keep do this but would be good to know if I have overseen something even more obvious.