### PR TITLE
Fix bidirectional relationship properties persistence.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-DATAGRAPH-1469-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
@@ -19,6 +19,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -109,6 +110,23 @@ public final class MappingSupport {
 
 		public Object getRelatedEntity() {
 			return relatedEntity;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			RelationshipPropertiesWithEntityHolder that = (RelationshipPropertiesWithEntityHolder) o;
+			return relationshipProperties.equals(that.relationshipProperties) && relatedEntity.equals(that.relatedEntity);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(relationshipProperties, relatedEntity);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalSameEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalSameEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.common;
+
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.schema.Relationship.Direction;
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+
+import java.util.List;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class BidirectionalSameEntity {
+
+	@Id
+	private String id;
+
+	@Relationship(type = "KNOWS", direction = Direction.OUTGOING)
+	private List<BidirectionalSameRelationship> knows;
+
+	public BidirectionalSameEntity(String id) {
+		this.id = id;
+	}
+
+	public void setKnows(List<BidirectionalSameRelationship> knows) {
+		this.knows = knows;
+	}
+
+	/**
+	 * Relationship properties class for the same relationship.
+	 */
+	@RelationshipProperties
+	public static class BidirectionalSameRelationship {
+
+		public BidirectionalSameRelationship(BidirectionalSameEntity entity) {
+			this.entity = entity;
+		}
+
+		@TargetNode
+		BidirectionalSameEntity entity;
+	}
+}


### PR DESCRIPTION
Previously a bidirectional relationships would have run into a StackOverflow on save.
We check for the existence in the already processed relationships `stateMachine` but those relationships with properties get wrapper objects created each time on access.
This led to the situation that, even though the very same relationship were processed, the exit condition were never met.

Short version: I have overwritten `hashCode` and `equals` 😺  Not even by myself but told the IDE to do so.