### PR TITLE
Optimize path querying and mapping

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
@@ -52,7 +52,6 @@ public final class Constants {
 	 */
 	public static final String NAME_OF_STATIC_LABELS_PARAM = "__staticLabels__";
 	public static final String NAME_OF_ENTITY_LIST_PARAM = "__entities__";
-	public static final String NAME_OF_PATHS = "__paths__";
 	public static final String NAME_OF_ALL_PROPERTIES = "__allProperties__";
 
 	public static final String NAME_OF_SYNTHESIZED_ROOT_NODE = "__sn__";

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -399,6 +399,8 @@ public enum CypherGenerator {
 			Node node = anyNode(nodeName);
 			RelationshipPattern pattern = createRelationships(node, relationships);
 			NamedPath p = Cypher.path("p").definedBy(pattern);
+			contentOfProjection.add(Constants.NAME_OF_SYNTHESIZED_ROOT_NODE);
+			contentOfProjection.add(Constants.NAME_OF_ROOT_NODE);
 			contentOfProjection.add(Constants.NAME_OF_PATHS);
 			contentOfProjection.add(Cypher.listBasedOn(p).returning(p));
 		} else {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -25,11 +25,13 @@ import static org.neo4j.cypherdsl.core.Cypher.parameter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
@@ -102,7 +104,13 @@ public enum CypherGenerator {
 	 * @return An ongoing match
 	 */
 	public StatementBuilder.OrderableOngoingReadingAndWith prepareMatchOf(NodeDescription<?> nodeDescription,
-			@Nullable Condition condition) {
+			  @Nullable Condition condition) {
+
+		return prepareMatchOf(nodeDescription, condition, Collections.emptyList());
+	}
+
+	public StatementBuilder.OrderableOngoingReadingAndWith prepareMatchOf(NodeDescription<?> nodeDescription,
+			@Nullable Condition condition, List<String> includedProperties) {
 
 		String primaryLabel = nodeDescription.getPrimaryLabel();
 		List<String> additionalLabels = nodeDescription.getAdditionalLabels();
@@ -113,28 +121,29 @@ public enum CypherGenerator {
 		expressions.add(Constants.NAME_OF_ROOT_NODE);
 		expressions.add(Functions.id(rootNode).as(Constants.NAME_OF_INTERNAL_ID));
 
-		if (nodeDescription.containsPossibleCircles()) {
-			return createPathMatchWithCondition(nodeDescription, condition, rootNode);
+		if (nodeDescription.containsPossibleCircles(includedProperties)) {
+			return createPathMatchWithCondition(nodeDescription, includedProperties, condition, rootNode);
 		} else {
 			return match(rootNode).where(conditionOrNoCondition(condition)).with(expressions.toArray(new Expression[] {}));
 		}
 	}
 
 	private StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere createPathMatchWithCondition(
-			NodeDescription<?> nodeDescription, @Nullable Condition condition, Node rootNode) {
+			NodeDescription<?> nodeDescription, List<String> includedProperties, @Nullable Condition condition, Node rootNode) {
 
-		return createPathMatchWithCondition(null, nodeDescription, condition, rootNode);
+		return createPathMatchWithCondition(null, nodeDescription, includedProperties, condition, rootNode);
 	}
 
 	public StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere createPathMatchWithCondition(
 			@Nullable StatementBuilder.OngoingReadingWithoutWhere previousMatches,
-			NodeDescription<?> nodeDescription, @Nullable Condition condition, Node rootNode) {
+			NodeDescription<?> nodeDescription, List<String> includedProperties, @Nullable Condition condition, Node rootNode) {
 
 		List<Expression> expressions1 = new ArrayList<>();
 		List<Expression> expressions2 = new ArrayList<>();
 
 		String aliasedPathName = "pathPattern";
-		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription);
+		Predicate<String> includeField = s -> includedProperties.isEmpty() || includedProperties.contains(s);
+		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription, includeField);
 		RelationshipPattern patternPath = createRelationships(rootNode, relationships);
 		NamedPath path = Cypher.path("p").definedBy(patternPath);
 
@@ -406,7 +415,7 @@ public enum CypherGenerator {
 	}
 
 	public Expression[] createReturnStatementForMatch(NodeDescription<?> nodeDescription) {
-		return createReturnStatementForMatch(nodeDescription, null);
+		return createReturnStatementForMatch(nodeDescription, Collections.emptyList());
 	}
 
 	/**
@@ -445,15 +454,15 @@ public enum CypherGenerator {
 
 	/**
 	 * @param nodeDescription Description of the root node
-	 * @param inputProperties A list of Java properties of the domain to be included. Those properties are compared with
+	 * @param includedProperties A list of Java properties of the domain to be included. Those properties are compared with
 	 *          the field names of graph properties respectively relationships.
 	 * @return An expresion to be returned by a Cypher statement
 	 */
 	public Expression[] createReturnStatementForMatch(NodeDescription<?> nodeDescription,
-			@Nullable List<String> inputProperties) {
+			List<String> includedProperties) {
 
 		List<RelationshipDescription> processedRelationships = new ArrayList<>();
-		if (nodeDescription.containsPossibleCircles()) {
+		if (nodeDescription.containsPossibleCircles(includedProperties)) {
 			List<Expression> returnExpressions = new ArrayList<>();
 			Node rootNode = anyNode(Constants.NAME_OF_ROOT_NODE);
 			returnExpressions.add(rootNode.as(Constants.NAME_OF_SYNTHESIZED_ROOT_NODE));
@@ -461,8 +470,7 @@ public enum CypherGenerator {
 			returnExpressions.add(Cypher.name(Constants.NAME_OF_SYNTHESIZED_RELATIONS));
 			return returnExpressions.toArray(new Expression[]{});
 		} else {
-			Predicate<String> includeField = s -> inputProperties == null || inputProperties.isEmpty()
-					|| inputProperties.contains(s);
+			Predicate<String> includeField = s -> includedProperties.isEmpty() || includedProperties.contains(s);
 			return new Expression[]{projectPropertiesAndRelationships(nodeDescription, Constants.NAME_OF_ROOT_NODE, includeField, processedRelationships)};
 		}
 	}
@@ -477,31 +485,23 @@ public enum CypherGenerator {
 	}
 
 	private MapProjection projectPropertiesAndRelationships(NodeDescription<?> nodeDescription, SymbolicName nodeName,
-			Predicate<String> includeProperty, List<RelationshipDescription> processedRelationships) {
+			Predicate<String> includedProperties, List<RelationshipDescription> processedRelationships) {
 
-		List<Object> contentOfProjection = new ArrayList<>();
+		List<Object> propertiesProjection = projectNodeProperties(nodeDescription, nodeName, includedProperties);
+		List<Object> contentOfProjection = new ArrayList<>(propertiesProjection);
 
-		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription);
-		relationships.removeIf(r -> !includeProperty.test(r.getFieldName()));
+		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription, includedProperties);
+		relationships.removeIf(r -> !includedProperties.test(r.getFieldName()));
 
-		if (nodeDescription.containsPossibleCircles()) {
-			Node node = anyNode(nodeName);
-			RelationshipPattern pattern = createRelationships(node, relationships);
-			NamedPath p = Cypher.path("p").definedBy(pattern);
-			contentOfProjection.add(Constants.NAME_OF_SYNTHESIZED_ROOT_NODE);
-			contentOfProjection.add(Constants.NAME_OF_ROOT_NODE);
-			contentOfProjection.add(Constants.NAME_OF_PATHS);
-			contentOfProjection.add(Cypher.listBasedOn(p).returning(p));
-		} else {
-			contentOfProjection.addAll(generateListsFor(relationships, nodeName, processedRelationships));
-		}
+		contentOfProjection.addAll(generateListsFor(relationships, nodeName, processedRelationships));
 		return Cypher.anyNode(nodeName).project(contentOfProjection);
 	}
 
 	@NonNull
-	static Collection<RelationshipDescription> getRelationshipDescriptionsUpAndDown(NodeDescription<?> nodeDescription) {
-		Collection<RelationshipDescription> relationships = new HashSet<>(nodeDescription.getRelationships());
+	static Collection<RelationshipDescription> getRelationshipDescriptionsUpAndDown(NodeDescription<?> nodeDescription,
+			Predicate<String> includedProperties) {
 
+		Collection<RelationshipDescription> relationships = new HashSet<>(nodeDescription.getRelationships());
 		for (NodeDescription<?> childDescription : nodeDescription.getChildNodeDescriptionsInHierarchy()) {
 			childDescription.getRelationships().forEach(concreteRelationship -> {
 
@@ -512,7 +512,10 @@ public enum CypherGenerator {
 				}
 			});
 		}
-		return relationships;
+
+		return relationships.stream().filter(relationshipDescription ->
+				includedProperties.test(relationshipDescription.getFieldName()))
+				.collect(Collectors.toSet());
 	}
 
 	private RelationshipPattern createRelationships(Node node, Collection<RelationshipDescription> relationshipDescriptions) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -24,6 +24,7 @@ import static org.neo4j.cypherdsl.core.Cypher.optionalMatch;
 import static org.neo4j.cypherdsl.core.Cypher.parameter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -110,8 +111,15 @@ public enum CypherGenerator {
 		List<Expression> expressions = new ArrayList<>();
 		expressions.add(Constants.NAME_OF_ROOT_NODE);
 		expressions.add(Functions.id(rootNode).as(Constants.NAME_OF_INTERNAL_ID));
-
-		return match(rootNode).where(conditionOrNoCondition(condition)).with(expressions.toArray(new Expression[] {}));
+		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription);
+		StatementBuilder.OngoingReadingWithoutWhere dings = match(rootNode);
+		if (nodeDescription.containsPossibleCircles()) {
+			RelationshipPattern pattern = createRelationships(rootNode, relationships);
+			NamedPath p = Cypher.path("p").definedBy(pattern);
+			dings = match(p);
+			expressions.add(p.getRequiredSymbolicName());
+		}
+		return dings.where(conditionOrNoCondition(condition)).with(expressions.toArray(new Expression[] {}));
 	}
 
 	/**
@@ -321,7 +329,7 @@ public enum CypherGenerator {
 				.delete(relationship.getSymbolicName().get()).build();
 	}
 
-	public Expression createReturnStatementForMatch(NodeDescription<?> nodeDescription) {
+	public Expression[] createReturnStatementForMatch(NodeDescription<?> nodeDescription) {
 		return createReturnStatementForMatch(nodeDescription, null);
 	}
 
@@ -365,16 +373,23 @@ public enum CypherGenerator {
 	 *          the field names of graph properties respectively relationships.
 	 * @return An expresion to be returned by a Cypher statement
 	 */
-	public Expression createReturnStatementForMatch(NodeDescription<?> nodeDescription,
+	public Expression[] createReturnStatementForMatch(NodeDescription<?> nodeDescription,
 			@Nullable List<String> inputProperties) {
 
-		Predicate<String> includeField = s -> inputProperties == null || inputProperties.isEmpty()
-				|| inputProperties.contains(s);
-
-		SymbolicName nodeName = Constants.NAME_OF_ROOT_NODE;
 		List<RelationshipDescription> processedRelationships = new ArrayList<>();
-
-		return projectPropertiesAndRelationships(nodeDescription, nodeName, includeField, processedRelationships);
+		if (nodeDescription.containsPossibleCircles()) {
+			List<Expression> returnExpressions = new ArrayList<>();
+			Node rootNode = anyNode(Constants.NAME_OF_ROOT_NODE);
+			NamedPath p = Cypher.path("p").get();
+			returnExpressions.add(rootNode.as(Constants.NAME_OF_SYNTHESIZED_ROOT_NODE));
+			returnExpressions.add(Functions.relationships(p).as(Constants.NAME_OF_SYNTHESIZED_RELATIONS));
+			returnExpressions.add(Functions.nodes(p).as(Constants.NAME_OF_SYNTHESIZED_RELATED_NODES));
+			return returnExpressions.toArray(new Expression[]{});
+		} else {
+			Predicate<String> includeField = s -> inputProperties == null || inputProperties.isEmpty()
+					|| inputProperties.contains(s);
+			return new Expression[]{projectPropertiesAndRelationships(nodeDescription, Constants.NAME_OF_ROOT_NODE, includeField, processedRelationships)};
+		}
 	}
 
 	// recursive entry point for relationships in return statement
@@ -389,8 +404,7 @@ public enum CypherGenerator {
 	private MapProjection projectPropertiesAndRelationships(NodeDescription<?> nodeDescription, SymbolicName nodeName,
 			Predicate<String> includeProperty, List<RelationshipDescription> processedRelationships) {
 
-		List<Object> propertiesProjection = projectNodeProperties(nodeDescription, nodeName, includeProperty);
-		List<Object> contentOfProjection = new ArrayList<>(propertiesProjection);
+		List<Object> contentOfProjection = new ArrayList<>();
 
 		Collection<RelationshipDescription> relationships = getRelationshipDescriptionsUpAndDown(nodeDescription);
 		relationships.removeIf(r -> !includeProperty.test(r.getFieldName()));

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
@@ -35,10 +34,8 @@ import java.util.stream.StreamSupport;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.neo4j.driver.internal.value.NodeValue;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.Node;
-import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
 import org.neo4j.driver.types.Type;
 import org.neo4j.driver.types.TypeSystem;

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -247,7 +247,10 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			Neo4jPersistentEntity<ET> concreteNodeDescription = (Neo4jPersistentEntity<ET>) nodeDescriptionAndLabels
 					.getNodeDescription();
 
-			Collection<RelationshipDescription> relationships = CypherGenerator.getRelationshipDescriptionsUpAndDown(nodeDescription);
+			Predicate<String> includeAllFields = (field) -> true;
+
+			Collection<RelationshipDescription> relationships = CypherGenerator
+					.getRelationshipDescriptionsUpAndDown(nodeDescription, includeAllFields);
 
 			ET instance = instantiate(concreteNodeDescription, queryResult, allValues, relationships,
 					nodeDescriptionAndLabels.getDynamicLabels(), lastMappedEntity);

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -87,8 +87,6 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 
 	private final Lazy<Boolean> isRelationshipPropertiesEntity;
 
-	private final Lazy<Boolean> containsPossibleCircles;
-
 	DefaultNeo4jPersistentEntity(TypeInformation<T> information) {
 		super(information);
 
@@ -99,7 +97,6 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 		this.dynamicLabelsProperty = Lazy.of(() -> getGraphProperties().stream().map(Neo4jPersistentProperty.class::cast)
 				.filter(Neo4jPersistentProperty::isDynamicLabels).findFirst().orElse(null));
 		this.isRelationshipPropertiesEntity = Lazy.of(() -> isAnnotationPresent(RelationshipProperties.class));
-		this.containsPossibleCircles = Lazy.of(this::calculatePossibleCircles);
 	}
 
 	/*
@@ -440,15 +437,18 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 	}
 
 	@Override
-	public boolean containsPossibleCircles() {
-		return containsPossibleCircles.get();
+	public boolean containsPossibleCircles(List<String> includedProperties) {
+		return calculatePossibleCircles(includedProperties);
 	}
 
-	private boolean calculatePossibleCircles() {
+	private boolean calculatePossibleCircles(List<String> includedProperties) {
 		Collection<RelationshipDescription> relationships = getRelationships();
 
 		Set<RelationshipDescription> processedRelationships = new HashSet<>();
 		for (RelationshipDescription relationship : relationships) {
+			if (!includedProperties.isEmpty() && !includedProperties.contains(relationship.getFieldName())) {
+				continue;
+			}
 			if (processedRelationships.contains(relationship)) {
 				return true;
 			}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
@@ -136,6 +136,6 @@ public interface NodeDescription<T> {
 	/**
 	 * @return Information if the domain would contain schema circles.
 	 */
-	boolean containsPossibleCircles();
+	boolean containsPossibleCircles(List<String> includeProperties);
 
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -162,8 +162,6 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 			this.propertyPath = propertyPath;
 		}
 
-
-
 		public PersistentPropertyPath<?> getPropertyPath() {
 			return propertyPath;
 		}
@@ -282,24 +280,22 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 
 		Iterator<PropertyPathWrapper> wrapperIterator = propertyPathWrappers.iterator();
 		while (wrapperIterator.hasNext()) {
-			PropertyPathWrapper propertyPathWithRelationship = wrapperIterator.next();
-			if (propertyPathWithRelationship.hasRelationships()) {
+			PropertyPathWrapper possiblePathWithRelationship = wrapperIterator.next();
+			if (possiblePathWithRelationship.hasRelationships()) {
 				// first loop should create the starting relationship
 				if (matches == null) {
-					matches = Cypher.match((RelationshipPattern) propertyPathWithRelationship.createRelationshipChain(startNode));
+					matches = Cypher.match((RelationshipPattern) possiblePathWithRelationship.createRelationshipChain(startNode));
 				} else { // the next ones adds another relationship chain as separated match
-					matches.match(((RelationshipPattern) propertyPathWithRelationship.createRelationshipChain(startNode)));
-				}
-				// closing action: add the condition and path match
-				if (!wrapperIterator.hasNext()) {
-					if (nodeDescription.containsPossibleCircles()) {
-						matchAndCondition = cypherGenerator
-								.createPathMatchWithCondition(matches, nodeDescription, condition, startNode);
-					} else {
-						matchAndCondition = matches.where(condition);
-					}
+					matches.match(((RelationshipPattern) possiblePathWithRelationship.createRelationshipChain(startNode)));
 				}
 			}
+		}
+
+		// closing action: add the condition and path match
+		if (nodeDescription.containsPossibleCircles(includedProperties)) {
+			matchAndCondition = cypherGenerator.createPathMatchWithCondition(matches, nodeDescription, includedProperties, condition, startNode);
+		} else if (matches != null) {
+			matchAndCondition = matches.where(condition);
 		}
 
 		Statement statement;

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -290,9 +290,14 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 				} else { // the next ones adds another relationship chain as separated match
 					matches.match(((RelationshipPattern) propertyPathWithRelationship.createRelationshipChain(startNode)));
 				}
-				// closing action: add the condition
+				// closing action: add the condition and path match
 				if (!wrapperIterator.hasNext()) {
-					matchAndCondition = matches.where(condition);
+					if (nodeDescription.containsPossibleCircles()) {
+						matchAndCondition = cypherGenerator
+								.createPathMatchWithCondition(matches, nodeDescription, condition, startNode);
+					} else {
+						matchAndCondition = matches.where(condition);
+					}
 				}
 			}
 		}

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/AdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/AdvancedMappingIT.java
@@ -85,6 +85,15 @@ class AdvancedMappingIT {
 		}
 	}
 
+	interface MovieProjectionWithActorProjection {
+		String getTitle();
+		List<ActorProjection> getActors();
+
+		interface ActorProjection {
+			String getName();
+		}
+	}
+
 	interface MovieProjection {
 
 		String getTitle();
@@ -117,6 +126,8 @@ class AdvancedMappingIT {
 		MovieProjection findProjectionByTitle(String title);
 
 		MovieDTO findDTOByTitle(String title);
+
+		MovieProjectionWithActorProjection findProjectionWithProjectionByTitle(String title);
 	}
 
 	@Test // GH-2117
@@ -139,6 +150,17 @@ class AdvancedMappingIT {
 		MovieDTO dtoProjection = movieRepository.findDTOByTitle("The Matrix");
 		assertThat(dtoProjection.getTitle()).isNotNull();
 		assertThat(dtoProjection.getActors()).isNotEmpty();
+	}
+
+	@Test // GH-2117
+	void bothCyclicAndNonCyclicRelationshipsAreExcludedFromProjectionsWithProjections(@Autowired MovieRepository movieRepository) {
+
+		// The movie domain is a good fit for this test
+		// as the cyclic dependencies is pretty slow to retrieve from Neo4j
+		// this does OOM in most setups.
+		MovieProjectionWithActorProjection projection = movieRepository.findProjectionWithProjectionByTitle("The Matrix");
+		assertThat(projection.getTitle()).isNotNull();
+		assertThat(projection.getActors()).isNotEmpty();
 	}
 
 	@Test // GH-2114

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -29,7 +29,7 @@
     <logger name="OutboundMessageHandler" level="info"/>
     <logger name="InboundMessageDispatcher" level="info"/>
 
-    <logger name="org.springframework.data.neo4j.cypher" level="info"/>
+    <logger name="org.springframework.data.neo4j.cypher" level="trace"/>
     <logger name="org.springframework.data.neo4j" level="info"/>
     <logger name="org.springframework.data.neo4j.test" level="info"/>
     <logger name="org.springframework.data.neo4j.repository.query.Neo4jQuerySupport" level="debug" />

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -29,7 +29,7 @@
     <logger name="OutboundMessageHandler" level="info"/>
     <logger name="InboundMessageDispatcher" level="info"/>
 
-    <logger name="org.springframework.data.neo4j.cypher" level="trace"/>
+    <logger name="org.springframework.data.neo4j.cypher" level="info"/>
     <logger name="org.springframework.data.neo4j" level="info"/>
     <logger name="org.springframework.data.neo4j.test" level="info"/>
     <logger name="org.springframework.data.neo4j.repository.query.Neo4jQuerySupport" level="debug" />


### PR DESCRIPTION
This PR reduces the complexity of path mapping from the application side to the database.
The result of a path-based query will be in the style of `n, collect(related_nodes), collect(relationships)`.

This PR is right now a draft because it needs a CypherDSL release with at least
https://github.com/neo4j-contrib/cypher-dsl/pull/118
and
https://github.com/neo4j-contrib/cypher-dsl/pull/120
available.