### PR TITLE
Push database selection down to (Reactive)Neo4jClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.1.0-SNAPSHOT</version>
+	<version>6.1.0-GH-2159-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
@@ -54,8 +54,8 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 	 * @return A imperative Neo4j client.
 	 */
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_CLIENT_BEAN_NAME)
-	public Neo4jClient neo4jClient(Driver driver) {
-		return Neo4jClient.create(driver);
+	public Neo4jClient neo4jClient(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
+		return Neo4jClient.create(driver, databaseSelectionProvider);
 	}
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
@@ -59,10 +59,9 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 	}
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
-	public Neo4jOperations neo4jTemplate(final Neo4jClient neo4jClient, final Neo4jMappingContext mappingContext,
-			DatabaseSelectionProvider databaseNameProvider) {
+	public Neo4jOperations neo4jTemplate(final Neo4jClient neo4jClient, final Neo4jMappingContext mappingContext) {
 
-		return new Neo4jTemplate(neo4jClient, mappingContext, databaseNameProvider);
+		return new Neo4jTemplate(neo4jClient, mappingContext);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
@@ -60,9 +60,9 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
 	public ReactiveNeo4jTemplate neo4jTemplate(final ReactiveNeo4jClient neo4jClient,
-			final Neo4jMappingContext mappingContext, final ReactiveDatabaseSelectionProvider databaseNameProvider) {
+			final Neo4jMappingContext mappingContext) {
 
-		return new ReactiveNeo4jTemplate(neo4jClient, mappingContext, databaseNameProvider);
+		return new ReactiveNeo4jTemplate(neo4jClient, mappingContext);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiConfigurationSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiConfigurationSupport.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.data.neo4j.config;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.apiguardian.api.API;
 import org.neo4j.driver.Driver;
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
@@ -31,6 +25,12 @@ import org.springframework.data.neo4j.core.convert.Neo4jConversions;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
 
 /**
  * Support class that can be used as is for all necessary CDI beans or as a blueprint for custom producers.
@@ -66,10 +66,9 @@ class Neo4jCdiConfigurationSupport {
 	@Produces @Builtin @Singleton
 	public Neo4jOperations neo4jOperations(
 			@Any Instance<Neo4jClient> neo4jClient,
-			@Any Instance<Neo4jMappingContext> mappingContext,
-			@Any Instance<DatabaseSelectionProvider> databaseNameProvider
+			@Any Instance<Neo4jMappingContext> mappingContext
 	) {
-		return new Neo4jTemplate(resolve(neo4jClient), resolve(mappingContext), resolve(databaseNameProvider));
+		return new Neo4jTemplate(resolve(neo4jClient), resolve(mappingContext));
 	}
 
 	@Produces @Singleton

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
@@ -56,13 +56,15 @@ class DefaultNeo4jClient implements Neo4jClient {
 
 	private final Driver driver;
 	private final TypeSystem typeSystem;
+	private final DatabaseSelectionProvider databaseSelectionProvider;
 	private final ConversionService conversionService;
 	private final Neo4jPersistenceExceptionTranslator persistenceExceptionTranslator = new Neo4jPersistenceExceptionTranslator();
 
-	DefaultNeo4jClient(Driver driver) {
+	DefaultNeo4jClient(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
 
 		this.driver = driver;
 		this.typeSystem = driver.defaultTypeSystem();
+		this.databaseSelectionProvider = databaseSelectionProvider;
 
 		this.conversionService = new DefaultConversionService();
 		new Neo4jConversions().registerConvertersIn((ConverterRegistry) conversionService);
@@ -262,7 +264,11 @@ class DefaultNeo4jClient implements Neo4jClient {
 
 		DefaultRecordFetchSpec(String targetDatabase, RunnableStatement runnableStatement,
 				BiFunction<TypeSystem, Record, T> mappingFunction) {
-			this.targetDatabase = targetDatabase;
+			this.targetDatabase = targetDatabase != null
+					? targetDatabase
+					: databaseSelectionProvider != null
+						? databaseSelectionProvider.getDatabaseSelection().getValue()
+						: null;
 			this.runnableStatement = runnableStatement;
 			this.mappingFunction = mappingFunction;
 		}

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
@@ -48,7 +48,12 @@ public interface Neo4jClient {
 
 	static Neo4jClient create(Driver driver) {
 
-		return new DefaultNeo4jClient(driver);
+		return new DefaultNeo4jClient(driver, null);
+	}
+
+	static Neo4jClient create(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
+
+		return new DefaultNeo4jClient(driver, databaseSelectionProvider);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
@@ -51,7 +51,7 @@ public interface ReactiveNeo4jClient {
 		return new DefaultReactiveNeo4jClient(driver, null);
 	}
 
-	static ReactiveNeo4jClient create(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
+	static ReactiveNeo4jClient create(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 		return new DefaultReactiveNeo4jClient(driver, databaseSelectionProvider);
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
@@ -48,7 +48,12 @@ public interface ReactiveNeo4jClient {
 
 	static ReactiveNeo4jClient create(Driver driver) {
 
-		return new DefaultReactiveNeo4jClient(driver);
+		return new DefaultReactiveNeo4jClient(driver, null);
+	}
+
+	static ReactiveNeo4jClient create(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
+
+		return new DefaultReactiveNeo4jClient(driver, databaseSelectionProvider);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
@@ -185,6 +185,30 @@ class Neo4jClientTest {
 		verify(driver).defaultTypeSystem();
 	}
 
+	@Test
+	void databaseSelectionBeanShouldGetRespectedIfExisting() {
+		prepareMocks();
+		when(session.run(anyString(), anyMap())).thenReturn(result);
+		when(result.stream()).thenReturn(Stream.of(record1, record2));
+		when(result.consume()).thenReturn(resultSummary);
+
+		DatabaseSelectionProvider databaseSelection = DatabaseSelectionProvider
+				.createStaticDatabaseSelectionProvider("databaseSelection");
+
+		Neo4jClient client = Neo4jClient.create(driver, databaseSelection);
+
+		client.query("RETURN 1").fetch().first();
+		verifyDatabaseSelection("databaseSelection");
+
+		verify(session).run(eq("RETURN 1"), anyMap());
+		verify(result).stream();
+		verify(result).consume();
+		verify(resultSummary).notifications();
+		verify(record1).asMap();
+		verify(session).close();
+
+	}
+
 	@Nested
 	@DisplayName("Callback handling should feel good")
 	class CallbackHandlingShouldFeelGood {

--- a/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
@@ -185,22 +185,24 @@ class Neo4jClientTest {
 		verify(driver).defaultTypeSystem();
 	}
 
-	@Test
+	@Test // GH-2159
 	void databaseSelectionBeanShouldGetRespectedIfExisting() {
 		prepareMocks();
 		when(session.run(anyString(), anyMap())).thenReturn(result);
 		when(result.stream()).thenReturn(Stream.of(record1, record2));
 		when(result.consume()).thenReturn(resultSummary);
 
+		String databaseName = "customDatabaseSelection";
 		DatabaseSelectionProvider databaseSelection = DatabaseSelectionProvider
-				.createStaticDatabaseSelectionProvider("databaseSelection");
+				.createStaticDatabaseSelectionProvider(databaseName);
 
 		Neo4jClient client = Neo4jClient.create(driver, databaseSelection);
 
-		client.query("RETURN 1").fetch().first();
-		verifyDatabaseSelection("databaseSelection");
+		String query = "RETURN 1";
+		client.query(query).fetch().first();
+		verifyDatabaseSelection(databaseName);
 
-		verify(session).run(eq("RETURN 1"), anyMap());
+		verify(session).run(eq(query), anyMap());
 		verify(result).stream();
 		verify(result).consume();
 		verify(resultSummary).notifications();

--- a/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
@@ -201,7 +201,7 @@ class ReactiveNeo4jClientTest {
 
 		String databaseName = "customDatabaseSelection";
 		String cypher = "RETURN 1";
-		DatabaseSelectionProvider databaseSelection = DatabaseSelectionProvider
+		ReactiveDatabaseSelectionProvider databaseSelection = ReactiveDatabaseSelectionProvider
 				.createStaticDatabaseSelectionProvider(databaseName);
 
 

--- a/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
@@ -15,26 +15,6 @@
  */
 package org.springframework.data.neo4j.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,6 +33,25 @@ import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.TypeSystem;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Michael J. Simons
@@ -188,6 +187,40 @@ class ReactiveNeo4jClientTest {
 		}
 
 		verify(driver).defaultTypeSystem();
+	}
+
+	@Test // GH-2159
+	void databaseSelectionBeanShouldGetRespectedIfExisting() {
+
+		prepareMocks();
+
+		when(transaction.run(anyString(), anyMap())).thenReturn(result);
+		when(transaction.commit()).thenReturn(Mono.empty());
+		when(result.records()).thenReturn(Flux.just(record1, record2));
+		when(result.consume()).thenReturn(Mono.just(resultSummary));
+
+		String databaseName = "customDatabaseSelection";
+		String cypher = "RETURN 1";
+		DatabaseSelectionProvider databaseSelection = DatabaseSelectionProvider
+				.createStaticDatabaseSelectionProvider(databaseName);
+
+
+		ReactiveNeo4jClient client = ReactiveNeo4jClient.create(driver, databaseSelection);
+
+		StepVerifier.create(client.query(cypher).fetch().first())
+				.expectNextCount(1L)
+				.verifyComplete();
+
+		verifyDatabaseSelection(databaseName);
+
+		verify(transaction).run(eq(cypher), anyMap());
+		verify(result).records();
+		verify(result).consume();
+		verify(resultSummary).notifications();
+		verify(record1).asMap();
+		verify(transaction).commit();
+		verify(transaction).rollback();
+		verify(session).close();
 	}
 
 	@Nested

--- a/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
@@ -91,7 +91,7 @@ class TransactionHandlingTest {
 				when(driver.session(any(SessionConfig.class))).thenReturn(session);
 
 				// Make template acquire session
-				DefaultNeo4jClient neo4jClient = new DefaultNeo4jClient(driver);
+				DefaultNeo4jClient neo4jClient = new DefaultNeo4jClient(driver, null);
 				try (DefaultNeo4jClient.AutoCloseableQueryRunner s = neo4jClient.getQueryRunner("aDatabase")) {
 					s.run("MATCH (n) RETURN n");
 				}
@@ -124,7 +124,7 @@ class TransactionHandlingTest {
 				Neo4jTransactionManager txManager = new Neo4jTransactionManager(driver);
 				TransactionTemplate txTemplate = new TransactionTemplate(txManager);
 
-				DefaultNeo4jClient neo4jClient = new DefaultNeo4jClient(driver);
+				DefaultNeo4jClient neo4jClient = new DefaultNeo4jClient(driver, null);
 				txTemplate.execute(tx -> {
 					try (DefaultNeo4jClient.AutoCloseableQueryRunner s = neo4jClient.getQueryRunner(null)) {
 						s.run("MATCH (n) RETURN n");

--- a/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
@@ -154,7 +154,7 @@ class TransactionHandlingTest {
 
 		@Test
 		void shouldNotOpenTransactionsWithoutSubscription() {
-			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver);
+			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver, null);
 			neo4jClient.query("RETURN 1").in("aDatabase").fetch().one();
 
 			verify(driver, never()).rxSession(any(SessionConfig.class));
@@ -169,7 +169,7 @@ class TransactionHandlingTest {
 			when(transaction.commit()).thenReturn(Mono.empty());
 			when(session.close()).thenReturn(Mono.empty());
 
-			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver);
+			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver, null);
 
 			Mono<String> sequence = neo4jClient.doInQueryRunnerForMono("aDatabase", tx -> Mono.just("1"));
 
@@ -191,7 +191,7 @@ class TransactionHandlingTest {
 			when(transaction.rollback()).thenReturn(Mono.empty());
 			when(session.close()).thenReturn(Mono.empty());
 
-			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver);
+			DefaultReactiveNeo4jClient neo4jClient = new DefaultReactiveNeo4jClient(driver, null);
 
 			Mono<String> sequence = neo4jClient.doInQueryRunnerForMono("aDatabase", tx -> Mono.error(new SomeException()));
 

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Config.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Config.java
@@ -63,10 +63,9 @@ public class Domain1Config {
 	@Primary @Bean
 	public Neo4jOperations domain1Template(
 			@Qualifier("domain1Client") Neo4jClient domain1Client,
-			@Qualifier("domain1Context") Neo4jMappingContext domain1Context,
-			@Qualifier("domain1Selection") DatabaseSelectionProvider domain1Selection
+			@Qualifier("domain1Context") Neo4jMappingContext domain1Context
 	) {
-		return new Neo4jTemplate(domain1Client, domain1Context, domain1Selection);
+		return new Neo4jTemplate(domain1Client, domain1Context);
 	}
 
 	@Primary @Bean

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Config.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Config.java
@@ -62,10 +62,9 @@ public class Domain2Config {
 	@Bean
 	public Neo4jOperations domain2Template(
 			@Qualifier("domain2Client") Neo4jClient domain2Client,
-			@Qualifier("domain2Context") Neo4jMappingContext domain2Context,
-			@Qualifier("domain2Selection") DatabaseSelectionProvider domain2Selection
+			@Qualifier("domain2Context") Neo4jMappingContext domain2Context
 	) {
-		return new Neo4jTemplate(domain2Client, domain2Context, domain2Selection);
+		return new Neo4jTemplate(domain2Client, domain2Context);
 	}
 
 	@Bean


### PR DESCRIPTION
This was done to give also users of the pure (Reactive)Neo4jClient the option to use the `DatabaseSelectionProvider` (or its reactive pendant).

We might have to discuss if the bean creation methods in the `AbstractNeo4jConfig` and `AbstractReactiveNeo4jConfig` need to keep the signature with the unused `DatabaseSelectionProvider` / `ReactiveDatabaseSelectionProvider` for a while with deprecation warnings and a replacement following in up in 6.2.0.