### PR TITLE
Respect class hierachy when querying for and mapping to generic classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.6-SNAPSHOT</version>
+	<version>6.0.6-GH-2138-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -701,7 +701,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			final Set<Long> relationshipIds = new HashSet<>();
 			final Set<Long> relatedNodeIds = new HashSet<>();
 
-			for (RelationshipDescription relationshipDescription : entityMetaData.getRelationshipsUpAndDown(fieldName -> queryFragments.includeField(fieldName))) {
+			for (RelationshipDescription relationshipDescription : entityMetaData.getRelationshipsInHierarchy(fieldName -> queryFragments.includeField(fieldName))) {
 
 				Statement statement = cypherGenerator
 						.prepareMatchOf(entityMetaData, relationshipDescription, queryFragments.getMatchOn(), queryFragments.getCondition())
@@ -720,7 +720,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		private void iterateNextLevel(Collection<Long> nodeIds, Neo4jPersistentEntity<?> target, Set<Long> relationshipIds,
 									  Set<Long> relatedNodeIds) {
 
-			Collection<RelationshipDescription> relationships = target.getRelationshipsUpAndDown(s -> true);
+			Collection<RelationshipDescription> relationships = target.getRelationshipsInHierarchy(s -> true);
 			for (RelationshipDescription relationshipDescription : relationships) {
 
 				Node node = anyNode(Constants.NAME_OF_ROOT_NODE);

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
@@ -702,13 +701,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			final Set<Long> relationshipIds = new HashSet<>();
 			final Set<Long> relatedNodeIds = new HashSet<>();
 
-			Predicate<RelationshipDescription> relationshipFilter = ((Predicate<RelationshipDescription>) relationshipDescription ->
-					queryFragments.includeField(relationshipDescription.getFieldName())).negate();
-
-			for (RelationshipDescription relationshipDescription : entityMetaData.getRelationships()) {
-				if (relationshipFilter.test(relationshipDescription)) {
-					continue;
-				}
+			for (RelationshipDescription relationshipDescription : entityMetaData.getRelationshipsUpAndDown(fieldName -> queryFragments.includeField(fieldName))) {
 
 				Statement statement = cypherGenerator
 						.prepareMatchOf(entityMetaData, relationshipDescription, queryFragments.getMatchOn(), queryFragments.getCondition())
@@ -727,7 +720,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		private void iterateNextLevel(Collection<Long> nodeIds, Neo4jPersistentEntity<?> target, Set<Long> relationshipIds,
 									  Set<Long> relatedNodeIds) {
 
-			Collection<RelationshipDescription> relationships = target.getRelationships();
+			Collection<RelationshipDescription> relationships = target.getRelationshipsUpAndDown(s -> true);
 			for (RelationshipDescription relationshipDescription : relationships) {
 
 				Node node = anyNode(Constants.NAME_OF_ROOT_NODE);

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -469,7 +469,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 				Set<Long> rootNodeIds = ctx.get("rootNodes");
 				Set<Long> processedRelationshipIds = ctx.get("processedRelationships");
 				Set<Long> processedNodeIds = ctx.get("processedNodes");
-				return Flux.fromIterable(entityMetaData.getRelationshipsUpAndDown(fieldName -> queryFragments.includeField(fieldName)))
+				return Flux.fromIterable(entityMetaData.getRelationshipsInHierarchy(fieldName -> queryFragments.includeField(fieldName)))
 						.flatMap(relationshipDescription -> {
 
 							Statement statement = cypherGenerator.prepareMatchOf(entityMetaData, relationshipDescription,
@@ -509,7 +509,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 		NodeDescription<?> target = relationshipDescription.getTarget();
 
-		return Flux.fromIterable(target.getRelationshipsUpAndDown(s -> true))
+		return Flux.fromIterable(target.getRelationshipsInHierarchy(s -> true))
 			.flatMap(relDe -> {
 				Node node = anyNode(Constants.NAME_OF_ROOT_NODE);
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -502,7 +502,7 @@ public enum CypherGenerator {
 		List<Object> propertiesProjection = projectNodeProperties(nodeDescription, nodeName, includedProperties);
 		List<Object> contentOfProjection = new ArrayList<>(propertiesProjection);
 
-		Collection<RelationshipDescription> relationships = nodeDescription.getRelationshipsUpAndDown(includedProperties);
+		Collection<RelationshipDescription> relationships = nodeDescription.getRelationshipsInHierarchy(includedProperties);
 		relationships.removeIf(r -> !includedProperties.test(r.getFieldName()));
 
 		contentOfProjection.addAll(generateListsFor(relationships, nodeName, processedRelationships));

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -422,7 +422,7 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 	}
 
 	@NonNull
-	public Collection<RelationshipDescription> getRelationshipsUpAndDown(Predicate<String> propertyFilter) {
+	public Collection<RelationshipDescription> getRelationshipsInHierarchy(Predicate<String> propertyFilter) {
 
 		Collection<RelationshipDescription> relationships = new HashSet<>(getRelationships());
 		for (NodeDescription<?> childDescription : getChildNodeDescriptionsInHierarchy()) {
@@ -496,7 +496,7 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 	}
 
 	private boolean calculatePossibleCircles(Predicate<String> includeField) {
-		Collection<RelationshipDescription> relationships = new HashSet<>(getRelationshipsUpAndDown(includeField));
+		Collection<RelationshipDescription> relationships = new HashSet<>(getRelationshipsInHierarchy(includeField));
 
 		Set<RelationshipDescription> processedRelationships = new HashSet<>();
 		for (RelationshipDescription relationship : relationships) {
@@ -515,7 +515,7 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 	}
 
 	private boolean calculatePossibleCircles(NodeDescription<?> nodeDescription, Set<RelationshipDescription> processedRelationships) {
-		Collection<RelationshipDescription> relationships = nodeDescription.getRelationshipsUpAndDown(s -> true);
+		Collection<RelationshipDescription> relationships = nodeDescription.getRelationshipsInHierarchy(s -> true);
 
 		for (RelationshipDescription relationship : relationships) {
 			if (processedRelationships.contains(relationship)) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
@@ -124,7 +124,7 @@ public final class NestedRelationshipContext {
 		Object value = propertyAccessor.getProperty(inverse);
 		boolean inverseValueIsEmpty = value == null;
 
-		RelationshipDescription relationship = neo4jPersistentEntity.getRelationships().stream()
+		RelationshipDescription relationship = neo4jPersistentEntity.getRelationshipsUpAndDown(s -> true).stream()
 				.filter(r -> r.getFieldName().equals(inverse.getName())).findFirst().get();
 
 		// if we have a relationship with properties, the targetNodeType is the map key

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
@@ -124,7 +124,7 @@ public final class NestedRelationshipContext {
 		Object value = propertyAccessor.getProperty(inverse);
 		boolean inverseValueIsEmpty = value == null;
 
-		RelationshipDescription relationship = neo4jPersistentEntity.getRelationshipsUpAndDown(s -> true).stream()
+		RelationshipDescription relationship = neo4jPersistentEntity.getRelationshipsInHierarchy(s -> true).stream()
 				.filter(r -> r.getFieldName().equals(inverse.getName())).findFirst().get();
 
 		// if we have a relationship with properties, the targetNodeType is the map key

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
@@ -103,7 +103,13 @@ public interface NodeDescription<T> {
 	 */
 	Collection<RelationshipDescription> getRelationships();
 
-	Collection<RelationshipDescription> getRelationshipsUpAndDown(Predicate<String> propertyPredicate);
+	/**
+	 * This returns the relationships this node, its parent and child has to other nodes.
+	 *
+	 * @param propertyPredicate - Predicate to filter the fields on this node description to
+	 * @return The relationships defined by instances of this node.
+	 */
+	Collection<RelationshipDescription> getRelationshipsInHierarchy(Predicate<String> propertyPredicate);
 
 	/**
 	 * Register a direct child node description for this entity.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
@@ -103,6 +103,8 @@ public interface NodeDescription<T> {
 	 */
 	Collection<RelationshipDescription> getRelationships();
 
+	Collection<RelationshipDescription> getRelationshipsUpAndDown(Predicate<String> propertyPredicate);
+
 	/**
 	 * Register a direct child node description for this entity.
 	 *

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
@@ -78,10 +78,11 @@ final class NodeDescriptionStore {
 
 	public static NodeDescriptionAndLabels deriveConcreteNodeDescription(Neo4jPersistentEntity<?> entityDescription,
 			List<String> labels) {
+
 		if (labels == null || labels.isEmpty()) {
 			return new NodeDescriptionAndLabels(entityDescription, Collections.emptyList());
 		}
-		NodeDescriptionAndLabels nodeDescriptionAndLabels = null;
+
 		for (NodeDescription<?> childNodeDescription : entityDescription.getChildNodeDescriptionsInHierarchy()) {
 			String primaryLabel = childNodeDescription.getPrimaryLabel();
 			List<String> additionalLabels = new ArrayList<>(childNodeDescription.getAdditionalLabels());
@@ -90,19 +91,9 @@ final class NodeDescriptionStore {
 				Set<String> surplusLabels = new HashSet<>(labels);
 				surplusLabels.remove(primaryLabel);
 				surplusLabels.removeAll(additionalLabels);
-				// if we find more than one, we have to distinguish between the options in the mapping logic later.
-				if (nodeDescriptionAndLabels == null) {
-					nodeDescriptionAndLabels = new NodeDescriptionAndLabels(childNodeDescription, surplusLabels);
-				} else {
-					surplusLabels = new HashSet<>(labels);
-					surplusLabels.remove(entityDescription.getPrimaryLabel());
-					surplusLabels.removeAll(entityDescription.getAdditionalLabels());
-					return new NodeDescriptionAndLabels(entityDescription, surplusLabels);
-				}
+
+				return new NodeDescriptionAndLabels(childNodeDescription, surplusLabels);
 			}
-		}
-		if (nodeDescriptionAndLabels != null) {
-			return nodeDescriptionAndLabels;
 		}
 
 		Set<String> surplusLabels = new HashSet<>(labels);

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
@@ -81,6 +81,7 @@ final class NodeDescriptionStore {
 		if (labels == null || labels.isEmpty()) {
 			return new NodeDescriptionAndLabels(entityDescription, Collections.emptyList());
 		}
+		NodeDescriptionAndLabels nodeDescriptionAndLabels = null;
 		for (NodeDescription<?> childNodeDescription : entityDescription.getChildNodeDescriptionsInHierarchy()) {
 			String primaryLabel = childNodeDescription.getPrimaryLabel();
 			List<String> additionalLabels = new ArrayList<>(childNodeDescription.getAdditionalLabels());
@@ -89,8 +90,19 @@ final class NodeDescriptionStore {
 				Set<String> surplusLabels = new HashSet<>(labels);
 				surplusLabels.remove(primaryLabel);
 				surplusLabels.removeAll(additionalLabels);
-				return new NodeDescriptionAndLabels(childNodeDescription, surplusLabels);
+				// if we find more than one, we have to distinguish between the options in the mapping logic later.
+				if (nodeDescriptionAndLabels == null) {
+					nodeDescriptionAndLabels = new NodeDescriptionAndLabels(childNodeDescription, surplusLabels);
+				} else {
+					surplusLabels = new HashSet<>(labels);
+					surplusLabels.remove(entityDescription.getPrimaryLabel());
+					surplusLabels.removeAll(entityDescription.getAdditionalLabels());
+					return new NodeDescriptionAndLabels(entityDescription, surplusLabels);
+				}
 			}
+		}
+		if (nodeDescriptionAndLabels != null) {
+			return nodeDescriptionAndLabels;
 		}
 
 		Set<String> surplusLabels = new HashSet<>(labels);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.imperative;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.AbstractNeo4jConfig;
+import org.springframework.data.neo4j.integration.shared.common.Inheritance;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Gerrit Meier
+ */
+@Neo4jIntegrationTest
+public class InheritanceMappingIT {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final Driver driver;
+
+	public InheritanceMappingIT(@Autowired Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	void deleteData() {
+		try (Session session = driver.session()) {
+			session.run("MATCH (n) DETACH DELETE n").consume();
+		}
+	}
+
+	@Test // GH-2138
+	void relationshipsShouldHaveCorrectTypes(@Autowired BuildingRepository repository) {
+
+		Long buildingId = null;
+		try (Session session = driver.session()) {
+			buildingId = session.run("CREATE (b:Building:Entity{name:'b'})-[:IS_CHILD]->(:Site:Entity{name:'s'})-[:IS_CHILD]->(:Company:Entity{name:'c'}) return id(b) as id").single()
+					.get(0).asLong();
+		}
+
+		Inheritance.Building building = repository.findById(buildingId).get();
+
+		assertThat(building.name).isEqualTo("b");
+		assertThat(building.parent.name).isEqualTo("s");
+		assertThat(building.parent).isOfAnyClassIn(Inheritance.Site.class);
+		assertThat(building.parent.parent.name).isEqualTo("c");
+		assertThat(building.parent.parent).isOfAnyClassIn(Inheritance.Company.class);
+	}
+
+	@Test // GH-2138
+	void collectionsShouldHaveCorrectTypes(@Autowired TerritoryRepository repository) {
+
+		Long territoryId = null;
+		try (Session session = driver.session()) {
+			territoryId = session.run("CREATE (c:Country:BaseTerritory:BaseEntity{nameEn:'country'}) " +
+					"CREATE (c)-[:LINK]->(:Country:BaseTerritory:BaseEntity{nameEn:'anotherCountry', countryProperty:'large'}) " +
+					"CREATE (c)-[:LINK]->(:Continent:BaseTerritory:BaseEntity{nameEn:'continent', continentProperty:'small'}) " +
+					"CREATE (c)-[:LINK]->(:GenericTerritory:BaseTerritory:BaseEntity{nameEn:'generic'}) " +
+					"return id(c) as id").single()
+					.get(0).asLong();
+		}
+
+		Inheritance.BaseTerritory territory = repository.findById(territoryId).get();
+
+		assertThat(territory.nameEn).isEqualTo("country");
+
+		Inheritance.Country country = new Inheritance.Country("anotherCountry", "large");
+		Inheritance.Continent continent = new Inheritance.Continent("continent", "small");
+		Inheritance.GenericTerritory genericTerritory = new Inheritance.GenericTerritory("generic");
+
+		assertThat(((Inheritance.Country) territory).relationshipList).containsExactlyInAnyOrder(
+				country,
+				continent,
+				genericTerritory
+		);
+	}
+
+	@Repository
+	interface BuildingRepository extends Neo4jRepository<Inheritance.Building, Long> {}
+
+	@Repository
+	interface TerritoryRepository extends Neo4jRepository<Inheritance.BaseTerritory, Long> {}
+
+	@Configuration
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singleton(Inheritance.class.getPackage().getName());
+		}
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Inheritance.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Inheritance.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.neo4j.integration.shared.common;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
@@ -428,5 +430,155 @@ public class Inheritance {
 		}
 	}
 
+	/**
+	 * Base entity for GH-2138 generic relationships tests
+	 */
+	@Node("Entity")
+	public static abstract class Entity {
+		@org.springframework.data.annotation.Id
+		@GeneratedValue
+		public Long id;
+		public String name;
 
+		@Relationship(type = "IS_CHILD")
+		public Entity parent;
+	}
+
+	/**
+	 * company
+	 */
+	@Node("Company")
+	public static class Company extends Entity {}
+
+	/**
+	 * site
+	 */
+	@Node("Site")
+	public static class Site extends Entity {}
+
+	/**
+	 * building
+	 */
+	@Node("Building")
+	public static class Building extends Entity {}
+
+	/**
+	 * Base entity for GH-2138 generic relationship in child class tests
+	 */
+	@Node
+	public static abstract class BaseEntity {
+		@Id
+		@GeneratedValue
+		public Long id;
+		public String name;
+	}
+
+	/**
+	 * BaseTerritory
+	 */
+	@Node
+	public static abstract class BaseTerritory extends BaseEntity {
+		public String nameEs;
+		public final String nameEn;
+
+		public BaseTerritory(String nameEn) {
+			this.nameEn = nameEn;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			BaseTerritory that = (BaseTerritory) o;
+			return nameEn.equals(that.nameEn);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(nameEn);
+		}
+	}
+
+	/**
+	 * GenericTerritory
+	 */
+	@Node
+	public static class GenericTerritory extends BaseTerritory {
+		public GenericTerritory(String nameEn) {
+			super(nameEn);
+		}
+	}
+
+	/**
+	 * Country
+	 */
+	@Node
+	public static class Country extends BaseTerritory {
+		public final String countryProperty;
+
+		@Relationship(type = "LINK", direction = Relationship.Direction.OUTGOING)
+		public Set<BaseTerritory> relationshipList = new HashSet<>();
+
+		public Country(String nameEn, String countryProperty) {
+			super(nameEn);
+			this.countryProperty = countryProperty;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			Country country = (Country) o;
+			return countryProperty.equals(country.countryProperty);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), countryProperty);
+		}
+	}
+
+	/**
+	 * Continent
+	 */
+	@Node
+	public static class Continent extends BaseTerritory {
+		public final String continentProperty;
+
+		public Continent(String nameEn, String continentProperty) {
+			super(nameEn);
+			this.continentProperty = continentProperty;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			Continent continent = (Continent) o;
+			return continentProperty.equals(continent.continentProperty);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), continentProperty);
+		}
+	}
 }


### PR DESCRIPTION
This solves two problems that go hand in hand with each other:
a) The created query did not respect potential relationships in the child classes.
b) The mapping (`Neo4j..Converter`) maps a graph 
`(A)-(:B:A)-(:C:A)`
as 
`(A)-(:B:A)-(:B:A)`
because it keeps the same concrete node description of the prior mapped object in the chain if the next one has the same base class (`A`).