### PR TITLE
Make state machine for saving process more robust.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.6-SNAPSHOT</version>
+	<version>6.0.6-GH-2177-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -565,9 +565,6 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		Neo4jPersistentProperty requiredIdProperty = targetNodeDescription.getRequiredIdProperty();
 		PersistentPropertyAccessor<Object> ding = targetNodeDescription.getPropertyAccessor(entity);
 		Object idValue = ding.getProperty(requiredIdProperty);
-		if (idValue == null) {
-			System.out.println("nein");
-		}
 
 		return neo4jClient.query(() ->
 				renderer.render(cypherGenerator.prepareMatchOf(targetNodeDescription,

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -323,8 +323,11 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 				.bind(entityList).to(Constants.NAME_OF_ENTITY_LIST_PARAM).run();
 
 		// Save related
-		entitiesToBeSaved.forEach(entityToBeSaved -> processRelations(entityMetaData, entityToBeSaved,
-				isNewIndicator.get(entitiesToBeSaved.indexOf(entityToBeSaved)), databaseName, entities.get(entitiesToBeSaved.indexOf(entityToBeSaved))));
+		entitiesToBeSaved.forEach(entityToBeSaved -> {
+			int positionInList = entitiesToBeSaved.indexOf(entityToBeSaved);
+			processRelations(entityMetaData, entityToBeSaved, isNewIndicator.get(positionInList), databaseName,
+					entities.get(positionInList));
+		});
 
 		SummaryCounters counters = resultSummary.counters();
 		log.debug(() -> String.format(
@@ -563,8 +566,8 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 									  @Nullable String inDatabase) {
 
 		Neo4jPersistentProperty requiredIdProperty = targetNodeDescription.getRequiredIdProperty();
-		PersistentPropertyAccessor<Object> ding = targetNodeDescription.getPropertyAccessor(entity);
-		Object idValue = ding.getProperty(requiredIdProperty);
+		PersistentPropertyAccessor<Object> targetPropertyAccessor = targetNodeDescription.getPropertyAccessor(entity);
+		Object idValue = targetPropertyAccessor.getProperty(requiredIdProperty);
 
 		return neo4jClient.query(() ->
 				renderer.render(cypherGenerator.prepareMatchOf(targetNodeDescription,

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -253,7 +253,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			propertyAccessor.setProperty(entityMetaData.getRequiredIdProperty(), optionalInternalId.get());
 			entityToBeSaved = propertyAccessor.getBean();
 		}
-		return processRelations(entityMetaData, entityToBeSaved, isEntityNew, inDatabase);
+		return processRelations(entityMetaData, entityToBeSaved, isEntityNew, inDatabase, instance);
 	}
 
 	private <T> DynamicLabels determineDynamicLabels(T entityToBeSaved, Neo4jPersistentEntity<?> entityMetaData,
@@ -284,9 +284,9 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 		String databaseName = getDatabaseName();
 
-		Collection<T> entities;
+		List<T> entities;
 		if (instances instanceof Collection) {
-			entities = (Collection<T>) instances;
+			entities = new ArrayList<>((Collection<T>) instances);
 		} else {
 			entities = new ArrayList<>();
 			instances.forEach(entities::add);
@@ -324,7 +324,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 		// Save related
 		entitiesToBeSaved.forEach(entityToBeSaved -> processRelations(entityMetaData, entityToBeSaved,
-				isNewIndicator.get(entitiesToBeSaved.indexOf(entityToBeSaved)), databaseName));
+				isNewIndicator.get(entitiesToBeSaved.indexOf(entityToBeSaved)), databaseName, entities.get(entitiesToBeSaved.indexOf(entityToBeSaved))));
 
 		SummaryCounters counters = resultSummary.counters();
 		log.debug(() -> String.format(
@@ -434,10 +434,10 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 	}
 
 	private <T> T processRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
-			boolean isParentObjectNew, @Nullable String inDatabase) {
+			boolean isParentObjectNew, @Nullable String inDatabase, Object parentEntity) {
 
 		return processNestedRelations(neo4jPersistentEntity, parentObject, isParentObjectNew, inDatabase,
-				new NestedRelationshipProcessingStateMachine());
+				new NestedRelationshipProcessingStateMachine(parentEntity));
 	}
 
 	private <T> T processNestedRelations(Neo4jPersistentEntity<?> sourceEntity, Object parentObject,
@@ -468,7 +468,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 			// break recursive procession and deletion of previously created relationships
 			ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-			if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS) {
+			if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS || processState == ProcessState.PROCESSED_BOTH) {
 				return;
 			}
 
@@ -517,8 +517,14 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 				relatedNode = eventSupport.maybeCallBeforeBind(relatedNode);
 
-				Long relatedInternalId = saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),
-						targetEntity, inDatabase);
+				Long relatedInternalId;
+				// No need to save values if processed
+				if (processState == ProcessState.PROCESSED_ALL_VALUES) {
+					relatedInternalId = queryRelatedNode(relatedNode, targetEntity, inDatabase);
+				} else {
+					relatedInternalId = saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),
+							targetEntity, inDatabase);
+				}
 
 				CreateRelationshipStatementHolder statementHolder = neo4jMappingContext.createStatement(
 						sourceEntity, relationshipContext, relatedValueToStore);
@@ -551,6 +557,26 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		});
 
 		return (T) propertyAccessor.getBean();
+	}
+
+	private <Y> Long queryRelatedNode(Object entity, Neo4jPersistentEntity<?> targetNodeDescription,
+									  @Nullable String inDatabase) {
+
+		Neo4jPersistentProperty requiredIdProperty = targetNodeDescription.getRequiredIdProperty();
+		PersistentPropertyAccessor<Object> ding = targetNodeDescription.getPropertyAccessor(entity);
+		Object idValue = ding.getProperty(requiredIdProperty);
+		if (idValue == null) {
+			System.out.println("nein");
+		}
+
+		return neo4jClient.query(() ->
+				renderer.render(cypherGenerator.prepareMatchOf(targetNodeDescription,
+						targetNodeDescription.getIdExpression().isEqualTo(parameter(Constants.NAME_OF_ID)))
+						.returning(Constants.NAME_OF_INTERNAL_ID)
+						.build())
+				)
+				.in(inDatabase).bindAll(Collections.singletonMap(Constants.NAME_OF_ID, idValue))
+				.fetchAs(Long.class).one().get();
 	}
 
 	private <Y> Long saveRelatedNode(Object entity, Class<Y> entityType, NodeDescription targetNodeDescription,

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -698,7 +698,8 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 											} else {
 												return relationshipCreationMonoNested.checkpoint().then();
 											}
-										}).checkpoint();});
+										}).checkpoint();
+								});
 							});
 					relationshipCreationMonos.add(createRelationship);
 				}

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -713,8 +713,8 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 									  @Nullable String inDatabase) {
 
 		Neo4jPersistentProperty requiredIdProperty = targetNodeDescription.getRequiredIdProperty();
-		PersistentPropertyAccessor<Object> ding = targetNodeDescription.getPropertyAccessor(entity);
-		Object idValue = ding.getProperty(requiredIdProperty);
+		PersistentPropertyAccessor<Object> targetPropertyAccessor = targetNodeDescription.getPropertyAccessor(entity);
+		Object idValue = targetPropertyAccessor.getProperty(requiredIdProperty);
 
 		return neo4jClient.query(() ->
 				renderer.render(cypherGenerator.prepareMatchOf(targetNodeDescription,

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -249,7 +249,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 							}));
 
 					if (!entityMetaData.isUsingInternalIds()) {
-						return idMono.then(processRelations(entityMetaData, entity, isNewEntity, inDatabase))
+						return idMono.then(processRelations(entityMetaData, entity, isNewEntity, inDatabase, instance))
 								.thenReturn(entity);
 					} else {
 						return idMono.map(internalId -> {
@@ -258,7 +258,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 							return propertyAccessor.getBean();
 						}).flatMap(
-								savedEntity -> processRelations(entityMetaData, savedEntity, isNewEntity, inDatabase)
+								savedEntity -> processRelations(entityMetaData, savedEntity, isNewEntity, inDatabase, instance)
 										.thenReturn(savedEntity));
 					}
 				}));
@@ -290,9 +290,9 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 	@Override
 	public <T> Flux<T> saveAll(Iterable<T> instances) {
 
-		Collection<T> entities;
+		List<T> entities;
 		if (instances instanceof Collection) {
-			entities = (Collection<T>) instances;
+			entities = new ArrayList<>((Collection<T>) instances);
 		} else {
 			entities = new ArrayList<>();
 			instances.forEach(entities::add);
@@ -338,7 +338,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 												T entityToBeSaved = t.getT2();
 												boolean isNew = isNewIndicator.get(Math.toIntExact(t.getT1()));
 												return processRelations(entityMetaData, entityToBeSaved, isNew,
-														databaseName.getValue())
+														databaseName.getValue(), entities.get(Math.toIntExact(t.getT1())))
 														.then(Mono.just(entityToBeSaved));
 											}
 									);
@@ -566,10 +566,10 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 	}
 
 	private Mono<Void> processRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
-			boolean isParentObjectNew, @Nullable String inDatabase) {
+			boolean isParentObjectNew, @Nullable String inDatabase, Object parentEntity) {
 
 		return processNestedRelations(neo4jPersistentEntity, parentObject, isParentObjectNew, inDatabase,
-				new NestedRelationshipProcessingStateMachine());
+				new NestedRelationshipProcessingStateMachine(parentEntity));
 	}
 
 	private Mono<Void> processNestedRelations(Neo4jPersistentEntity<?> sourceEntity, Object parentObject,
@@ -602,7 +602,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 				// break recursive procession and deletion of previously created relationships
 				ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
-				if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS) {
+				if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS || processState == ProcessState.PROCESSED_BOTH) {
 					return;
 				}
 
@@ -652,9 +652,16 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 							.flatMap(relatedNode -> {
 								Neo4jPersistentEntity<?> targetEntity = neo4jMappingContext
 										.getPersistentEntity(relatedNodePreEvt.getClass());
-								return Mono.just(targetEntity.isNew(relatedNode)).flatMap(isNew ->
-										saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),
-										targetEntity, inDatabase).flatMap(relatedInternalId -> {
+								return Mono.just(targetEntity.isNew(relatedNode)).flatMap(isNew -> {
+									Mono<Long> relatedIdMono;
+
+									if (processState == ProcessState.PROCESSED_ALL_VALUES) {
+										relatedIdMono = queryRelatedNode(relatedNode, targetEntity, inDatabase);
+									} else {
+										relatedIdMono = saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),
+												targetEntity, inDatabase);
+									}
+									return relatedIdMono.flatMap(relatedInternalId -> {
 
 											// if an internal id is used this must get set to link this entity in the next iteration
 											PersistentPropertyAccessor<?> targetPropertyAccessor = targetEntity
@@ -691,7 +698,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 											} else {
 												return relationshipCreationMonoNested.checkpoint().then();
 											}
-										}).checkpoint());
+										}).checkpoint();});
 							});
 					relationshipCreationMonos.add(createRelationship);
 				}
@@ -699,6 +706,23 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 			return Flux.concat(relationshipCreationMonos).checkpoint().then();
 		});
+	}
+
+	private <Y> Mono<Long> queryRelatedNode(Object entity, Neo4jPersistentEntity<?> targetNodeDescription,
+									  @Nullable String inDatabase) {
+
+		Neo4jPersistentProperty requiredIdProperty = targetNodeDescription.getRequiredIdProperty();
+		PersistentPropertyAccessor<Object> ding = targetNodeDescription.getPropertyAccessor(entity);
+		Object idValue = ding.getProperty(requiredIdProperty);
+
+		return neo4jClient.query(() ->
+				renderer.render(cypherGenerator.prepareMatchOf(targetNodeDescription,
+						targetNodeDescription.getIdExpression().isEqualTo(parameter(Constants.NAME_OF_ID)))
+						.returning(Constants.NAME_OF_INTERNAL_ID)
+						.build())
+		)
+				.in(inDatabase).bindAll(Collections.singletonMap(Constants.NAME_OF_ID, idValue))
+				.fetchAs(Long.class).one();
 	}
 
 	private <Y> Mono<Long> saveRelatedNode(Object relatedNode, Class<Y> entityType, NodeDescription targetNodeDescription,

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -55,6 +55,10 @@ public final class NestedRelationshipProcessingStateMachine {
 	 */
 	private final Set<Object> processedObjects = new HashSet<>();
 
+	public NestedRelationshipProcessingStateMachine(Object initialObject) {
+		processedObjects.add(initialObject);
+	}
+
 	/**
 	 * @param relationshipDescription Check whether this relationship description has been processed
 	 * @param valuesToStore Check whether all the values in the collection have been processed

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -3542,7 +3542,7 @@ class RepositoryIT {
 				@Autowired SuperBaseClassWithRelationshipRepository repository) {
 
 			Inheritance.ConcreteClassA ccA = new Inheritance.ConcreteClassA("cc1", "test");
-			Inheritance.ConcreteClassB ccB1 = new Inheritance.ConcreteClassB("cc2a", 42);
+			Inheritance.ConcreteClassB ccB1 = new Inheritance.ConcreteClassB("cc2a", 41);
 			Inheritance.ConcreteClassB ccB2 = new Inheritance.ConcreteClassB("cc2b", 42);
 
 			List<Inheritance.SuperBaseClass> things = new ArrayList<>();

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
@@ -64,8 +64,12 @@ public class VersionedThing {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		VersionedThing that = (VersionedThing) o;
 		return Objects.equals(id, that.id) && name.equals(that.name);
 	}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
@@ -16,6 +16,7 @@
 package org.springframework.data.neo4j.integration.shared.common;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.annotation.Version;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
@@ -41,6 +42,10 @@ public class VersionedThing {
 		this.name = name;
 	}
 
+	public Long getId() {
+		return id;
+	}
+
 	public Long getMyVersion() {
 		return myVersion;
 	}
@@ -55,5 +60,18 @@ public class VersionedThing {
 
 	public void setOtherVersionedThings(List<VersionedThing> otherVersionedThings) {
 		this.otherVersionedThings = otherVersionedThings;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		VersionedThing that = (VersionedThing) o;
+		return Objects.equals(id, that.id) && name.equals(that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name);
 	}
 }


### PR DESCRIPTION
If two entities and one were saved as
`(:A{name:'a1'})-[:KNOWS]->(:A{name:'a2'})`
and we would add another back-referencing `KNOWS` relationship from `a2` to `a1` in a clean operation
`loadA1` (which automatically pulls also `a2`)
`loadA2`
`createA2KnowsA1`
the state machine assumes that a`a2` from the existing `a1` relationship differs from the directly loaded `a2`
and wants to re-create it which causes in the scenario of activated optimistic locking an `OptimisticLockingException` because "one of the two" `a2`s already got an update of its version.
To mitigate the problem, a registration of initial objects in the state machine to mark them as processed were introduced.

Besides that the state machine got a little bit more robust, I wonder if the approach to check for objects' equality, that results in a `PROCESSED_ALL_VALUES` state, is the right one. I had to adjust one existing test because there were two "different" objects that were "equal" due to a very simple equals method.

