### PR TITLE
Fix state machine for more complex scenarios.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.7-SNAPSHOT</version>
+	<version>6.0.7-GH-2191-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -470,7 +470,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			}
 
 			// break recursive procession and deletion of previously created relationships
-			ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
+			ProcessState processState = stateMachine.getStateOf(fromId, relationshipDescriptionObverse, relatedValuesToStore);
 			if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS || processState == ProcessState.PROCESSED_BOTH) {
 				return;
 			}
@@ -478,7 +478,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			// Remove all relationships before creating all new if the entity is not new and the relationship
 			// has not been processed before.
 			// This avoids the usage of cache but might have significant impact on overall performance
-			if (!isParentObjectNew && !stateMachine.hasProcessedRelationship(relationshipDescription)) {
+			if (!isParentObjectNew && !stateMachine.hasProcessedRelationship(fromId, relationshipDescription)) {
 
 				List<Long> knownRelationshipsIds = new ArrayList<>();
 				if (idProperty != null) {
@@ -509,7 +509,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 				return;
 			}
 
-			stateMachine.markRelationshipAsProcessed(relationshipDescription);
+			stateMachine.markRelationshipAsProcessed(fromId, relationshipDescription);
 
 			for (Object relatedValueToStore : relatedValuesToStore) {
 

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -656,7 +656,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 								return Mono.just(targetEntity.isNew(relatedNode)).flatMap(isNew -> {
 									Mono<Long> relatedIdMono;
 
-									if (processState == ProcessState.PROCESSED_ALL_VALUES) {
+									if (stateMachine.hasProcessedValue(relatedValueToStore)) {
 										relatedIdMono = queryRelatedNode(relatedNode, targetEntity, inDatabase);
 									} else {
 										relatedIdMono = saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -606,9 +606,10 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 					return;
 				}
 
-				// remove all relationships before creating all new if the entity is not new
-				// this avoids the usage of cache but might have significant impact on overall performance
-				if (!isParentObjectNew) {
+				// Remove all relationships before creating all new if the entity is not new and the relationship
+				// has not been processed before.
+				// This avoids the usage of cache but might have significant impact on overall performance
+				if (!isParentObjectNew && !stateMachine.hasProcessedRelationship(relationshipDescription)) {
 
 					List<Long> knownRelationshipsIds = new ArrayList<>();
 					if (idProperty != null) {
@@ -642,7 +643,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 					return;
 				}
 
-				stateMachine.markAsProcessed(relationshipDescription, relatedValuesToStore);
+				stateMachine.markRelationshipAsProcessed(relationshipDescription);
 
 				for (Object relatedValueToStore : relatedValuesToStore) {
 
@@ -661,6 +662,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 										relatedIdMono = saveRelatedNode(relatedNode, relationshipContext.getAssociationTargetType(),
 												targetEntity, inDatabase);
 									}
+									stateMachine.markValueAsProcessed(relatedValueToStore);
 									return relatedIdMono.flatMap(relatedInternalId -> {
 
 											// if an internal id is used this must get set to link this entity in the next iteration

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -601,7 +601,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 				}
 
 				// break recursive procession and deletion of previously created relationships
-				ProcessState processState = stateMachine.getStateOf(relationshipDescriptionObverse, relatedValuesToStore);
+				ProcessState processState = stateMachine.getStateOf(fromId, relationshipDescriptionObverse, relatedValuesToStore);
 				if (processState == ProcessState.PROCESSED_ALL_RELATIONSHIPS || processState == ProcessState.PROCESSED_BOTH) {
 					return;
 				}
@@ -609,7 +609,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 				// Remove all relationships before creating all new if the entity is not new and the relationship
 				// has not been processed before.
 				// This avoids the usage of cache but might have significant impact on overall performance
-				if (!isParentObjectNew && !stateMachine.hasProcessedRelationship(relationshipDescription)) {
+				if (!isParentObjectNew && !stateMachine.hasProcessedRelationship(fromId, relationshipDescription)) {
 
 					List<Long> knownRelationshipsIds = new ArrayList<>();
 					if (idProperty != null) {
@@ -643,7 +643,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 					return;
 				}
 
-				stateMachine.markRelationshipAsProcessed(relationshipDescription);
+				stateMachine.markRelationshipAsProcessed(fromId, relationshipDescription);
 
 				for (Object relatedValueToStore : relatedValuesToStore) {
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.core.mapping;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -48,7 +49,7 @@ public final class NestedRelationshipProcessingStateMachine {
 	/**
 	 * The set of already processed relationships.
 	 */
-	private final Set<RelationshipDescription> processedRelationshipDescriptions = new HashSet<>();
+	private final Set<RelationshipDescriptionWithSourceId> processedRelationshipDescriptions = new HashSet<>();
 
 	/**
 	 * The set of already processed related objects.
@@ -64,11 +65,11 @@ public final class NestedRelationshipProcessingStateMachine {
 	 * @param valuesToStore Check whether all the values in the collection have been processed
 	 * @return The state of things processed
 	 */
-	public ProcessState getStateOf(RelationshipDescription relationshipDescription, @Nullable Collection<?> valuesToStore) {
+	public ProcessState getStateOf(Object fromId, RelationshipDescription relationshipDescription, @Nullable Collection<?> valuesToStore) {
 
 		try {
 			read.lock();
-			boolean hasProcessedRelationship = hasProcessedRelationship(relationshipDescription);
+			boolean hasProcessedRelationship = hasProcessedRelationship(fromId, relationshipDescription);
 			boolean hasProcessedAllValues = hasProcessedAllOf(valuesToStore);
 			if (hasProcessedRelationship && hasProcessedAllValues) {
 				return ProcessState.PROCESSED_BOTH;
@@ -86,15 +87,48 @@ public final class NestedRelationshipProcessingStateMachine {
 	}
 
 	/**
+	 * Combination of relationship description and fromId to differentiate between `equals`-wise equal relationship
+	 * descriptions by their source identifier. This is needed because sometimes the very same relationship definition
+	 * can get processed for different objects of the same entity.
+	 * One could say that this is a Tuple but it has a nicer name.
+	 */
+	private static class RelationshipDescriptionWithSourceId {
+		private final Object id;
+		private final RelationshipDescription relationshipDescription;
+
+		public RelationshipDescriptionWithSourceId(Object id, RelationshipDescription relationshipDescription) {
+			this.id = id;
+			this.relationshipDescription = relationshipDescription;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			RelationshipDescriptionWithSourceId that = (RelationshipDescriptionWithSourceId) o;
+			return id.equals(that.id) && relationshipDescription.equals(that.relationshipDescription);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, relationshipDescription);
+		}
+	}
+
+	/**
 	 * Marks the passed objects as processed
 	 *
 	 * @param relationshipDescription To be marked as processed
 	 */
-	public void markRelationshipAsProcessed(RelationshipDescription relationshipDescription) {
+	public void markRelationshipAsProcessed(Object fromId, RelationshipDescription relationshipDescription) {
 
 		try {
 			write.lock();
-			this.processedRelationshipDescriptions.add(relationshipDescription);
+			this.processedRelationshipDescriptions.add(new RelationshipDescriptionWithSourceId(fromId, relationshipDescription));
 		} finally {
 			write.unlock();
 		}
@@ -130,9 +164,9 @@ public final class NestedRelationshipProcessingStateMachine {
 	 * @param relationshipDescription the relationship that should be looked for in the registry.
 	 * @return processed yes (true) / no (false)
 	 */
-	public boolean hasProcessedRelationship(@Nullable RelationshipDescription relationshipDescription) {
+	public boolean hasProcessedRelationship(Object fromId, @Nullable RelationshipDescription relationshipDescription) {
 		if (relationshipDescription != null) {
-			return processedRelationshipDescriptions.contains(relationshipDescription);
+			return processedRelationshipDescriptions.contains(new RelationshipDescriptionWithSourceId(fromId, relationshipDescription));
 		}
 		return false;
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -68,7 +68,7 @@ public final class NestedRelationshipProcessingStateMachine {
 
 		try {
 			read.lock();
-			boolean hasProcessedRelationship = hasProcessed(relationshipDescription);
+			boolean hasProcessedRelationship = hasProcessedRelationship(relationshipDescription);
 			boolean hasProcessedAllValues = hasProcessedAllOf(valuesToStore);
 			if (hasProcessedRelationship && hasProcessedAllValues) {
 				return ProcessState.PROCESSED_BOTH;
@@ -89,19 +89,52 @@ public final class NestedRelationshipProcessingStateMachine {
 	 * Marks the passed objects as processed
 	 *
 	 * @param relationshipDescription To be marked as processed
-	 * @param valuesToStore If not {@literal null}, all non-null values will be marked as processed
 	 */
-	public void markAsProcessed(RelationshipDescription relationshipDescription, @Nullable Collection<?> valuesToStore) {
+	public void markRelationshipAsProcessed(RelationshipDescription relationshipDescription) {
 
 		try {
 			write.lock();
 			this.processedRelationshipDescriptions.add(relationshipDescription);
-			if (valuesToStore != null) {
-				valuesToStore.stream().filter(v -> v != null).forEach(processedObjects::add);
-			}
 		} finally {
 			write.unlock();
 		}
+	}
+	/**
+	 * Marks the passed objects as processed
+	 *
+	 * @param valueToStore If not {@literal null}, all non-null values will be marked as processed
+	 */
+	public void markValueAsProcessed(Object valueToStore) {
+
+		try {
+			write.lock();
+			this.processedObjects.add(valueToStore);
+		} finally {
+			write.unlock();
+		}
+	}
+
+	/**
+	 * Checks if the value has already been processed.
+	 *
+	 * @param value the object that should be looked for in the registry.
+ 	 * @return processed yes (true) / no (false)
+	 */
+	public boolean hasProcessedValue(Object value) {
+		return processedObjects.contains(value);
+	}
+
+	/**
+	 * Checks if the relationship has already been processed.
+	 *
+	 * @param relationshipDescription the relationship that should be looked for in the registry.
+	 * @return processed yes (true) / no (false)
+	 */
+	public boolean hasProcessedRelationship(@Nullable RelationshipDescription relationshipDescription) {
+		if (relationshipDescription != null) {
+			return processedRelationshipDescriptions.contains(relationshipDescription);
+		}
+		return false;
 	}
 
 	private boolean hasProcessedAllOf(@Nullable Collection<?> valuesToStore) {
@@ -112,11 +145,4 @@ public final class NestedRelationshipProcessingStateMachine {
 		return processedObjects.containsAll(valuesToStore);
 	}
 
-	private boolean hasProcessed(RelationshipDescription relationshipDescription) {
-
-		if (relationshipDescription != null) {
-			return processedRelationshipDescriptions.contains(relationshipDescription);
-		}
-		return false;
-	}
 }


### PR DESCRIPTION
Two things are solved with this:
1. Check if the related value was already processed instead of checking for all values
2. Only trigger the delete of relationships if the relationship description was not processed before.