### PR TITLE
Stabilize immutable mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.9-SNAPSHOT</version>
+	<version>6.0.9-GH-2240-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -598,7 +598,6 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 					targetPropertyAccessor.setProperty(targetEntity.getRequiredIdProperty(), relatedInternalId);
 				}
 				stateMachine.markValueAsProcessedAs(relatedObjectBeforeCallbacksApplied, targetPropertyAccessor.getBean());
-//				stateMachine.irgendwasMitIdSet(targetPropertyAccessor.getBean(), relatedInternalId);
 
 				if (processState != ProcessState.PROCESSED_ALL_VALUES) {
 					processNestedRelations(targetEntity, targetPropertyAccessor, isEntityNew, inDatabase, stateMachine);

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -37,24 +37,6 @@ import org.springframework.lang.Nullable;
 @API(status = API.Status.INTERNAL, since = "6.0")
 public final class NestedRelationshipProcessingStateMachine {
 
-	public void markValueAsProcessedAs(Object relatedValueToStore, Object bean) {
-		try {
-			write.lock();
-			processedObjectsAlias.put(relatedValueToStore, bean);
-		} finally {
-			write.unlock();
-		}
-	}
-
-	public Object getProcessedAs(Object entity) {
-		try {
-			read.lock();
-			return processedObjectsAlias.getOrDefault(entity, entity);
-		} finally {
-			read.unlock();
-		}
-	}
-
 	/**
 	 * Valid processing states.
 	 */
@@ -190,6 +172,24 @@ public final class NestedRelationshipProcessingStateMachine {
 			return processedRelationshipDescriptions.contains(new RelationshipDescriptionWithSourceId(fromId, relationshipDescription));
 		}
 		return false;
+	}
+
+	public void markValueAsProcessedAs(Object relatedValueToStore, Object bean) {
+		try {
+			write.lock();
+			processedObjectsAlias.put(relatedValueToStore, bean);
+		} finally {
+			write.unlock();
+		}
+	}
+
+	public Object getProcessedAs(Object entity) {
+		try {
+			read.lock();
+			return processedObjectsAlias.getOrDefault(entity, entity);
+		} finally {
+			read.unlock();
+		}
 	}
 
 	private boolean hasProcessedAllOf(@Nullable Collection<?> valuesToStore) {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableAssignedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableAssignedIdsIT.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.data.neo4j.integration.imperative;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +37,7 @@ import org.springframework.data.neo4j.test.Neo4jExtension;
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,6 +56,19 @@ public class ImmutableAssignedIdsIT {
 
 	public static final String SOME_VALUE_VALUE = "testValue";
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final Driver driver;
+
+	public ImmutableAssignedIdsIT(@Autowired Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	void cleanUp() {
+		try (Session session = driver.session()) {
+			session.run("MATCH (n) DETACH DELETE n").consume();
+		}
+	}
 
 	@Test // GH-2141
 	void saveWithAssignedIdsReturnsObjectWithIdSet(
@@ -298,6 +315,36 @@ public class ImmutableAssignedIdsIT {
 		assertThat(savedPerson.relationshipPropertiesDynamicCollection.keySet().iterator().next()).isEqualTo("Nope");
 		assertThat(savedPerson.relationshipPropertiesDynamicCollection.values().iterator().next().get(0).name).isEqualTo("rel4");
 		assertThat(savedPerson.relationshipPropertiesDynamicCollection.values().iterator().next().get(0).target.id).isNotNull();
+	}
+
+	@Test // GH-2235
+	void saveWithGeneratedIdsWithMultipleRelationshipsToOneNode(@Autowired ImmutablePersonWithAssignedIdRepository repository) {
+		ImmutablePersonWithAssignedId person1 = new ImmutablePersonWithAssignedId();
+		ImmutablePersonWithAssignedId person2 = ImmutablePersonWithAssignedId.fallback(person1);
+		List<ImmutablePersonWithAssignedId> onboardedBy = new ArrayList<>();
+		onboardedBy.add(person1);
+		onboardedBy.add(person2);
+		ImmutablePersonWithAssignedId person3 = ImmutablePersonWithAssignedId.wasOnboardedBy(onboardedBy);
+
+		ImmutablePersonWithAssignedId savedPerson = repository.save(person3);
+		assertThat(savedPerson.id).isNotNull();
+		assertThat(savedPerson.wasOnboardedBy).allMatch(ob -> ob.id != null);
+
+		ImmutablePersonWithAssignedId savedPerson2 = savedPerson.wasOnboardedBy.stream().filter(p -> p.fallback != null)
+				.findFirst().get();
+
+		assertThat(savedPerson2.fallback.id).isNotNull();
+
+		try (Session session = driver.session()) {
+			List<Record> result = session.run(
+					"MATCH (person3:ImmutablePersonWithAssignedId) " +
+							"-[:ONBOARDED_BY]->(person2:ImmutablePersonWithAssignedId) " +
+							"-[:FALLBACK]->(person1:ImmutablePersonWithAssignedId), " +
+							"(person3)-[:ONBOARDED_BY]->(person1) " +
+							"return person3")
+					.list();
+			assertThat(result).hasSize(1);
+		}
 	}
 
 	interface ImmutablePersonWithAssignedIdRepository extends Neo4jRepository<ImmutablePersonWithAssignedId, Long> {}

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -87,7 +88,9 @@ import org.springframework.data.neo4j.integration.shared.common.AltHobby;
 import org.springframework.data.neo4j.integration.shared.common.AltLikedByPersonRelationship;
 import org.springframework.data.neo4j.integration.shared.common.AltPerson;
 import org.springframework.data.neo4j.integration.shared.common.AnotherThingWithAssignedId;
+import org.springframework.data.neo4j.integration.shared.common.BidirectionalAssignedId;
 import org.springframework.data.neo4j.integration.shared.common.BidirectionalEnd;
+import org.springframework.data.neo4j.integration.shared.common.BidirectionalExternallyGeneratedId;
 import org.springframework.data.neo4j.integration.shared.common.BidirectionalSameEntity;
 import org.springframework.data.neo4j.integration.shared.common.BidirectionalStart;
 import org.springframework.data.neo4j.integration.shared.common.Club;
@@ -2280,6 +2283,35 @@ class RepositoryIT {
 			}
 		}
 
+		@Test // GH-2240
+		void saveBidirectionalRelationshipsWithExternallyGeneratedId(@Autowired BidirectionalExternallyGeneratedIdRepository repository) {
+
+			BidirectionalExternallyGeneratedId a = new BidirectionalExternallyGeneratedId();
+			BidirectionalExternallyGeneratedId b = new BidirectionalExternallyGeneratedId();
+			BidirectionalExternallyGeneratedId savedA = repository.save(a);
+
+			b.other = savedA;
+			savedA.other = b;
+			repository.save(b);
+
+		}
+
+		@Test // GH-2240
+		void saveBidirectionalRelationshipsWithAssignedId(@Autowired BidirectionalAssignedIdRepository repository) {
+
+			BidirectionalAssignedId a = new BidirectionalAssignedId();
+			a.uuid = UUID.randomUUID();
+			BidirectionalAssignedId b = new BidirectionalAssignedId();
+			b.uuid = UUID.randomUUID();
+
+			BidirectionalAssignedId savedA = repository.save(a);
+
+			b.other = savedA;
+			savedA.other = b;
+			repository.save(b);
+
+		}
+
 		@Test // GH-2108
 		void saveRelatedEntitesWithSameCustomIdsAndRelationshipProperties(
 				@Autowired SameIdEntitiesWithRelationshipPropertiesRepository repository) {
@@ -3963,6 +3995,12 @@ class RepositoryIT {
 			});
 		}
 	}
+
+	interface BidirectionalExternallyGeneratedIdRepository
+			extends Neo4jRepository<BidirectionalExternallyGeneratedId, UUID> {}
+
+	interface BidirectionalAssignedIdRepository
+			extends Neo4jRepository<BidirectionalAssignedId, UUID> {}
 
 	interface BidirectionalStartRepository extends Neo4jRepository<BidirectionalStart, Long> {}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -2290,9 +2290,15 @@ class RepositoryIT {
 			BidirectionalExternallyGeneratedId b = new BidirectionalExternallyGeneratedId();
 			BidirectionalExternallyGeneratedId savedA = repository.save(a);
 
-			b.other = savedA;
-			savedA.other = b;
-			repository.save(b);
+			b.otter = savedA;
+			savedA.otter = b;
+			BidirectionalExternallyGeneratedId savedB = repository.save(b);
+
+			assertThat(savedB.uuid).isNotNull();
+			assertThat(savedB.otter).isNotNull();
+			assertThat(savedB.otter.uuid).isNotNull();
+			// this would be b again
+			assertThat(savedB.otter.otter).isNotNull();
 
 		}
 
@@ -2306,9 +2312,15 @@ class RepositoryIT {
 
 			BidirectionalAssignedId savedA = repository.save(a);
 
-			b.other = savedA;
-			savedA.other = b;
-			repository.save(b);
+			b.otter = savedA;
+			savedA.otter = b;
+			BidirectionalAssignedId savedB = repository.save(b);
+
+			assertThat(savedB.uuid).isNotNull();
+			assertThat(savedB.otter).isNotNull();
+			assertThat(savedB.otter.uuid).isNotNull();
+			// this would be b again
+			assertThat(savedB.otter.otter).isNotNull();
 
 		}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
@@ -85,7 +85,7 @@ public class ReactiveImmutableExternallyGeneratedIdsIT {
 				.verifyComplete();
 	}
 
-	@Test // GH-41
+	@Test // GH-2141
 	void saveAllWithExternallyGeneratedIdsReturnsObjectWithIdSet(
 			@Autowired ReactiveImmutablePersonWithExternalIdRepository repository) {
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.integration.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import reactor.test.StepVerifier;
@@ -56,6 +57,18 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class ReactiveImmutableGeneratedIdsIT {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+	private final Driver driver;
+
+	public ReactiveImmutableGeneratedIdsIT(@Autowired Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	void cleanUp() {
+		try (Session session = driver.session()) {
+			session.run("MATCH (n) DETACH DELETE n").consume();
+		}
+	}
 
 	@Test // GH-2141
 	void saveWithGeneratedIdsReturnsObjectWithIdSet(
@@ -306,7 +319,7 @@ public class ReactiveImmutableGeneratedIdsIT {
 	}
 
 	@Test // GH-2223
-	void saveWithGeneratedIdsWithMultipleRelationshipsToOneNode(@Autowired Driver driver,
+	void saveWithGeneratedIdsWithMultipleRelationshipsToOneNode(
 			@Autowired ImmutablePersonWithGeneratedIdRepository repository) {
 
 		ImmutablePersonWithGeneratedId person1 = new ImmutablePersonWithGeneratedId();

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
 
+import org.springframework.data.neo4j.integration.shared.common.BidirectionalAssignedId;
+import org.springframework.data.neo4j.integration.shared.common.BidirectionalExternallyGeneratedId;
 import org.springframework.data.neo4j.integration.shared.common.DtoPersonProjection;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels;
 import org.springframework.data.neo4j.integration.shared.common.SimplePerson;
@@ -38,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -2099,6 +2102,55 @@ class ReactiveRepositoryIT {
 					})
 					.verifyComplete();
 		}
+
+		@Test // GH-2240
+		void saveBidirectionalRelationshipsWithExternallyGeneratedId(@Autowired BidirectionalExternallyGeneratedIdRepository repository) {
+
+			BidirectionalExternallyGeneratedId a = new BidirectionalExternallyGeneratedId();
+			StepVerifier.create(
+					repository.save(a).flatMap(savedA -> {
+						BidirectionalExternallyGeneratedId b = new BidirectionalExternallyGeneratedId();
+						b.otter = savedA;
+						savedA.otter = b;
+						return repository.save(b);
+					})
+			)
+			.assertNext(savedB -> {
+				assertThat(savedB.uuid).isNotNull();
+				assertThat(savedB.otter).isNotNull();
+				assertThat(savedB.otter.uuid).isNotNull();
+				// this would be b again
+				assertThat(savedB.otter.otter).isNotNull();
+			})
+			.verifyComplete();
+
+		}
+
+		@Test // GH-2240
+		void saveBidirectionalRelationshipsWithAssignedId(@Autowired BidirectionalAssignedIdRepository repository) {
+
+			BidirectionalAssignedId a = new BidirectionalAssignedId();
+			a.uuid = UUID.randomUUID();
+
+			StepVerifier.create(
+					repository.save(a).flatMap(savedA -> {
+						BidirectionalAssignedId b = new BidirectionalAssignedId();
+						b.uuid = UUID.randomUUID();
+						b.otter = savedA;
+						savedA.otter = b;
+						return repository.save(b);
+					})
+			)
+					.assertNext(savedB -> {
+						assertThat(savedB.uuid).isNotNull();
+						assertThat(savedB.otter).isNotNull();
+						assertThat(savedB.otter.uuid).isNotNull();
+						// this would be b again
+						assertThat(savedB.otter.otter).isNotNull();
+					})
+					.verifyComplete();
+
+		}
 	}
 
 	@Nested
@@ -2497,6 +2549,12 @@ class ReactiveRepositoryIT {
 			}
 		}
 	}
+
+	interface BidirectionalExternallyGeneratedIdRepository
+			extends ReactiveNeo4jRepository<BidirectionalExternallyGeneratedId, UUID> {}
+
+	interface BidirectionalAssignedIdRepository
+			extends ReactiveNeo4jRepository<BidirectionalAssignedId, UUID> {}
 
 	interface BidirectionalStartRepository extends ReactiveNeo4jRepository<BidirectionalStart, Long> {}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.common;
+
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.UUID;
+
+/**
+ * Bidirectional relationship persisting with assigned id.
+ */
+@Node
+public class BidirectionalAssignedId {
+
+	@Id
+	public UUID uuid;
+
+	@Relationship("OTHER")
+	public BidirectionalAssignedId other;
+
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
@@ -31,6 +31,6 @@ public class BidirectionalAssignedId {
 	public UUID uuid;
 
 	@Relationship("OTHER")
-	public BidirectionalAssignedId other;
+	public BidirectionalAssignedId otter;
 
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.common;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.UUID;
+
+/**
+ * Bidirectional relationship persisting with externally generated id.
+ */
+@Node
+public class BidirectionalExternallyGeneratedId {
+
+	@Id
+	@GeneratedValue(GeneratedValue.UUIDGenerator.class)
+	public UUID uuid;
+
+	@Relationship("OTHER")
+	public BidirectionalExternallyGeneratedId other;
+
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
@@ -33,6 +33,6 @@ public class BidirectionalExternallyGeneratedId {
 	public UUID uuid;
 
 	@Relationship("OTHER")
-	public BidirectionalExternallyGeneratedId other;
+	public BidirectionalExternallyGeneratedId otter;
 
 }


### PR DESCRIPTION
* Register aliases for mapped objects in a cache (before -> after) to avoid duplicates.
* Cache internal identifier for the relationship creation phase.
* Something with otter