### PR TITLE
Add support for distinct derived queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.9-SNAPSHOT</version>
+	<version>6.0.9-GH-2243-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -85,6 +85,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryFragmentsAndPar
 	private final NodeDescription<?> nodeDescription;
 
 	private final Neo4jQueryType queryType;
+	private final boolean isDistinct;
 
 	private final Iterator<Neo4jQueryMethod.Neo4jParameter> formalParameters;
 	private final Queue<Parameter> lastParameter = new LinkedList<>();
@@ -127,6 +128,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryFragmentsAndPar
 		this.nodeDescription = this.mappingContext.getRequiredNodeDescription(this.domainType);
 
 		this.queryType = queryType;
+		this.isDistinct = tree.isDistinct();
 
 		this.formalParameters = actualParameters.getParameters().iterator();
 		this.maxResults = tree.isLimiting() ? tree.getMaxResults() : null;
@@ -293,7 +295,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryFragmentsAndPar
 		} else if (queryType == Neo4jQueryType.EXISTS) {
 			queryFragments.setReturnExpression(Functions.count(Constants.NAME_OF_ROOT_NODE).gt(Cypher.literalOf(0)), true);
 		} else {
-			queryFragments.setReturnBasedOn(nodeDescription, includedProperties);
+			queryFragments.setReturnBasedOn(nodeDescription, includedProperties, isDistinct);
 			queryFragments.setOrderBy(Stream
 					.concat(sortItems.stream(),
 							pagingParameter.getSort().and(sort).stream().map(CypherAdapterUtils.sortAdapterFor(nodeDescription)))

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -3952,6 +3952,17 @@ class RepositoryIT {
 			assertThat(repository.findByPetsFriendsName("Jerry")).isNull();
 		}
 
+		@Test // GH-2243
+		void findDistinctByRelatedEntity(@Autowired RelationshipRepository repository) {
+			try (Session session = createSession()) {
+				session.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(:Hobby{name: 'Music'})"
+						+ "CREATE (n)-[:Has]->(:Hobby{name: 'Music'})");
+			}
+
+			assertThat(repository.findDistinctByHobbiesName("Music")).isNotNull();
+
+		}
+
 		@Test
 		void findByPropertyOnRelationshipWithProperties(
 				@Autowired PersonWithRelationshipWithPropertiesRepository repository) {
@@ -4124,6 +4135,8 @@ class RepositoryIT {
 		PersonWithRelationship findByPetsHobbiesName(String hobbyName);
 
 		PersonWithRelationship findByPetsFriendsName(String petName);
+
+		PersonWithRelationship.PersonWithHobby findDistinctByHobbiesName(String hobbyName);
 	}
 
 	interface SimilarThingRepository extends Neo4jRepository<SimilarThing, Long> {}

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -1389,6 +1389,18 @@ class ReactiveRepositoryIT {
 			StepVerifier.create(repository.findByPetsFriendsName("Jerry")).verifyComplete();
 		}
 
+		@Test // GH-2243
+		void findDistinctByRelatedEntity(@Autowired ReactiveRelationshipRepository repository) {
+			try (Session session = createSession()) {
+				session.run("CREATE (n:PersonWithRelationship{name:'Freddie'})-[:Has]->(:Hobby{name: 'Music'})"
+						+ "CREATE (n)-[:Has]->(:Hobby{name: 'Music'})");
+			}
+
+			StepVerifier.create(repository.findDistinctByHobbiesName("Music"))
+					.assertNext(person -> assertThat(person).isNotNull())
+					.verifyComplete();
+		}
+
 		@Test
 		void findByPropertyOnRelationshipWithProperties(
 				@Autowired ReactivePersonWithRelationshipWithPropertiesRepository repository) {
@@ -2618,6 +2630,8 @@ class ReactiveRepositoryIT {
 		Mono<PersonWithRelationship> findByPetsFriendsName(String petName);
 
 		Flux<PersonWithRelationship> findByName(String name, Sort sort);
+
+		Mono<PersonWithRelationship.PersonWithHobby> findDistinctByHobbiesName(String hobbyName);
 	}
 
 	interface ReactiveSimilarThingRepository extends ReactiveCrudRepository<SimilarThing, Long> {}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationship.java
@@ -77,4 +77,12 @@ public class PersonWithRelationship {
 	public void setPets(List<Pet> pets) {
 		this.pets = pets;
 	}
+
+	/**
+	 * Simple person with hobbies relationship to enforce non-cyclic querying.
+	 */
+	public interface PersonWithHobby {
+		String getName();
+		Hobby getHobbies();
+	}
 }


### PR DESCRIPTION
The addition of `distinct` is only needed for queries that do not work with a circular model / projection.
I tried to come up with other examples beside the obvious one. Maybe you can chime in to challenge the very simplistic logic ;)