### PR TITLE
Simplify relationship determination logic.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>6.0.10-SNAPSHOT</version>
+	<version>6.0.10-GH-2290-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -363,7 +363,12 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				Neo4jPersistentProperty matchingProperty = nodeDescription.getRequiredPersistentProperty(parameter.getName());
 
 				if (matchingProperty.isRelationship()) {
-					return createInstanceOfRelationships(matchingProperty, values, allValues, nodeDescription.getRelationships().stream().filter(r -> r.getFieldName().equals(matchingProperty.getFieldName())).findFirst().get()).orElse(null);
+					RelationshipDescription relationshipDescription = nodeDescription.getRelationships().stream()
+							.filter(r -> {
+								String propertyFieldName = matchingProperty.getFieldName();
+								return r.getFieldName().equals(propertyFieldName);
+							}).findFirst().get();
+					return createInstanceOfRelationships(matchingProperty, values, allValues, relationshipDescription).orElse(null);
 				} else if (matchingProperty.isDynamicLabels()) {
 					return createDynamicLabelsProperty(matchingProperty.getTypeInformation(), surplusLabels);
 				} else if (matchingProperty.isEntityWithRelationshipProperties()) {


### PR DESCRIPTION
Moved the `....findFirst` logic into the constructor mapping because here we can be sure that there is only one field with the same name in the same class.