### PR TITLE
GH-2408 - Evaluate type parameters of converters and apply to complete collections if necessary.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -319,7 +319,7 @@ public final class Neo4jTemplate implements
 
 		return neo4jMappingContext.getConversionService().writeValue(idValues,
 				ClassTypeInformation.from(idValues.getClass()),
-				idProperty == null ? null : idProperty.getOptionalWritingConverter());
+				idProperty == null ? null : idProperty.getOptionalConverter());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -301,7 +301,7 @@ public final class ReactiveNeo4jTemplate implements
 		}
 
 		return neo4jMappingContext.getConversionService().writeValue(idValues,
-				ClassTypeInformation.from(idValues.getClass()), idProperty == null ? null : idProperty.getOptionalWritingConverter());
+				ClassTypeInformation.from(idValues.getClass()), idProperty == null ? null : idProperty.getOptionalConverter());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversionService.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversionService.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.neo4j.core.convert;
 
-import java.util.function.Function;
-
 import org.apiguardian.api.API;
 import org.neo4j.driver.Value;
 import org.springframework.dao.TypeMismatchDataAccessException;
@@ -69,7 +67,7 @@ public interface Neo4jConversionService {
 	 */
 	@Nullable
 	Object readValue(
-			@Nullable Value source, TypeInformation<?> targetType, @Nullable Function<Value, Object> conversionOverride
+			@Nullable Value source, TypeInformation<?> targetType, @Nullable Neo4jPersistentPropertyConverter<?> conversionOverride
 	);
 
 	/**
@@ -80,7 +78,7 @@ public interface Neo4jConversionService {
 	 * @return A driver compatible value object.
 	 */
 	Value writeValue(
-			@Nullable Object value, TypeInformation<?> sourceType, @Nullable Function<Object, Value> conversionOverride
+			@Nullable Object value, TypeInformation<?> sourceType, @Nullable Neo4jPersistentPropertyConverter<?> conversionOverride
 	);
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -193,7 +193,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				return;
 			}
 
-			final Value value = conversionService.writeValue(propertyAccessor.getProperty(p), p.getTypeInformation(), p.getOptionalWritingConverter());
+			final Value value = conversionService.writeValue(propertyAccessor.getProperty(p), p.getTypeInformation(), p.getOptionalConverter());
 			if (p.isComposite()) {
 				value.keys().forEach(k -> properties.put(k, value.get(k)));
 			} else {
@@ -207,7 +207,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 		if (nodeDescription.hasIdProperty()) {
 			Neo4jPersistentProperty idProperty = nodeDescription.getRequiredIdProperty();
 			parameters.put(Constants.NAME_OF_ID,
-					conversionService.writeValue(propertyAccessor.getProperty(idProperty), idProperty.getTypeInformation(), idProperty.getOptionalWritingConverter()));
+					conversionService.writeValue(propertyAccessor.getProperty(idProperty), idProperty.getTypeInformation(), idProperty.getOptionalConverter()));
 		}
 		// in case of relationship properties ignore internal id property
 		if (nodeDescription.hasVersionProperty()) {
@@ -427,7 +427,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				} else if (matchingProperty.isEntityWithRelationshipProperties()) {
 					result = lastMappedEntity;
 				} else {
-					result =  conversionService.readValue(extractValueOf(matchingProperty, values), parameter.getType(), matchingProperty.getOptionalReadingConverter());
+					result =  conversionService.readValue(extractValueOf(matchingProperty, values), parameter.getType(), matchingProperty.getOptionalConverter());
 				}
 				return (T) result;
 			}
@@ -454,7 +454,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 					propertyAccessor.setProperty(property, targetNode);
 				}
 			} else {
-				Object value = conversionService.readValue(extractValueOf(property, queryResult), typeInformation, property.getOptionalReadingConverter());
+				Object value = conversionService.readValue(extractValueOf(property, queryResult), typeInformation, property.getOptionalConverter());
 				Class<?> rawType = typeInformation.getType();
 				propertyAccessor.setProperty(property, getValueOrDefault(ownerIsKotlinType, rawType, value));
 			}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -17,10 +17,7 @@ package org.springframework.data.neo4j.core.mapping;
 
 import java.lang.reflect.Field;
 import java.util.Optional;
-import java.util.function.Function;
 
-import org.neo4j.driver.Value;
-import org.neo4j.driver.Values;
 import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
@@ -217,29 +214,11 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 		return isEntity() && ((Neo4jPersistentEntity<?>) getOwner()).isRelationshipPropertiesEntity();
 	}
 
-	private static Function<Object, Value> nullSafeWrite(Function<Object, Value> delegate) {
-		return source -> source == null ? Values.NULL : delegate.apply(source);
-	}
-
 	@Override
-	public Function<Object, Value> getOptionalWritingConverter() {
+	public Neo4jPersistentPropertyConverter<?> getOptionalConverter() {
 		return customConversion.getOptional()
 				.map(Neo4jPersistentPropertyConverter.class::cast)
-				.map(c -> {
-					@SuppressWarnings("unchecked")
-					Function<Object, Value> originalConversion = c::write;
-					return this.isComposite() ? originalConversion : nullSafeWrite(originalConversion);
-				})
 				.orElse(null);
-	}
-
-	private static Function<Value, Object> nullSafeRead(Function<Value, Object> delegate) {
-		return source -> source == null || source.isNull() ? null : delegate.apply(source);
-	}
-
-	@Override
-	public Function<Value, Object> getOptionalReadingConverter() {
-		return customConversion.getOptional().map(c -> nullSafeRead(c::read)).orElse(null);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
@@ -225,7 +225,7 @@ public final class DtoInstantiatingConverter implements Converter<EntityInstance
 					singleValue = p -> context.getEntityConverter().read(actualType, p);
 				} else {
 					ClassTypeInformation<?> actualTargetType = ClassTypeInformation.from(actualType);
-					singleValue = p -> context.getConversionService().readValue(p, actualTargetType, targetProperty.getOptionalReadingConverter());
+					singleValue = p -> context.getConversionService().readValue(p, actualTargetType, targetProperty.getOptionalConverter());
 				}
 
 				if (targetProperty.isCollectionLike()) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
@@ -17,6 +17,8 @@ package org.springframework.data.neo4j.core.mapping;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Statement;
@@ -34,6 +37,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.context.AbstractMappingContext;
@@ -349,7 +353,26 @@ public final class Neo4jMappingContext extends AbstractMappingContext<Neo4jPersi
 
 		ConvertWith convertWith = persistentProperty.getRequiredAnnotation(ConvertWith.class);
 		Neo4jPersistentPropertyConverterFactory persistentPropertyConverterFactory = this.getOrCreateConverterFactoryOfType(convertWith.converterFactory());
-		return persistentPropertyConverterFactory.getPropertyConverterFor(persistentProperty);
+		Neo4jPersistentPropertyConverter<?> customConversions = persistentPropertyConverterFactory.getPropertyConverterFor(persistentProperty);
+
+		boolean forCollection = false;
+		if (persistentProperty.isCollectionLike() && convertWith.converter() != ConvertWith.UnsetConverter.class) {
+			Map<String, Type> typeVariableMap = GenericTypeResolver.getTypeVariableMap(convertWith.converter())
+					.entrySet()
+					.stream()
+					.collect(Collectors.toMap(e -> e.getKey().getName(), Map.Entry::getValue));
+			Type propertyType = null;
+			if (typeVariableMap.containsKey("T")) {
+				propertyType = typeVariableMap.get("T");
+			} else if (typeVariableMap.containsKey("P")) {
+				propertyType = typeVariableMap.get("P");
+			}
+			forCollection =
+					propertyType != null && propertyType instanceof ParameterizedType && persistentProperty.getType()
+							.equals(((ParameterizedType) propertyType).getRawType());
+		}
+
+		return new NullSafeNeo4jPersistentPropertyConverter<>(customConversions, persistentProperty.isComposite(), forCollection);
 	}
 
 	@Override
@@ -381,7 +404,7 @@ public final class Neo4jMappingContext extends AbstractMappingContext<Neo4jPersi
 			if (relationshipContext.getRelationship().isDynamic()) {
 				TypeInformation<?> keyType = relationshipContext.getInverse().getTypeInformation().getRequiredComponentType();
 				Object key = ((Map.Entry) relatedValue).getKey();
-				dynamicRelationshipType = conversionService.writeValue(key, keyType, relationshipContext.getInverse().getOptionalWritingConverter()).asString();
+				dynamicRelationshipType = conversionService.writeValue(key, keyType, relationshipContext.getInverse().getOptionalConverter()).asString();
 			}
 			return createStatementForRelationShipWithProperties(
 					neo4jPersistentEntity, relationshipContext,
@@ -417,7 +440,7 @@ public final class Neo4jMappingContext extends AbstractMappingContext<Neo4jPersi
 			Neo4jPersistentProperty inverse = relationshipContext.getInverse();
 			TypeInformation<?> keyType = inverse.getTypeInformation().getRequiredComponentType();
 			Object key = ((Map.Entry<?, ?>) relatedValue).getKey();
-			relationshipType = conversionService.writeValue(key, keyType, inverse.getOptionalWritingConverter()).asString();
+			relationshipType = conversionService.writeValue(key, keyType, inverse.getOptionalConverter()).asString();
 		}
 
 		Statement relationshipCreationQuery = CypherGenerator.INSTANCE.prepareSaveOfRelationship(

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
@@ -16,11 +16,10 @@
 package org.springframework.data.neo4j.core.mapping;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.apiguardian.api.API;
-import org.neo4j.driver.Value;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
 import org.springframework.data.neo4j.core.schema.CompositeProperty;
 import org.springframework.data.neo4j.core.schema.DynamicLabels;
 import org.springframework.lang.Nullable;
@@ -69,10 +68,7 @@ public interface Neo4jPersistentProperty extends PersistentProperty<Neo4jPersist
 	}
 
 	@Nullable
-	Function<Object, Value> getOptionalWritingConverter();
-
-	@Nullable
-	Function<Value, Object> getOptionalReadingConverter();
+	Neo4jPersistentPropertyConverter<?> getOptionalConverter();
 
 	/**
 	 * @return True if this property targets an entity which is a container for relationship properties.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NullSafeNeo4jPersistentPropertyConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NullSafeNeo4jPersistentPropertyConverter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.mapping;
+
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
+import org.springframework.lang.Nullable;
+
+/**
+ * All property converters will be wrapped by this class. It adds the information if a converter needs to be applied to
+ * a complete collection or to individual values.
+ *
+ * @author Michael J. Simons
+ * @param <T> The type of the property this converter converts.
+ * @soundtrack Roger Taylor - The Outsider
+ */
+final class NullSafeNeo4jPersistentPropertyConverter<T> implements Neo4jPersistentPropertyConverter<T> {
+
+	/**
+	 * The actual delegate doing the conversation.
+	 */
+	private final Neo4jPersistentPropertyConverter<T> delegate;
+
+	/**
+	 * {@literal false} for all non-composite converters. If true, {@literal null} will be passed to the writing converter
+	 */
+	private final boolean passNullOnWrite;
+
+	/**
+	 * {@literal true} if the converter needs to be applied to a whole collection.
+	 */
+	private final boolean forCollection;
+
+	NullSafeNeo4jPersistentPropertyConverter(Neo4jPersistentPropertyConverter<T> delegate, boolean passNullOnWrite,
+			boolean forCollection) {
+		this.delegate = delegate;
+		this.passNullOnWrite = passNullOnWrite;
+		this.forCollection = forCollection;
+	}
+
+	@Override
+	public Value write(@Nullable T source) {
+		if (source == null) {
+			return passNullOnWrite ? delegate.write(source) : Values.NULL;
+		}
+		return delegate.write(source);
+	}
+
+	@Override @Nullable
+	public T read(@Nullable Value source) {
+		return source == null || source.isNull() ? null : delegate.read(source);
+	}
+
+	public boolean isForCollection() {
+		return forCollection;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/core/schema/CompositeProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/CompositeProperty.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
@@ -270,7 +271,15 @@ final class CompositePropertyConverterFactory implements Neo4jPersistentProperty
 					() -> "SDN could not determine the property type of your toMap converter " + generateLocation(
 							persistentProperty));
 
-			if (persistentProperty.getActualType() != typeVariableMap.get(PROPERTY_TYPE_KEY)) {
+			Type type = typeVariableMap.get(PROPERTY_TYPE_KEY);
+			if (persistentProperty.isCollectionLike() && type instanceof ParameterizedType) {
+				ParameterizedType pt = (ParameterizedType) type;
+				if (persistentProperty.getType().equals(pt.getRawType()) && pt.getActualTypeArguments().length == 1) {
+					type = ((ParameterizedType) type).getActualTypeArguments()[0];
+				}
+			}
+
+			if (persistentProperty.getActualType() != type) {
 				throw new IllegalArgumentException(
 						"The property type `" + typeVariableMap.get(PROPERTY_TYPE_KEY).getTypeName() + "` created by `"
 								+ delegateClass.getName() + "` " + generateLocation(persistentProperty)

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
@@ -170,7 +170,7 @@ final class Neo4jNestedMapEntityWriter implements EntityWriter<Object, Map<Strin
 						.flatMap(intoSingleCollectionEntries())
 						.map(relatedEntry -> {
 							String key = conversionService.writeValue(relatedEntry.getKey(), keyType,
-									property.getOptionalWritingConverter())
+									property.getOptionalConverter())
 									.asString();
 
 							Map<String, Object> relatedObjectProperties;

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -26,12 +26,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
-import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
@@ -43,6 +41,7 @@ import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.neo4j.core.TemplateSupport;
+import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
 import org.springframework.data.neo4j.core.mapping.EntityInstanceWithSource;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
@@ -159,7 +158,7 @@ abstract class Neo4jQuerySupport {
 	 * @param conversionOverride Passed to the entity converter if present.
 	 * @return A parameter that fits the placeholders of a generated query
 	 */
-	final Object convertParameter(Object parameter, @Nullable Function<Object, Value> conversionOverride) {
+	final Object convertParameter(Object parameter, @Nullable Neo4jPersistentPropertyConverter<?> conversionOverride) {
 
 		if (parameter == null) {
 			return Values.NULL;

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
@@ -137,7 +137,7 @@ final class Predicate {
 						v -> {
 							Neo4jPersistentProperty neo4jPersistentProperty = (Neo4jPersistentProperty) graphProperty;
 							return conversionService.writeValue(v, neo4jPersistentProperty.getTypeInformation(),
-											neo4jPersistentProperty.getOptionalWritingConverter());
+											neo4jPersistentProperty.getOptionalConverter());
 						})
 						.get());
 			}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ListPropertyConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ListPropertyConversionIT.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.conversion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.AbstractNeo4jConfig;
+import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
+import org.springframework.data.neo4j.core.Neo4jTemplate;
+import org.springframework.data.neo4j.core.convert.ConvertWith;
+import org.springframework.data.neo4j.core.convert.Neo4jConversionService;
+import org.springframework.data.neo4j.core.convert.Neo4jConversions;
+import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
+import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyToMapConverter;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.schema.CompositeProperty;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
+import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
+import org.springframework.data.neo4j.test.BookmarkCapture;
+import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Test around collections to be converted as a whole and not as individual elements.
+ *
+ * @author Michael J. Simons
+ */
+@Neo4jIntegrationTest
+class ListPropertyConversionIT {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	protected static Long existingNodeId;
+
+	@BeforeAll
+	static void setupData(@Autowired Driver driver, @Autowired BookmarkCapture bookmarkCapture) {
+
+		try (Session session = driver.session(bookmarkCapture.createSessionConfig())) {
+			session.run("MATCH (n) DETACH DELETE n").consume();
+			existingNodeId = session.run("CREATE (n:DomainObjectWithListOfConvertables {"
+										 + "someprefixA_0: '1', someprefixB_0: '2', someprefixA_1: '3', someprefixB_1: '4', "
+										 + "anotherSet: '1;2,3;4'"
+										 + "}) RETURN id(n)")
+					.single().get(0).asLong();
+			bookmarkCapture.seedWith(session.lastBookmark());
+		}
+	}
+
+	@Test // GH-2408
+	void writingDecomposedListsShouldWork(@Autowired Neo4jTemplate template,
+			@Autowired BookmarkCapture bookmarkCapture) {
+
+		DomainObjectWithListOfConvertables object = new DomainObjectWithListOfConvertables();
+		object.collectedData = Arrays.asList(
+				new SomeConvertableClass(new BigDecimal("523.6"), new BigDecimal("67689.7")),
+				new SomeConvertableClass(new BigDecimal("4456.3"), new BigDecimal("3109.6")),
+				new SomeConvertableClass(new BigDecimal("100.6"), new BigDecimal("3050.6"))
+		);
+
+		object = template.save(object);
+
+		try (Session session = neo4jConnectionSupport.getDriver().session(bookmarkCapture.createSessionConfig())) {
+			org.neo4j.driver.types.Node node =
+					session.run("MATCH (n:DomainObjectWithListOfConvertables) WHERE id(n) = $id RETURN n",
+							Collections.singletonMap("id", object.id)).single().get(0).asNode();
+
+			assertThat(node.get("someprefixA_0").asString()).isEqualTo("523.6");
+			assertThat(node.get("someprefixA_1").asString()).isEqualTo("4456.3");
+			assertThat(node.get("someprefixA_2").asString()).isEqualTo("100.6");
+
+			assertThat(node.get("someprefixB_0").asString()).isEqualTo("67689.7");
+			assertThat(node.get("someprefixB_1").asString()).isEqualTo("3109.6");
+			assertThat(node.get("someprefixB_2").asString()).isEqualTo("3050.6");
+		}
+	}
+
+	@Test // GH-2408
+	void writingCompressedListsShouldWork(@Autowired Neo4jTemplate template,
+			@Autowired BookmarkCapture bookmarkCapture) {
+
+		DomainObjectWithListOfConvertables object = new DomainObjectWithListOfConvertables();
+		object.anotherSet = Arrays.asList(
+				new SomeConvertableClass(new BigDecimal("523.6"), new BigDecimal("67689.7")),
+				new SomeConvertableClass(new BigDecimal("4456.3"), new BigDecimal("3109.6")),
+				new SomeConvertableClass(new BigDecimal("100.6"), new BigDecimal("3050.6"))
+		);
+
+		object = template.save(object);
+		try (Session session = neo4jConnectionSupport.getDriver().session(bookmarkCapture.createSessionConfig())) {
+			org.neo4j.driver.types.Node node =
+					session.run("MATCH (n:DomainObjectWithListOfConvertables) WHERE id(n) = $id RETURN n",
+							Collections.singletonMap("id", object.id)).single().get(0).asNode();
+			assertThat(node.get("anotherSet").asString()).isEqualTo("523.6;67689.7,4456.3;3109.6,100.6;3050.6");
+		}
+	}
+
+	@Test // GH-2408
+	void readingDecomposedListsShouldWork(@Autowired Neo4jTemplate template) {
+
+		Optional<DomainObjectWithListOfConvertables> optionalResult = template.findById(existingNodeId,
+				DomainObjectWithListOfConvertables.class);
+
+		assertThat(optionalResult).hasValueSatisfying(object -> {
+			assertThat(object.collectedData).hasSize(2);
+			assertThat(object.collectedData).containsExactlyInAnyOrder(
+					new SomeConvertableClass(new BigDecimal("1"), new BigDecimal("2")),
+					new SomeConvertableClass(new BigDecimal("3"), new BigDecimal("4"))
+			);
+		});
+	}
+
+	@Test // GH-2408
+	void readingCompressedListsShouldWork(@Autowired Neo4jTemplate template) {
+
+		Optional<DomainObjectWithListOfConvertables> optionalResult = template.findById(existingNodeId,
+				DomainObjectWithListOfConvertables.class);
+
+		assertThat(optionalResult).hasValueSatisfying(object -> {
+			assertThat(object.anotherSet).hasSize(2);
+			assertThat(object.anotherSet).containsExactlyInAnyOrder(
+					new SomeConvertableClass(new BigDecimal("1"), new BigDecimal("2")),
+					new SomeConvertableClass(new BigDecimal("3"), new BigDecimal("4"))
+			);
+		});
+	}
+
+	@Node
+	static class DomainObjectWithListOfConvertables {
+
+		@Id @GeneratedValue
+		private Long id;
+
+		@CompositeProperty(converter = ListDecomposingConverter.class, delimiter = "", prefix = "someprefix")
+		private List<SomeConvertableClass> collectedData;
+
+		@ConvertWith(converter = F.class)
+		private List<SomeConvertableClass> anotherSet;
+
+	}
+
+	static class SomeConvertableClass {
+
+		private final BigDecimal x;
+		private final BigDecimal y;
+
+		SomeConvertableClass(BigDecimal x, BigDecimal y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		public BigDecimal getX() {
+			return x;
+		}
+
+		public BigDecimal getY() {
+			return y;
+		}
+
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SomeConvertableClass that = (SomeConvertableClass) o;
+			return x.equals(that.x) && y.equals(that.y);
+		}
+
+		@Override public int hashCode() {
+			return Objects.hash(x, y);
+		}
+	}
+
+	static class ListDecomposingConverter implements
+			Neo4jPersistentPropertyToMapConverter<String, List<SomeConvertableClass>> {
+
+		@Override
+		public Map<String, Value> decompose(List<SomeConvertableClass> property,
+				Neo4jConversionService neo4jConversionService) {
+
+			if (property == null) {
+				return Collections.emptyMap();
+			}
+
+			Map<String, Value> properties = new HashMap<>();
+			for (int i = 0; i < property.size(); i++) {
+				SomeConvertableClass some = property.get(i);
+				if (some != null) {
+					properties.put("A_" + i, Values.value(some.getX().toString()));
+					properties.put("B_" + i, Values.value(some.getY().toString()));
+				}
+			}
+
+			return properties;
+		}
+
+		@Override
+		public List<SomeConvertableClass> compose(Map<String, Value> source,
+				Neo4jConversionService neo4jConversionService) {
+
+			if (source.isEmpty()) {
+				return Collections.emptyList();
+			}
+
+			List<SomeConvertableClass> result = new ArrayList<>(source.size() / 2);
+			for (int i = 0; i < source.size() / 2; ++i) {
+				result.add(new SomeConvertableClass(
+						new BigDecimal(source.get("A_" + i).asString()),
+						new BigDecimal(source.get("B_" + i).asString())
+				));
+			}
+
+			return result;
+		}
+	}
+
+	static class F implements Neo4jPersistentPropertyConverter<List<SomeConvertableClass>> {
+
+		@Override public Value write(List<SomeConvertableClass> source) {
+
+			if (source == null) {
+				return Values.NULL;
+			}
+
+			return Values.value(source.stream().map(v ->
+							String.format("%s;%s", v.x.toString(), v.y.toString()))
+					.collect(Collectors.joining(",")));
+		}
+
+		@Override
+		public List<SomeConvertableClass> read(Value source) {
+
+			return Arrays.stream(source.asString().split(",")).map(v -> {
+				String[] pair = v.split(";");
+				return new SomeConvertableClass(new BigDecimal(pair[0]), new BigDecimal(pair[1]));
+			}).collect(Collectors.toList());
+		}
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		public Neo4jMappingContext neo4jMappingContext(Neo4jConversions neo4JConversions)
+				throws ClassNotFoundException {
+
+			Neo4jMappingContext ctx = new Neo4jMappingContext(neo4JConversions);
+			ctx.setInitialEntitySet(Collections.singleton(DomainObjectWithListOfConvertables.class));
+			return ctx;
+		}
+
+		@Bean
+		public BookmarkCapture bookmarkCapture() {
+			return new BookmarkCapture();
+		}
+
+		@Override
+		public PlatformTransactionManager transactionManager(Driver driver,
+				DatabaseSelectionProvider databaseNameProvider) {
+
+			BookmarkCapture bookmarkCapture = bookmarkCapture();
+			return new Neo4jTransactionManager(driver, databaseNameProvider,
+					Neo4jBookmarkManager.create(bookmarkCapture));
+		}
+	}
+}


### PR DESCRIPTION
This change applies custom converters to collections if they indicate via their type parameter if they want to work on a whole collection or on single elements.

To make this work, a somewhat breaking change is required: The `Neo4jPersistentProperty` cannot return `Function<?, ?>` for their optional reading and writing converters anymore, as we loose the converter information at that place.

The chances that someone extends that interface are minimal and can hopefully be mitigated in case anyone does so. The urgency of that feature justifies the change.

In addition, the null safe writing and reading must be replaced with a delegating mechanism. This has the advantage that we have simpler stacks, as we don't pass lambdas around anymore.

This fixes #2408.