### PR TITLE
GH-2428 - Provide mapping functions via supplier.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
@@ -621,7 +622,7 @@ public final class Neo4jTemplate implements
 	private <T> ExecutableQuery<T> createExecutableQuery(Class<T> domainType, @Nullable Class<?> resultType,  @Nullable String cypherStatement,
 			Map<String, Object> parameters) {
 
-		BiFunction<TypeSystem, MapAccessor, ?> mappingFunction = TemplateSupport
+		Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction = TemplateSupport
 				.getAndDecorateMappingFunction(neo4jMappingContext, domainType, resultType);
 		PreparedQuery<T> preparedQuery = PreparedQuery.queryFor(domainType)
 				.withCypherQuery(cypherStatement)
@@ -881,7 +882,7 @@ public final class Neo4jTemplate implements
 	private <T> ExecutableQuery<T> createExecutableQuery(Class<T> domainType, Class<?> resultType,
  			QueryFragmentsAndParameters queryFragmentsAndParameters) {
 
-		BiFunction<TypeSystem, MapAccessor, ?> mappingFunction = TemplateSupport
+		Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction = TemplateSupport
 				.getAndDecorateMappingFunction(neo4jMappingContext, domainType, resultType);
 		PreparedQuery<T> preparedQuery = PreparedQuery.queryFor(domainType)
 				.withQueryFragmentsAndParameters(queryFragmentsAndParameters)

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
@@ -611,7 +612,7 @@ public final class ReactiveNeo4jTemplate implements
 	private <T> Mono<ExecutableQuery<T>> createExecutableQuery(Class<T> domainType, @Nullable Class<?> resultType, @Nullable String cypherQuery,
 			Map<String, Object> parameters) {
 
-		BiFunction<TypeSystem, MapAccessor, ?> mappingFunction = TemplateSupport
+		Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction = TemplateSupport
 				.getAndDecorateMappingFunction(neo4jMappingContext, domainType, resultType);
 		PreparedQuery<T> preparedQuery = PreparedQuery.queryFor(domainType).withCypherQuery(cypherQuery)
 				.withParameters(parameters)

--- a/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -227,16 +228,18 @@ public final class TemplateSupport {
 	 * @param <T>            The domain type
 	 * @return A mapping function
 	 */
-	static <T> BiFunction<TypeSystem, MapAccessor, ?> getAndDecorateMappingFunction(
+	static <T> Supplier<BiFunction<TypeSystem, MapAccessor, ?>> getAndDecorateMappingFunction(
 			Neo4jMappingContext mappingContext, Class<T> domainType, @Nullable Class<?> resultType) {
 
 		Assert.notNull(mappingContext.getPersistentEntity(domainType), "Cannot get or create persistent entity.");
-		BiFunction<TypeSystem, MapAccessor, ?> mappingFunction = mappingContext
-				.getRequiredMappingFunctionFor(domainType);
-		if (resultType != null && domainType != resultType && !resultType.isInterface()) {
-			mappingFunction = EntityInstanceWithSource.decorateMappingFunction(mappingFunction);
-		}
-		return mappingFunction;
+		return () -> {
+			BiFunction<TypeSystem, MapAccessor, ?> mappingFunction = mappingContext.getRequiredMappingFunctionFor(
+					domainType);
+			if (resultType != null && domainType != resultType && !resultType.isInterface()) {
+				mappingFunction = EntityInstanceWithSource.decorateMappingFunction(mappingFunction);
+			}
+			return mappingFunction;
+		};
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
@@ -150,7 +150,7 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 	protected abstract <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType,
 			Map<PropertyPath, Boolean> includedProperties, Neo4jParameterAccessor parameterAccessor,
 			@Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction,
+			@Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction,
 			@Nullable UnaryOperator<Integer> limitModifier);
 
 	protected Optional<PreparedQuery<Long>> getCountQuery(Neo4jParameterAccessor parameterAccessor) {

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.repository.query;
 
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
@@ -91,5 +92,5 @@ abstract class AbstractReactiveNeo4jQuery extends Neo4jQuerySupport implements R
 
 	protected abstract <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType,
 				Map<PropertyPath, Boolean> includedProperties, Neo4jParameterAccessor parameterAccessor,
-				@Nullable Neo4jQueryType queryType, @Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction);
+				@Nullable Neo4jQueryType queryType, @Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction);
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslBasedQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslBasedQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.neo4j.cypherdsl.core.Statement;
@@ -57,7 +58,7 @@ final class CypherdslBasedQuery extends AbstractNeo4jQuery {
 	protected <T> PreparedQuery<T> prepareQuery(Class<T> returnedType,
 			Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, Neo4jQueryType queryType,
-			BiFunction<TypeSystem, MapAccessor, ?> mappingFunction,
+			Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction,
 			UnaryOperator<Integer> limitModifier) {
 
 		Object[] parameters = parameterAccessor.getValues();

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.neo4j.driver.types.MapAccessor;
@@ -62,7 +63,7 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction, UnaryOperator<Integer> limitModifier) {
+			@Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction, UnaryOperator<Integer> limitModifier) {
 
 		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslBasedQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslBasedQuery.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.repository.query;
 
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.driver.types.MapAccessor;
@@ -52,7 +53,7 @@ final class ReactiveCypherdslBasedQuery extends AbstractReactiveNeo4jQuery {
 	@Override
 	protected <T> PreparedQuery<T> prepareQuery(Class<T> returnedType, Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, Neo4jQueryType queryType,
-			BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
+			Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction) {
 
 		Object[] parameters = parameterAccessor.getValues();
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.neo4j.driver.types.MapAccessor;
@@ -62,7 +63,7 @@ final class ReactivePartTreeNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
+			@Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction) {
 
 		CypherQueryCreator queryCreator = new CypherQueryCreator(mappingContext, getDomainType(queryMethod),
 				Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
@@ -126,7 +127,7 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction) {
+			@Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction) {
 
 		Map<String, Object> boundParameters = bindParameters(parameterAccessor);
 		QueryContext queryContext = new QueryContext(

--- a/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
@@ -175,7 +176,7 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 	@Override
 	protected <T extends Object> PreparedQuery<T> prepareQuery(Class<T> returnedType, Map<PropertyPath, Boolean> includedProperties,
 			Neo4jParameterAccessor parameterAccessor, @Nullable Neo4jQueryType queryType,
-			@Nullable BiFunction<TypeSystem, MapAccessor, ?> mappingFunction,
+			@Nullable Supplier<BiFunction<TypeSystem, MapAccessor, ?>> mappingFunction,
 			UnaryOperator<Integer> limitModifier
 	) {
 

--- a/src/test/java/org/springframework/data/neo4j/repository/query/ReactiveRepositoryQueryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/ReactiveRepositoryQueryTest.java
@@ -145,7 +145,7 @@ final class ReactiveRepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity()
+					() -> (typeSystem, mapAccessor) -> new TestEntity()
 			);
 			assertThat(logbackCapture.getFormattedMessages())
 					.anyMatch(s -> s.matches(
@@ -179,7 +179,7 @@ final class ReactiveRepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity()
+					() -> (typeSystem, mapAccessor) -> new TestEntity()
 			);
 			assertThat(pq.getQueryFragmentsAndParameters().getCypherQuery())
 					.isEqualTo("MATCH (n:Test) RETURN n ORDER BY name ASC SKIP $skip LIMIT $limit");
@@ -215,7 +215,7 @@ final class ReactiveRepositoryQueryTest {
 						Collections.emptyMap(),
 						parameterAccessor,
 						Neo4jQueryType.DEFAULT,
-						(typeSystem, mapAccessor) -> new TestEntity()
+						() -> (typeSystem, mapAccessor) -> new TestEntity()
 				);
 				return pq.getQueryFragmentsAndParameters().getCypherQuery();
 			}).block();

--- a/src/test/java/org/springframework/data/neo4j/repository/query/RepositoryQueryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/RepositoryQueryTest.java
@@ -336,7 +336,7 @@ final class RepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity(),
+					() -> (typeSystem, mapAccessor) -> new TestEntity(),
 					UnaryOperator.identity()
 			);
 			assertThat(logbackCapture.getFormattedMessages())
@@ -362,7 +362,7 @@ final class RepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity(),
+					() -> (typeSystem, mapAccessor) -> new TestEntity(),
 					UnaryOperator.identity()
 			);
 			assertThat(logbackCapture.getFormattedMessages())
@@ -394,7 +394,7 @@ final class RepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity(),
+					() -> (typeSystem, mapAccessor) -> new TestEntity(),
 					UnaryOperator.identity()
 			);
 			assertThat(pq.getQueryFragmentsAndParameters().getCypherQuery())
@@ -427,7 +427,7 @@ final class RepositoryQueryTest {
 					Collections.emptyMap(),
 					parameterAccessor,
 					Neo4jQueryType.DEFAULT,
-					(typeSystem, mapAccessor) -> new TestEntity(),
+					() -> (typeSystem, mapAccessor) -> new TestEntity(),
 					UnaryOperator.identity()
 			);
 			assertThat(pq.getQueryFragmentsAndParameters().getCypherQuery())


### PR DESCRIPTION
This avoids potentially stale objects during caches in mapping functions (like in our own) and fixes #2428.