### PR TITLE
Fix ResultSummariesTest on Windows

### DIFF
--- a/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
@@ -33,25 +33,27 @@ import org.neo4j.driver.summary.Notification;
  */
 class ResultSummariesTest {
 
+	private static final String LINE_SEPARATOR = System.lineSeparator();
+
 	private static Stream<Arguments> params() {
 		return Stream.of(
 				Arguments.of("match (n) - [r:FOO*] -> (m) RETURN r", 1, 19, ""
-						+ "\tmatch (n) - [r:FOO*] -> (m) RETURN r\n"
-						+ "\t                  ^\n"),
+						+ "\tmatch (n) - [r:FOO*] -> (m) RETURN r" + LINE_SEPARATOR
+						+ "\t                  ^" + LINE_SEPARATOR),
 				Arguments.of("match (n)\n- [r:FOO*] -> (m) RETURN r", 2, 1, ""
-						+ "\tmatch (n)\n"
-						+ "\t- [r:FOO*] -> (m) RETURN r\n"
-						+ "\t^\n"),
+						+ "\tmatch (n)" + LINE_SEPARATOR
+						+ "\t- [r:FOO*] -> (m) RETURN r" + LINE_SEPARATOR
+						+ "\t^" + LINE_SEPARATOR),
 				Arguments.of("match (x0123456789) \nwith x0123456789\nmatch(n) - [r:FOO*] -> (m) RETURN r", 3, 10, ""
-						+ "\tmatch (x0123456789) \n"
-						+ "\twith x0123456789\n"
-						+ "\tmatch(n) - [r:FOO*] -> (m) RETURN r\n"
-						+ "\t         ^\n"),
+						+ "\tmatch (x0123456789) " + LINE_SEPARATOR
+						+ "\twith x0123456789" + LINE_SEPARATOR
+						+ "\tmatch(n) - [r:FOO*] -> (m) RETURN r" + LINE_SEPARATOR
+						+ "\t         ^" + LINE_SEPARATOR),
 				Arguments.of("match (n)                  \n-        [r:FOO*] -> (m) \nRETURN r", 2, 1, ""
-						+ "\tmatch (n)                  \n"
-						+ "\t-        [r:FOO*] -> (m) \n"
-						+ "\t^\n"
-						+ "\tRETURN r\n")
+						+ "\tmatch (n)                  " + LINE_SEPARATOR
+						+ "\t-        [r:FOO*] -> (m) " + LINE_SEPARATOR
+						+ "\t^" + LINE_SEPARATOR
+						+ "\tRETURN r" + LINE_SEPARATOR)
 		);
 	}
 
@@ -71,7 +73,7 @@ class ResultSummariesTest {
 		when(notification.position()).thenReturn(inputPosition);
 
 		String formattedNotification = ResultSummaries.format(notification, query);
-		assertThat(formattedNotification).isEqualTo("KGQ.Warning: Das ist keine gute Query.\n"
+		assertThat(formattedNotification).isEqualTo("KGQ.Warning: Das ist keine gute Query." + LINE_SEPARATOR
 				+ expected
 				+ "Das solltest Du besser nicht mehr machen.");
 	}

--- a/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.summary.Notification;
 
 /**
  * @author Michael J. Simons
+ * @author Kevin Wittek
  * @soundtrack Fatoni & Dexter - Yo, Picasso
  */
 class ResultSummariesTest {


### PR DESCRIPTION
The test was asserting for `\n` in the rendered summary, while the formatting code uses System.lineSeparator().
This changes the test to check for the platform dependent line separator.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data Neo4j contribution guidelines](https://github.com/spring-projects/spring-data-neo4j/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
