### PR TITLE
Improve interoperability with Spring Data Rest and other projects.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -60,11 +60,11 @@ import org.springframework.core.log.LogAccessor;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.mapping.Association;
-import org.springframework.data.mapping.AssociationHandler;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.neo4j.core.TemplateSupport.NodesAndRelationshipsByIdStatementProvider;
+import org.springframework.data.neo4j.core.mapping.AssociationHandlerSupport;
 import org.springframework.data.neo4j.core.mapping.Constants;
 import org.springframework.data.neo4j.core.mapping.CreateRelationshipStatementHolder;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
@@ -717,7 +717,7 @@ public final class Neo4jTemplate implements
 
 		Object fromId = propertyAccessor.getProperty(sourceEntity.getRequiredIdProperty());
 
-		sourceEntity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) association -> {
+		AssociationHandlerSupport.of(sourceEntity).doWithAssociations(association -> {
 
 			// create context to bundle parameters
 			NestedRelationshipContext relationshipContext = NestedRelationshipContext.of(association, propertyAccessor, sourceEntity);

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -21,6 +21,7 @@ import static org.neo4j.cypherdsl.core.Cypher.parameter;
 
 import org.springframework.data.mapping.Association;
 import org.springframework.data.neo4j.core.TemplateSupport.FilteredBinderFunction;
+import org.springframework.data.neo4j.core.mapping.AssociationHandlerSupport;
 import org.springframework.data.neo4j.core.schema.TargetNode;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -65,7 +66,6 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.data.mapping.AssociationHandler;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
@@ -847,7 +847,7 @@ public final class ReactiveNeo4jTemplate implements
 		List<Mono<Void>> relationshipDeleteMonos = new ArrayList<>();
 		List<Flux<RelationshipHandler>> relationshipCreationCreations = new ArrayList<>();
 
-		sourceEntity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) association -> {
+		AssociationHandlerSupport.of(sourceEntity).doWithAssociations(association -> {
 
 			// create context to bundle parameters
 			NestedRelationshipContext relationshipContext = NestedRelationshipContext.of(association, parentPropertyAccessor, sourceEntity);

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/AssociationHandlerSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/AssociationHandlerSupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.mapping;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apiguardian.api.API;
+import org.springframework.data.mapping.AssociationHandler;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+
+/**
+ * <strong>Warning</strong> Internal API, might change without further notice, even in patch releases.
+ * <p>
+ * This class removes {@link TargetNode @TargetNode} properties again from associations.
+ *
+ * @author Michael J. Simons
+ * @since 6.3
+ */
+@API(status = API.Status.INTERNAL, since = "6.3")
+public final class AssociationHandlerSupport {
+
+	private final static Map<Neo4jPersistentEntity<?>, AssociationHandlerSupport> CACHE = new ConcurrentHashMap<>();
+
+	public static AssociationHandlerSupport of(Neo4jPersistentEntity<?> entity) {
+		return CACHE.computeIfAbsent(entity, AssociationHandlerSupport::new);
+	}
+
+	private final Neo4jPersistentEntity<?> entity;
+
+	private AssociationHandlerSupport(Neo4jPersistentEntity<?> entity) {
+		this.entity = entity;
+	}
+
+	public Neo4jPersistentEntity<?> doWithAssociations(AssociationHandler<Neo4jPersistentProperty> handler) {
+		entity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) association -> {
+			if (!association.getInverse().isAnnotationPresent(TargetNode.class)) {
+				handler.doWithAssociation(association);
+			}
+		});
+		return entity;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -189,7 +189,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 				.getNodeDescription(source.getClass());
 
 		PersistentPropertyAccessor<Object> propertyAccessor = nodeDescription.getPropertyAccessor(source);
-		nodeDescription.doWithProperties((Neo4jPersistentProperty p) -> {
+		PropertyHandlerSupport.of(nodeDescription).doWithProperties((Neo4jPersistentProperty p) -> {
 
 			// Skip the internal properties, we don't want them to end up stored as properties
 			if (p.isInternalIdProperty() || p.isDynamicLabels() || p.isEntity() || p.isVersionProperty() || p.isReadOnly()) {
@@ -339,14 +339,14 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			// Fill simple properties
 			PropertyHandler<Neo4jPersistentProperty> handler = populateFrom(queryResult, propertyAccessor,
 					isConstructorParameter, nodeDescriptionAndLabels.getDynamicLabels(), lastMappedEntity, isKotlinType);
-			concreteNodeDescription.doWithProperties(handler);
+			PropertyHandlerSupport.of(concreteNodeDescription).doWithProperties(handler);
 		}
 		// in a cyclic graph / with bidirectional relationships, we could end up in a state in which we
 		// reference the start again. Because it is getting still constructed, it won't be in the knownObjects
 		// store unless we temporarily put it there.
 		knownObjects.storeObject(internalId, mappedObject);
 
-		concreteNodeDescription.doWithAssociations(
+		AssociationHandlerSupport.of(concreteNodeDescription).doWithAssociations(
 				populateFrom(queryResult, nodeDescription, propertyAccessor, isConstructorParameter, objectAlreadyMapped, relationshipsFromResult, nodesFromResult));
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -90,7 +90,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 			if (isAnnotationPresent(Relationship.class)) {
 				return true;
 			}
-			return !(isWritableProperty.get() || isAnnotationPresent(TargetNode.class));
+			return !(isWritableProperty.get());
 		});
 
 		this.customConversion = Lazy.of(() -> {
@@ -229,7 +229,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 	@Nullable
 	private String computeGraphPropertyName() {
 
-		if (this.isAssociation()) {
+		if (this.isRelationship()) {
 			return null;
 		}
 
@@ -270,7 +270,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 	@Override
 	public boolean isRelationship() {
 
-		return isAssociation();
+		return isAssociation() && !isAnnotationPresent(TargetNode.class);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
@@ -33,7 +33,6 @@ import org.springframework.data.mapping.Parameter;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.data.mapping.SimplePropertyHandler;
 import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.lang.Nullable;
@@ -86,7 +85,7 @@ public final class DtoInstantiatingConverter implements Converter<EntityInstance
 				);
 
 		PersistentPropertyAccessor<Object> dtoAccessor = targetEntity.getPropertyAccessor(dto);
-		targetEntity.doWithProperties((SimplePropertyHandler) property -> {
+		PropertyHandlerSupport.of(targetEntity).doWithProperties(property -> {
 
 			if (creator != null && creator.isCreatorParameter(property)) {
 				return;

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/EntityFromDtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/EntityFromDtoInstantiatingConverter.java
@@ -29,6 +29,7 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.model.ParameterValueProvider;
+import org.springframework.data.neo4j.core.schema.TargetNode;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.lang.Nullable;
@@ -118,7 +119,7 @@ public final class EntityFromDtoInstantiatingConverter<T> implements Converter<O
 			return ReflectionUtils.getPrimitiveDefault(targetPropertyType);
 		}
 
-		if (targetProperty.isAssociation() && targetProperty.isCollectionLike()) {
+		if (targetProperty.isAssociation() && !targetProperty.isAnnotationPresent(TargetNode.class) && targetProperty.isCollectionLike()) {
 			EntityFromDtoInstantiatingConverter<?> nestedConverter = converterCache.computeIfAbsent(targetProperty.getComponentType(), t -> new EntityFromDtoInstantiatingConverter<>(t, context));
 			Collection<?> source = (Collection<?>) propertyValue;
 			if (source == null) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -27,6 +27,10 @@ import org.springframework.data.mapping.model.MutablePersistentEntity;
  * Neo4j. Both Spring Data methods {@link #doWithProperties(PropertyHandler)} and
  * {@link #doWithAssociations(AssociationHandler)} are aware which field of a class is meant to be mapped as a property
  * of a node or a relationship or if it is a relationship (in Spring Data terms: if it is an association).
+ * <p>
+ * <strong>Note</strong> to the outside world, we treat the {@link org.springframework.data.neo4j.core.schema.TargetNode @TargetNode}
+ * annotated field of a {@link org.springframework.data.neo4j.core.schema.RelationshipProperties @RelationshipProperties} annotated
+ * class as association. Internally, we treat it as a property
  *
  * @author Michael J. Simons
  * @param <T> type of the underlying class

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
@@ -44,7 +44,7 @@ public interface Neo4jPersistentProperty extends PersistentProperty<Neo4jPersist
 	 */
 	default boolean isDynamicAssociation() {
 
-		return isAssociation() && isMap() && (getComponentType() == String.class || getComponentType().isEnum());
+		return isRelationship() && isMap() && (getComponentType() == String.class || getComponentType().isEnum());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyHandlerSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyHandlerSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.mapping;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apiguardian.api.API;
+import org.springframework.data.mapping.AssociationHandler;
+import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+
+/**
+ * <strong>Warning</strong> Internal API, might change without further notice, even in patch releases.
+ * <p>
+ * This class adds {@link TargetNode @TargetNode} properties back to properties.
+ *
+ * @author Michael J. Simons
+ * @since 6.3
+ */
+@API(status = API.Status.INTERNAL, since = "6.3")
+public final class PropertyHandlerSupport {
+
+	private final static Map<Neo4jPersistentEntity<?>, PropertyHandlerSupport> CACHE = new ConcurrentHashMap<>();
+
+	public static PropertyHandlerSupport of(Neo4jPersistentEntity<?> entity) {
+		return CACHE.computeIfAbsent(entity, PropertyHandlerSupport::new);
+	}
+
+	private final Neo4jPersistentEntity<?> entity;
+
+	private PropertyHandlerSupport(Neo4jPersistentEntity<?> entity) {
+		this.entity = entity;
+	}
+
+	public Neo4jPersistentEntity<?> doWithProperties(PropertyHandler<Neo4jPersistentProperty> handler) {
+		entity.doWithProperties(handler);
+		entity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) association -> {
+			if (association.getInverse().isAnnotationPresent(TargetNode.class)) {
+				handler.doWithPersistentProperty(association.getInverse());
+			}
+		});
+		return entity;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyTraverser.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyTraverser.java
@@ -25,6 +25,7 @@ import java.util.function.BiPredicate;
 import org.apiguardian.api.API;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.neo4j.core.schema.TargetNode;
 import org.springframework.lang.Nullable;
 
 /**
@@ -79,7 +80,7 @@ public final class PropertyTraverser {
 			}
 
 			sink.accept(path, p);
-			if (p.isAssociation() && !pathAlreadyVisited) {
+			if (p.isAssociation() && !(pathAlreadyVisited || p.isAnnotationPresent(TargetNode.class))) {
 				Class<?> associationTargetType = p.getAssociationTargetType();
 				if (associationTargetType == null) {
 					return;

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -180,6 +180,10 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryFragmentsAndPar
 			int cnt = 0;
 			for (PersistentProperty<?> persistentProperty : propertyPath) {
 
+				if (persistentProperty.isAssociation() && persistentProperty.isAnnotationPresent(TargetNode.class)) {
+					break;
+				}
+
 				RelationshipDescription relationshipDescription = (RelationshipDescription) persistentProperty.getAssociation();
 
 				if (relationshipDescription == null) {

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
@@ -34,11 +34,10 @@ import org.apiguardian.api.API;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.springframework.data.convert.EntityWriter;
-import org.springframework.data.mapping.AssociationHandler;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.neo4j.core.convert.Neo4jConversionService;
+import org.springframework.data.neo4j.core.mapping.AssociationHandlerSupport;
 import org.springframework.data.neo4j.core.mapping.Constants;
 import org.springframework.data.neo4j.core.mapping.MappingSupport.RelationshipPropertiesWithEntityHolder;
 import org.springframework.data.neo4j.core.mapping.Neo4jEntityConverter;
@@ -46,6 +45,7 @@ import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentProperty;
 import org.springframework.data.neo4j.core.mapping.NestedRelationshipContext;
+import org.springframework.data.neo4j.core.mapping.PropertyHandlerSupport;
 import org.springframework.data.neo4j.core.mapping.RelationshipDescription;
 import org.springframework.data.neo4j.core.schema.TargetNode;
 import org.springframework.data.util.TypeInformation;
@@ -121,7 +121,7 @@ final class Neo4jNestedMapEntityWriter implements EntityWriter<Object, Map<Strin
 		if (initialObject && entity.isRelationshipPropertiesEntity()) {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> propertyMap = (Map<String, Object>) sink.get(Constants.NAME_OF_PROPERTIES_PARAM);
-			entity.doWithProperties((PropertyHandler<Neo4jPersistentProperty>) p -> {
+			PropertyHandlerSupport.of(entity).doWithProperties(p -> {
 				if (p.isAnnotationPresent(TargetNode.class)) {
 					Map<String, Object> target = this.writeImpl(propertyAccessor.getProperty(p), new HashMap<>(), seenObjects, false);
 					propertyMap.put("__target__", Values.value(target));
@@ -149,7 +149,7 @@ final class Neo4jNestedMapEntityWriter implements EntityWriter<Object, Map<Strin
 
 		@SuppressWarnings("unchecked")
 		Map<String, Object> propertyMap = (Map<String, Object>) sink.get(Constants.NAME_OF_PROPERTIES_PARAM);
-		entity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) association -> {
+		AssociationHandlerSupport.of(entity).doWithAssociations(association -> {
 
 			NestedRelationshipContext context = NestedRelationshipContext.of(association, propertyAccessor, entity);
 			RelationshipDescription description = (RelationshipDescription) association;

--- a/src/main/java/org/springframework/data/neo4j/repository/support/EntityAndGraphPropertyAccessingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/EntityAndGraphPropertyAccessingMethodInterceptor.java
@@ -26,7 +26,7 @@ import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.NotReadablePropertyException;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
-import org.springframework.data.neo4j.core.mapping.Neo4jPersistentProperty;
+import org.springframework.data.neo4j.core.mapping.PropertyHandlerSupport;
 import org.springframework.data.neo4j.core.schema.Property;
 import org.springframework.data.projection.MethodInterceptorFactory;
 import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
@@ -121,8 +121,8 @@ final class EntityAndGraphPropertyAccessingMethodInterceptor implements MethodIn
 
 				AtomicReference<String> value = new AtomicReference<>();
 				if (entity != null) {
-					entity.doWithProperties(
-							(org.springframework.data.mapping.PropertyHandler<Neo4jPersistentProperty>) p -> {
+					PropertyHandlerSupport.of(entity).doWithProperties(
+							p -> {
 								if (p.findAnnotation(Property.class) != null && p.getPropertyName()
 										.equals(propertyName)) {
 									value.compareAndSet(null, p.getFieldName());

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyTraverserTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyTraverserTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.data.neo4j.core.schema.TargetNode;
 import org.springframework.data.neo4j.integration.movies.shared.Movie;
 
 /**
@@ -46,7 +47,8 @@ class PropertyTraverserTest {
 
 		PropertyTraverser traverser = new PropertyTraverser(this.ctx);
 		Map<String, Boolean> includedProperties = new TreeMap<>();
-		traverser.traverse(Movie.class, (path, property) -> includedProperties.put(path.toString(), property.isAssociation()));
+		traverser.traverse(Movie.class, (path, property) -> includedProperties.put(path.toString(), property.isAssociation() && !property.isAnnotationPresent(
+				TargetNode.class)));
 
 		Map<String, Boolean> expected = new LinkedHashMap<>();
 		expected.put("Movie.actors", true);


### PR DESCRIPTION
This improves the interoperability with Spring Data Rest by a magnitude by treating `@TargetNode` as association to the outside world. Why? Because no resource processing needs to be done on `@RelationshipProperties` to have embedded links for their target node.

Two support classes for both associations and properties have been added as internal API to chim our philosophy from that change.

To demonstrate that change have a look here: https://github.com/michael-simons/neo4j-examples-and-tips/blob/832e0334a09692bdd72474c9ba11390bc68a493b/examples/sdn6-rest/src/main/java/org/neo4j/tips/sdn/sdn6_rest/SpringDataRestConfig.java#L29-L40

This piece is necessary to include the actual `Person` behind the `Actor` as an embedded resource. Otherwise, SDR won't recognise it as association, even though it is managed by a repository.

With this change in place, we also can use proper excerpts as recommended by @odrotbohm, for example see here_

https://github.com/michael-simons/neo4j-examples-and-tips/commit/9a746979919d298fbbd1c605296605133364bb51

A full blown result that shows 

- Uniform excerpts on all people
- Correctly embedded people on the actors

```json
{
  "_embedded" : {
    "movies" : [ {
      "title" : "The Matrix",
      "description" : "Welcome to the Real World",
      "actors" : [ {
        "roles" : [ "Emil" ],
        "_embedded" : {
          "person" : {
            "name" : "Emil Eifrem",
            "_links" : {
              "self" : {
                "href" : "http://localhost:8080/people/e43fd0ea-1d26-48ee-b183-a4d74164411e{?projection}",
                "templated" : true
              }
            }
          }
        },
        "_links" : {
          "person" : {
            "href" : "http://localhost:8080/people/e43fd0ea-1d26-48ee-b183-a4d74164411e{?projection}",
            "templated" : true
          }
        }
      } ],
      "released" : 1999,
      "_embedded" : {
        "directors" : [ {
          "name" : "Lana Wachowski",
          "_links" : {
            "self" : {
              "href" : "http://localhost:8080/people/2141c773-86b2-4bab-930a-101de3ba55fc{?projection}",
              "templated" : true
            }
          }
        }, {
          "name" : "Lilly Wachowski",
          "_links" : {
            "self" : {
              "href" : "http://localhost:8080/people/9daf0125-b276-4a1a-9008-6a8e6c1b22ad{?projection}",
              "templated" : true
            }
          }
        } ]
      },
      "_links" : {
        "self" : {
          "href" : "http://localhost:8080/movies/The%20Matrix"
        },
        "movie" : {
          "href" : "http://localhost:8080/movies/The%20Matrix"
        },
        "directors" : {
          "href" : "http://localhost:8080/movies/The%20Matrix/directors{?projection}",
          "templated" : true
        }
      }
    } ]
  },
  "_links" : {
    "first" : {
      "href" : "http://localhost:8080/movies?page=0&size=1"
    },
    "self" : {
      "href" : "http://localhost:8080/movies?size=1"
    },
    "next" : {
      "href" : "http://localhost:8080/movies?page=1&size=1"
    },
    "last" : {
      "href" : "http://localhost:8080/movies?page=37&size=1"
    },
    "profile" : {
      "href" : "http://localhost:8080/profile/movies"
    }
  },
  "page" : {
    "size" : 1,
    "totalElements" : 38,
    "totalPages" : 38,
    "number" : 0
  }
}
```