### PR TITLE
Provide ReactiveCypherdslConditionExecutor.

### DIFF
--- a/src/main/asciidoc/object-mapping/sdn-extensions.adoc
+++ b/src/main/asciidoc/object-mapping/sdn-extensions.adoc
@@ -19,6 +19,8 @@ Additional mixins provided are:
 * `QuerydslPredicateExecutor`
 * `CypherdslConditionExecutor`
 * `CypherdslStatementExecutor`
+* `ReactiveQuerydslPredicateExecutor`
+* `ReactiveCypherdslConditionExecutor`
 * `ReactiveCypherdslStatementExecutor`
 
 [[sdn-mixins.dynamic-conditions]]

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
@@ -131,8 +131,6 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 	@Override
 	public boolean exists(Condition condition) {
-		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
-				.returning(Functions.count(asterisk())).build();
-		return this.neo4jOperations.count(statement, statement.getParameters()) > 0;
+		return count(condition) > 0;
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.query;
+
+import static org.neo4j.cypherdsl.core.Cypher.asterisk;
+
+import java.util.Arrays;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.Condition;
+import org.neo4j.cypherdsl.core.Conditions;
+import org.neo4j.cypherdsl.core.Functions;
+import org.neo4j.cypherdsl.core.SortItem;
+import org.neo4j.cypherdsl.core.Statement;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
+import org.springframework.data.neo4j.core.mapping.CypherGenerator;
+import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
+import org.springframework.data.neo4j.repository.support.ReactiveCypherdslConditionExecutor;
+import org.springframework.data.neo4j.repository.support.Neo4jEntityInformation;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Michael J. Simons
+ * @param <T> The returned domain type.
+ * @since 6.3.3
+ */
+@API(status = API.Status.INTERNAL, since = "6.3.3")
+public final class ReactiveCypherdslConditionExecutorImpl<T> implements ReactiveCypherdslConditionExecutor<T> {
+
+	private final Neo4jEntityInformation<T, Object> entityInformation;
+
+	private final ReactiveNeo4jOperations neo4jOperations;
+
+	private final Neo4jPersistentEntity<T> metaData;
+
+	public ReactiveCypherdslConditionExecutorImpl(Neo4jEntityInformation<T, Object> entityInformation,
+    ReactiveNeo4jOperations neo4jOperations) {
+
+		this.entityInformation = entityInformation;
+		this.neo4jOperations = neo4jOperations;
+		this.metaData = this.entityInformation.getEntityMetaData();
+	}
+
+	@Override
+	public Mono<T> findOne(Condition condition) {
+
+		return this.neo4jOperations.toExecutableQuery(
+				this.metaData.getType(),
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+		).flatMap(ReactiveNeo4jOperations.ExecutableQuery::getSingleResult);
+	}
+
+	@Override
+	public Flux<T> findAll(Condition condition) {
+
+		return this.neo4jOperations.toExecutableQuery(
+				this.metaData.getType(),
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
+	}
+
+	@Override
+	public Flux<T> findAll(Condition condition, Sort sort) {
+
+		return this.neo4jOperations.toExecutableQuery(
+				metaData.getType(),
+				QueryFragmentsAndParameters.forCondition(
+						this.metaData, condition, null, CypherAdapterUtils.toSortItems(this.metaData, sort)
+				)
+		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
+	}
+
+	@Override
+	public Flux<T> findAll(Condition condition, SortItem... sortItems) {
+
+		return this.neo4jOperations.toExecutableQuery(
+				this.metaData.getType(),
+				QueryFragmentsAndParameters.forCondition(
+						this.metaData, condition, null, Arrays.asList(sortItems)
+				)
+		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
+	}
+
+	@Override
+	public Flux<T> findAll(SortItem... sortItems) {
+
+		return this.neo4jOperations.toExecutableQuery(
+				this.metaData.getType(),
+				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), null, Arrays.asList(sortItems))
+		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
+	}
+
+	@Override
+	public Mono<Long> count(Condition condition) {
+
+		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
+				.returning(Functions.count(asterisk())).build();
+		return this.neo4jOperations.count(statement, statement.getParameters());
+	}
+
+	@Override
+	public Mono<Boolean> exists(Condition condition) {
+		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
+				.returning(Functions.count(asterisk())).build();
+		return this.neo4jOperations.count(statement, statement.getParameters()).map(count -> count > 0);
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
+ * @author Niklas Krieger
  * @author Michael J. Simons
  * @param <T> The returned domain type.
  * @since 6.3.3
@@ -50,7 +51,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 	private final Neo4jPersistentEntity<T> metaData;
 
 	public ReactiveCypherdslConditionExecutorImpl(Neo4jEntityInformation<T, Object> entityInformation,
-    ReactiveNeo4jOperations neo4jOperations) {
+			ReactiveNeo4jOperations neo4jOperations) {
 
 		this.entityInformation = entityInformation;
 		this.neo4jOperations = neo4jOperations;
@@ -102,7 +103,8 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), null, Arrays.asList(sortItems))
+				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), null,
+						Arrays.asList(sortItems))
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
 
@@ -116,8 +118,6 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 	@Override
 	public Mono<Boolean> exists(Condition condition) {
-		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
-				.returning(Functions.count(asterisk())).build();
-		return this.neo4jOperations.count(statement, statement.getParameters()).map(count -> count > 0);
+		return count(condition).map(count -> count > 0);
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.Condition;
+import org.neo4j.cypherdsl.core.SortItem;
+import org.springframework.data.domain.Sort;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * An interface that can be added to any repository so that queries can be enriched by {@link Condition conditions} of the
+ * Cypher-DSL. This interface behaves the same as the {@link org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor}.
+ *
+ * @author Michael J. Simons
+ * @param <T> Type of the domain
+ * @since 6.3.3
+ */
+@API(status = API.Status.STABLE, since = "6.3.3")
+public interface ReactiveCypherdslConditionExecutor<T> {
+
+	Mono<T> findOne(Condition condition);
+
+	Flux<T> findAll(Condition condition);
+
+	Flux<T> findAll(Condition condition, Sort sort);
+
+	Flux<T> findAll(Condition condition, SortItem... sortItems);
+
+	Flux<T> findAll(SortItem... sortItems);
+
+	Mono<Long> count(Condition condition);
+
+	Mono<Boolean> exists(Condition condition);
+}
+

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono;
  * An interface that can be added to any repository so that queries can be enriched by {@link Condition conditions} of the
  * Cypher-DSL. This interface behaves the same as the {@link org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor}.
  *
+ * @author Niklas Krieger
  * @author Michael J. Simons
  * @param <T> Type of the domain
  * @since 6.3.3

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -27,6 +27,7 @@ import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
 import org.springframework.data.neo4j.repository.query.ReactiveNeo4jQueryLookupStrategy;
 import org.springframework.data.neo4j.repository.query.ReactiveQuerydslNeo4jPredicateExecutor;
 import org.springframework.data.neo4j.repository.query.SimpleReactiveQueryByExampleExecutor;
+import org.springframework.data.neo4j.repository.query.ReactiveCypherdslConditionExecutorImpl;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.querydsl.QuerydslUtils;
@@ -91,6 +92,11 @@ final class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupp
 		if (isQueryDslRepository) {
 
 			fragments = fragments.append(createDSLExecutorFragment(metadata, ReactiveQuerydslNeo4jPredicateExecutor.class));
+		}
+
+		if (ReactiveCypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+
+			fragments = fragments.append(createDSLExecutorFragment(metadata, ReactiveCypherdslConditionExecutorImpl.class));
 		}
 
 		return fragments;

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -46,6 +46,7 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
  *
  * @author Gerrit Meier
  * @author Michael J. Simons
+ * @author Niklas Krieger
  * @since 6.0
  */
 final class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupport {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslConditionExecutorIT.java
@@ -58,17 +58,11 @@ class CypherdslConditionExecutorIT {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
 
-	private final Driver driver;
-	private final BookmarkCapture bookmarkCapture;
-	private final Node person;
 	private final Property firstName;
 	private final Property lastName;
 
 	@Autowired
-	CypherdslConditionExecutorIT(Driver driver, BookmarkCapture bookmarkCapture) {
-
-		this.driver = driver;
-		this.bookmarkCapture = bookmarkCapture;
+	CypherdslConditionExecutorIT() {
 
 		//CHECKSTYLE:OFF
 		// tag::sdn-mixins.dynamic-conditions.usage[]
@@ -78,7 +72,6 @@ class CypherdslConditionExecutorIT {
 		// end::sdn-mixins.dynamic-conditions.usage[]
 		//CHECKSTYLE:ON
 
-		this.person = person;
 		this.firstName = firstName;
 		this.lastName = lastName;
 	}

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.reactive;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.Property;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.neo4j.core.ReactiveDatabaseSelectionProvider;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
+import org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager;
+import org.springframework.data.neo4j.integration.shared.common.Person;
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.config.EnableReactiveNeo4jRepositories;
+import org.springframework.data.neo4j.repository.support.ReactiveCypherdslConditionExecutor;
+import org.springframework.data.neo4j.test.BookmarkCapture;
+import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.data.neo4j.test.Neo4jReactiveTestConfiguration;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import reactor.test.StepVerifier;
+
+/**
+ * @author Michael J. Simons
+ */
+@Tag(Neo4jExtension.NEEDS_REACTIVE_SUPPORT)
+@Neo4jIntegrationTest
+class ReactiveCypherdslConditionExecutorIT {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final Driver driver;
+	private final Node person;
+	private final Property firstName;
+	private final Property lastName;
+
+	ReactiveCypherdslConditionExecutorIT(@Autowired Driver driver) {
+
+		this.driver = driver;
+
+		this.person = Cypher.node("Person").named("person");
+		this.firstName = person.property("firstName");
+		this.lastName = person.property("lastName");
+	}
+
+	@BeforeAll
+	protected static void setupData(@Autowired BookmarkCapture bookmarkCapture) {
+		try (Session session = neo4jConnectionSupport.getDriver().session(bookmarkCapture.createSessionConfig());
+			 Transaction transaction = session.beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			transaction.run("CREATE (p:Person{firstName: 'A', lastName: 'LA'})");
+			transaction.run("CREATE (p:Person{firstName: 'B', lastName: 'LB'})");
+			transaction
+					.run("CREATE (p:Person{firstName: 'Helge', lastName: 'Schneider'}) -[:LIVES_AT]-> (a:Address {city: 'Mülheim an der Ruhr'})");
+			transaction.run("CREATE (p:Person{firstName: 'Bela', lastName: 'B.'})");
+			transaction.commit();
+			bookmarkCapture.seedWith(session.lastBookmark());
+		}
+	}
+
+	@Test
+	void findOneShouldWork(@Autowired PersonRepository repository) {
+
+		repository.findOne(firstName.eq(Cypher.literalOf("Helge")))
+				.as(StepVerifier::create)
+				.expectNextMatches(p -> p.getLastName().equals("Schneider"))
+				.verifyComplete();
+	}
+
+	@Test
+	void findAllShouldWork(@Autowired PersonRepository repository) {
+
+		repository.findAll(firstName.eq(Cypher.literalOf("Helge")).or(lastName.eq(Cypher.literalOf("B."))))
+				.map(Person::getFirstName)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bela", "Helge")
+				.verifyComplete();
+	}
+
+	@Test
+	void sortedFindAllShouldWork(@Autowired PersonRepository repository) {
+
+		repository.findAll(firstName.eq(Cypher.literalOf("Helge")).or(lastName.eq(Cypher.literalOf("B."))),
+						Sort.by("lastName").descending()
+				)
+				.map(Person::getFirstName)
+				.as(StepVerifier::create)
+				.expectNext("Helge", "Bela")
+				.verifyComplete();
+	}
+
+	@Test
+	void sortedFindAllShouldWorkWithParameter(@Autowired PersonRepository repository) {
+
+		repository.findAll(
+				firstName.eq(Cypher.anonParameter("Helge"))
+						.or(lastName.eq(Cypher.parameter("someName", "B."))), // <.>
+				lastName.descending() // <.>
+		)
+				.map(Person::getFirstName)
+				.as(StepVerifier::create)
+				.expectNext("Helge", "Bela")
+				.verifyComplete();
+	}
+
+	@Test
+	void orderedFindAllShouldWork(@Autowired PersonRepository repository) {
+
+			repository.findAll(firstName.eq(Cypher.literalOf("Helge")).or(lastName.eq(Cypher.literalOf("B."))),
+					Sort.by("lastName").descending()
+			)
+					.map(Person::getFirstName)
+					.as(StepVerifier::create)
+					.expectNext("Helge", "Bela")
+					.verifyComplete();
+	}
+
+	@Test
+	void orderedFindAllWithoutPredicateShouldWork(@Autowired PersonRepository repository) {
+
+		repository.findAll(lastName.descending())
+				.map(Person::getFirstName)
+				.as(StepVerifier::create)
+				.expectNext("Helge", "B", "A", "Bela")
+				.verifyComplete();
+	}
+
+	@Test
+	void countShouldWork(@Autowired PersonRepository repository) {
+
+		repository.count(firstName.eq(Cypher.literalOf("Helge")).or(lastName.eq(Cypher.literalOf("B."))))
+				.as(StepVerifier::create)
+				.expectNext(2L)
+				.verifyComplete();
+	}
+
+	@Test
+	void existsShouldWork(@Autowired PersonRepository repository) {
+
+		repository.exists(firstName.eq(Cypher.literalOf("A")))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	interface PersonRepository extends ReactiveNeo4jRepository<Person, Long>, ReactiveCypherdslConditionExecutor<Person> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends Neo4jReactiveTestConfiguration {
+
+		@Bean
+		public Driver driver() {
+
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Bean
+		public BookmarkCapture bookmarkCapture() {
+			return new BookmarkCapture();
+		}
+
+		@Override
+		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
+
+			BookmarkCapture bookmarkCapture = bookmarkCapture();
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+		}
+
+		@Override
+		public boolean isCypher5Compatible() {
+			return neo4jConnectionSupport.isCypher5SyntaxCompatible();
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
@@ -44,6 +44,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import reactor.test.StepVerifier;
 
 /**
+ * @author Niklas Krieger
  * @author Michael J. Simons
  */
 @Tag(Neo4jExtension.NEEDS_REACTIVE_SUPPORT)
@@ -52,19 +53,9 @@ class ReactiveCypherdslConditionExecutorIT {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
 
-	private final Driver driver;
-	private final Node person;
-	private final Property firstName;
-	private final Property lastName;
-
-	ReactiveCypherdslConditionExecutorIT(@Autowired Driver driver) {
-
-		this.driver = driver;
-
-		this.person = Cypher.node("Person").named("person");
-		this.firstName = person.property("firstName");
-		this.lastName = person.property("lastName");
-	}
+	private final Node person = Cypher.node("Person").named("person");
+	private final Property firstName = person.property("firstName");
+	private final Property lastName = person.property("lastName");
 
 	@BeforeAll
 	protected static void setupData(@Autowired BookmarkCapture bookmarkCapture) {


### PR DESCRIPTION
Provides a reactive equivalent to CypherdslConditionExecutor.
See #2575

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data Neo4j contribution guidelines](https://github.com/spring-projects/spring-data-neo4j/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Please note:
- I did not change the `@author` tag, as I took existing classes and adopted them. If you want me to change that, please let me know
- I tried to apply the formatter, however it caused lots of changes which are inconsistent with existing files in the project (as most of my code is just an adoption of existing code). I suspect that my config is broken, therefore, help formatting would be appreciated
- I set all `since` to  `6.3.3`, as mentioned [here](https://github.com/spring-projects/spring-data-neo4j/issues/2575#issuecomment-1202146890), the changes will (hopefully) be backported. If you want me to change that, please let me know. I tested my changes also against the 6.3.x branch, so there are hopefully no issues backporting.
- Even though support for `ReactiveQuerydslPredicateExecutor` was already implemented with #2361, I still mentioned it to the documentation, as I also reference this support in `ReactiveCypherdslConditionExecutor`