### PR TITLE
GH-2621: Recursively apply DtoInstantiating converter for fluent ops.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -375,6 +375,10 @@ public final class Neo4jTemplate implements
 				projectionFactory, neo4jMappingContext);
 
 		T savedInstance = saveImpl(instance, pps, null);
+		if (!resultType.isInterface()) {
+			@SuppressWarnings("unchecked") R result = (R) new DtoInstantiatingConverter(resultType, neo4jMappingContext).convertDirectly(savedInstance);
+			return result;
+		}
 		if (projectionInformation.isClosed()) {
 			return projectionFactory.createProjection(resultType, savedInstance);
 		}

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -360,6 +360,14 @@ public final class ReactiveNeo4jTemplate implements
 				projectionFactory, neo4jMappingContext);
 
 		Mono<T> savingPublisher = saveImpl(instance, pps, null);
+
+		if (!resultType.isInterface()) {
+			return savingPublisher.map(savedInstance -> {
+				@SuppressWarnings("unchecked")
+				R result = (R) (new DtoInstantiatingConverter(resultType, neo4jMappingContext).convertDirectly(savedInstance));
+				return result;
+			});
+		}
 		if (projectionInformation.isClosed()) {
 			return savingPublisher.map(savedInstance -> projectionFactory.createProjection(resultType, savedInstance));
 		}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
@@ -109,7 +109,12 @@ public final class DtoInstantiatingConverter implements Converter<EntityInstance
 		if (sourceProperty == null) {
 			return null;
 		}
-		return sourceAccessor.getProperty(sourceProperty);
+
+		Object result = sourceAccessor.getProperty(sourceProperty);
+		if (targetProperty.isEntity() && !targetProperty.getTypeInformation().isAssignableFrom(sourceProperty.getTypeInformation())) {
+			return new DtoInstantiatingConverter(targetProperty.getType(), this.context).convertDirectly(result);
+		}
+		return result;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/GH2621Domain.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/GH2621Domain.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2011-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.shared.common;
+
+import java.util.UUID;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * Container for a bunch of domain classes.
+ */
+public final class GH2621Domain {
+
+	/**
+	 * A node.
+	 */
+	@Node("GH2621Foo")
+	public static class Foo {
+		@Id
+		@GeneratedValue
+		private UUID id;
+
+		private final Bar bar;
+
+		public Foo(Bar bar) {
+			this.bar = bar;
+		}
+
+		public UUID getId() {
+			return id;
+		}
+
+		public Bar getBar() {
+			return bar;
+		}
+	}
+
+	/**
+	 * A node.
+	 */
+	@Node("GH2621Bar")
+	public static class Bar {
+		@Id
+		@GeneratedValue
+		private UUID id;
+
+		private final String value1;
+
+		public Bar(String value1) {
+			this.value1 = value1;
+		}
+
+		public UUID getId() {
+			return id;
+		}
+
+		public String getValue1() {
+			return value1;
+		}
+	}
+
+	/**
+	 * A node.
+	 */
+	@Node("GH2621BarBar")
+	public static class BarBar extends Bar {
+		private final String value2;
+
+		public BarBar(String value1, String value2) {
+			super(value1);
+			this.value2 = value2;
+		}
+
+		public String getValue2() {
+			return value2;
+		}
+	}
+
+	/**
+	 * Projects {@link Foo}
+	 */
+	public static class FooProjection {
+		private final BarProjection bar;
+
+		public FooProjection(BarProjection bar) {
+			this.bar = bar;
+		}
+
+		public BarProjection getBar() {
+			return bar;
+		}
+	}
+
+	/**
+	 * Projects {@link Bar} and {@link BarBar}
+	 */
+	public static class BarProjection {
+		private final String value1;
+
+		public BarProjection(String value1) {
+			this.value1 = value1;
+		}
+
+		public String getValue1() {
+			return value1;
+		}
+	}
+
+	/**
+	 * Projects {@link Bar} and {@link BarBar}
+	 */
+	public static class BarBarProjection extends BarProjection {
+		private final String value2;
+
+		public BarBarProjection(String value1, String value2) {
+			super(value1);
+			this.value2 = value2;
+		}
+
+		public String getValue2() {
+			return value2;
+		}
+	}
+
+
+	private GH2621Domain() {
+	}
+}


### PR DESCRIPTION
This allows to use Dto based projections to be used in a nested fashion when using the fluent save operations.

This does not solve - or attempt to solve - the issue that we don’t have any information what concrete projection class to be used when projection in all cases.

In the test `nestedProjectWithFluentOpsShouldWork` we could argue that the concrete value can be used to determine the type information. However, while that can be made to work with heterogeneous collections, it would bring a big performance penalty, getting new persistent entity instances and property accessors all the time.

Thus, this change now makes sure no exception is thrown when using such inherited projections, but does explicitly not bring support for deriving the projected properties from them accross an inheritance hierachy.

For more information, please read the comments in org.springframework.data.neo4j.integration.imperative.ProjectionIT#nestedProjectWithFluentOpsShouldWork and org.springframework.data.neo4j.integration.imperative.ProjectionIT#nestedProjectWithFluentOpsShouldWork2.

This closes #2621.