### PR TITLE
Support relationships in find by example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.1.0-SNAPSHOT</version>
+	<version>7.1.0-GH2696-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PropertyPathWrapper.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PropertyPathWrapper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2011-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.query;
+
+import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.ExposesRelationships;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.RelationshipPattern;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
+import org.springframework.data.neo4j.core.mapping.NodeDescription;
+import org.springframework.data.neo4j.core.mapping.RelationshipDescription;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+import org.springframework.lang.Nullable;
+
+class PropertyPathWrapper {
+	private static final String NAME_OF_RELATED_FILTER_ENTITY = "m";
+	private static final String NAME_OF_RELATED_FILTER_RELATIONSHIP = "r";
+
+	private final int index;
+	private final PersistentPropertyPath<?> persistentPropertyPath;
+	private final int lengthModification;
+
+	PropertyPathWrapper(int index, PersistentPropertyPath<?> persistentPropertyPath) {
+		this(index, persistentPropertyPath, true);
+	}
+
+	PropertyPathWrapper(int index, PersistentPropertyPath<?> persistentPropertyPath, boolean hasPropertyEnding) {
+		this.index = index;
+		this.persistentPropertyPath = persistentPropertyPath;
+		this.lengthModification = hasPropertyEnding ? 0 : 1;
+	}
+
+	public PersistentPropertyPath<?> getPersistentPropertyPath() {
+		return persistentPropertyPath;
+	}
+
+	String getNodeName() {
+		return NAME_OF_RELATED_FILTER_ENTITY + "_" + index;
+	}
+
+	String getRelationshipName() {
+		return NAME_OF_RELATED_FILTER_RELATIONSHIP + "_" + index;
+	}
+
+	ExposesRelationships<?> createRelationshipChain(ExposesRelationships<?> existingRelationshipChain) {
+
+		ExposesRelationships<?> cypherRelationship = existingRelationshipChain;
+		int cnt = 0;
+		for (PersistentProperty<?> persistentProperty : persistentPropertyPath) {
+
+			if (persistentProperty.isAssociation() && persistentProperty.isAnnotationPresent(TargetNode.class)) {
+				break;
+			}
+
+			RelationshipDescription relationshipDescription = (RelationshipDescription) persistentProperty.getAssociation();
+
+			if (relationshipDescription == null) {
+				break;
+			}
+
+			NodeDescription<?> relationshipPropertiesEntity = relationshipDescription.getRelationshipPropertiesEntity();
+			boolean isRelationshipPropertiesEntity = isRelationshipPropertiesEntity(relationshipPropertiesEntity);
+
+			NodeDescription<?> targetEntity = relationshipDescription.getTarget();
+			Node relatedNode = Cypher.node(targetEntity.getPrimaryLabel(), targetEntity.getAdditionalLabels());
+
+			// length - 1 = last index
+			// length - 2 = property on last node
+			// length - 3 = last node itself
+			// length + 1 if there is no property ending but the path only goes until it reaches the relationship field
+			boolean lastNode = cnt > (persistentPropertyPath.getLength() - 3 + lengthModification);
+			boolean lastRelationship = cnt + 1 > (persistentPropertyPath.getLength() - 4 + lengthModification);
+			cnt = cnt + 1;
+
+			// we don't yet if the condition will target a relationship property
+			// that's why here is lastNode or any relationship property
+			if (lastNode || (isRelationshipPropertiesEntity && lastRelationship)) {
+				relatedNode = relatedNode.named(getNodeName());
+			}
+
+			cypherRelationship = switch (relationshipDescription.getDirection()) {
+				case OUTGOING -> cypherRelationship
+						.relationshipTo(relatedNode, relationshipDescription.getType());
+				case INCOMING -> cypherRelationship
+						.relationshipFrom(relatedNode, relationshipDescription.getType());
+			};
+
+			if (lastNode || (isRelationshipPropertiesEntity && lastRelationship)) {
+				cypherRelationship = ((RelationshipPattern) cypherRelationship).named(getRelationshipName());
+			}
+		}
+
+		return cypherRelationship;
+	}
+
+	private boolean isRelationshipPropertiesEntity(@Nullable NodeDescription<?> relationshipPropertiesEntity) {
+		return relationshipPropertiesEntity != null
+				&& ((Neo4jPersistentEntity<?>) relationshipPropertiesEntity)
+				.getPersistentProperty(TargetNode.class) != null;
+	}
+
+	// if there is no direct property access, the list size is greater than 1 and as a consequence has to contain
+	// relationships.
+	boolean hasRelationships() {
+		return this.persistentPropertyPath.getLength() > 1;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -3038,7 +3038,8 @@ class RepositoryIT {
      					CREATE
      						(n:PersonWithRelationship{name:'Freddie'})-[:Has]->(h1:Hobby{name:'Music'}),
      						(n)-[:Has]->(p1:Pet{name: 'Jerry'}),
-     						(n)-[:Has]->(p2:Pet{name: 'Tom'})
+     						(n)-[:Has]->(p2:Pet{name: 'Tom'}),
+     						(p1)-[:Has]->(p3:Pet{name: 'Silvester'})-[:Has]->(h2:Hobby{name: 'Hunt Tweety'})
 						RETURN n, h1, p1, p2
 						""").single());
 
@@ -3054,6 +3055,17 @@ class RepositoryIT {
 
 			PersonWithRelationship probe = new PersonWithRelationship();
 			probe.setName("Freddie");
+			Hobby hobbies = new Hobby();
+			hobbies.setName("Music");
+			probe.setHobbies(hobbies);
+			Pet jerry = new Pet("Jerry");
+			// yes, now we bring multiple universes together
+			Pet silvester = new Pet("Silvester");
+			Hobby silvesterHobby = new Hobby();
+			silvesterHobby.setName("Hunt Tweety");
+			silvester.setHobbies(Set.of(silvesterHobby));
+			jerry.setFriends(List.of(silvester));
+			probe.setPets(List.of(jerry));
 			PersonWithRelationship loadedPerson = repository.findAll(Example.of(probe)).get(0);
 			assertThat(loadedPerson.getName()).isEqualTo("Freddie");
 			assertThat(loadedPerson.getId()).isEqualTo(personId);


### PR DESCRIPTION
Also use the `PropertyPathWrapper`, that was only used for `PartTree` / derived queries, now for the relationship pattern creation of the find-by-example mechanism.