### PR TITLE
Add scroll support for (Reactive)FluentQuery... classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.1.1-SNAPSHOT</version>
+	<version>7.1.1-GH-2726-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -624,7 +624,7 @@ public enum CypherGenerator {
 	}
 
 	public Collection<Expression> createReturnStatementForMatch(Neo4jPersistentEntity<?> nodeDescription) {
-		return createReturnStatementForMatch(nodeDescription, (pp -> true));
+		return createReturnStatementForMatch(nodeDescription, PropertyFilter.NO_FILTER);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
@@ -125,7 +125,7 @@ public final class NestedRelationshipContext {
 		Object value = propertyAccessor.getProperty(inverse);
 		boolean inverseValueIsEmpty = value == null;
 
-		RelationshipDescription relationship = neo4jPersistentEntity.getRelationshipsInHierarchy((pp -> true)).stream()
+		RelationshipDescription relationship = neo4jPersistentEntity.getRelationshipsInHierarchy((PropertyFilter.NO_FILTER)).stream()
 				.filter(r -> r.getFieldName().equals(inverse.getName())).findFirst().orElseThrow(() -> new MappingException(
 						neo4jPersistentEntity.getName() + " does not define a relationship for " + inverse.getFieldName()));
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyFilter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyFilter.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.springframework.data.neo4j.core.schema.Property;
@@ -38,6 +39,8 @@ public abstract class PropertyFilter {
 	public static PropertyFilter acceptAll() {
 		return new NonFilteringPropertyFilter();
 	}
+
+	public static final Predicate<RelaxedPropertyPath> NO_FILTER = (pp) -> true;
 
 	public abstract boolean contains(String dotPath, Class<?> typeToCheck);
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
@@ -39,6 +39,7 @@ import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.ScrollPosition.Direction;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.neo4j.core.convert.Neo4jConversionService;
 import org.springframework.data.neo4j.core.mapping.Constants;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentProperty;
@@ -98,7 +99,7 @@ public final class CypherAdapterUtils {
 		};
 	}
 
-	public static Condition combineKeysetIntoCondition(Neo4jPersistentEntity<?> entity, KeysetScrollPosition scrollPosition, Sort sort) {
+	public static Condition combineKeysetIntoCondition(Neo4jPersistentEntity<?> entity, KeysetScrollPosition scrollPosition, Sort sort, Neo4jConversionService conversionService) {
 
 		var incomingKeys = scrollPosition.getKeys();
 		var orderedKeys = new LinkedHashMap<String, Object>();
@@ -135,7 +136,7 @@ public final class CypherAdapterUtils {
 			if (v == null || (v instanceof Value value && value.isNull())) {
 				throw new IllegalStateException("Cannot resume from KeysetScrollPosition. Offending key: '%s' is 'null'".formatted(k));
 			}
-			var parameter = Cypher.anonParameter(v);
+			var parameter = Cypher.anonParameter(conversionService.convert(v, Value.class));
 
 			Expression expression;
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -239,7 +239,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryFragmentsAndPar
 
 				queryFragments.setLimit(limitModifier.apply(maxResults.intValue()));
 				if (!keysetScrollPosition.isInitial()) {
-					conditionFragment = conditionFragment.and(CypherAdapterUtils.combineKeysetIntoCondition(entity, keysetScrollPosition, theSort));
+					conditionFragment = conditionFragment.and(CypherAdapterUtils.combineKeysetIntoCondition(entity, keysetScrollPosition, theSort, mappingContext.getConversionService()));
 				}
 
 				queryFragments.setRequiresReverseSort(keysetScrollPosition.scrollsBackward());

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.LongSupplier;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
@@ -35,6 +36,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.neo4j.core.Neo4jOperations;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
+import org.springframework.data.neo4j.core.mapping.PropertyFilter;
 import org.springframework.data.neo4j.repository.support.CypherdslConditionExecutor;
 import org.springframework.data.neo4j.repository.support.Neo4jEntityInformation;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -82,10 +84,11 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 	@Override
 	public Collection<T> findAll(Condition condition, Sort sort) {
 
+		Predicate<PropertyFilter.RelaxedPropertyPath> noFilter = PropertyFilter.NO_FILTER;
 		return this.neo4jOperations.toExecutableQuery(
 				metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, sort
+				QueryFragmentsAndParameters.forConditionAndSort(
+						this.metaData, condition, sort, null, noFilter
 				)
 		).getResults();
 	}
@@ -95,7 +98,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(
+				QueryFragmentsAndParameters.forConditionAndSortItems(
 						this.metaData, condition, Arrays.asList(sortItems)
 				)
 		).getResults();
@@ -106,16 +109,17 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), Arrays.asList(sortItems))
+				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Conditions.noCondition(), Arrays.asList(sortItems))
 		).getResults();
 	}
 
 	@Override
 	public Page<T> findAll(Condition condition, Pageable pageable) {
 
+		Predicate<PropertyFilter.RelaxedPropertyPath> noFilter = PropertyFilter.NO_FILTER;
 		List<T> page = this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, pageable)
+				QueryFragmentsAndParameters.forConditionAndPageable(this.metaData, condition, pageable, noFilter)
 		).getResults();
 		LongSupplier totalCountSupplier = () -> this.count(condition);
 		return PageableExecutionUtils.getPage(page, pageable, totalCountSupplier);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
@@ -66,7 +66,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition)
 		).getSingleResult();
 	}
 
@@ -75,7 +75,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition)
 		).getResults();
 	}
 
@@ -85,7 +85,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 		return this.neo4jOperations.toExecutableQuery(
 				metaData.getType(),
 				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, null, CypherAdapterUtils.toSortItems(this.metaData, sort)
+						this.metaData, condition, sort
 				)
 		).getResults();
 	}
@@ -96,7 +96,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
 				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, null, Arrays.asList(sortItems)
+						this.metaData, condition, Arrays.asList(sortItems)
 				)
 		).getResults();
 	}
@@ -106,7 +106,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), null, Arrays.asList(sortItems))
+				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), Arrays.asList(sortItems))
 		).getResults();
 	}
 
@@ -115,7 +115,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		List<T> page = this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, pageable, null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition, pageable)
 		).getResults();
 		LongSupplier totalCountSupplier = () -> this.count(condition);
 		return PageableExecutionUtils.getPage(page, pageable, totalCountSupplier);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
@@ -16,7 +16,9 @@
 package org.springframework.data.neo4j.repository.query;
 
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.Condition;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.OffsetScrollPosition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -171,9 +173,13 @@ final class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<R> im
 				: (scrollPosition instanceof OffsetScrollPosition offsetScrollPosition) ? offsetScrollPosition.getOffset()
 				: 0;
 
+		Condition condition = scrollPosition instanceof KeysetScrollPosition keysetScrollPosition
+				? CypherAdapterUtils.combineKeysetIntoCondition(mappingContext.getPersistentEntity(example.getProbeType()), keysetScrollPosition, sort, mappingContext.getConversionService())
+				: null;
+
 		List<R> rawResult = findOperation.find(domainType)
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExampleWithScroll(mappingContext, example, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
+				.matching(QueryFragmentsAndParameters.forExampleWithScroll(mappingContext, example, condition, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
 				.all();
 
 		return scroll(scrollPosition, rawResult, entity);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
@@ -128,7 +128,7 @@ final class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<R> im
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
+				.matching(QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.oneValue();
 	}
@@ -145,7 +145,7 @@ final class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<R> im
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
+				.matching(QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.all();
 	}
@@ -155,7 +155,7 @@ final class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<R> im
 
 		List<R> page = findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, pageable,
+				.matching(QueryFragmentsAndParameters.forExampleWithPageable(mappingContext, example, pageable,
 						createIncludedFieldsPredicate()))
 				.all();
 
@@ -179,7 +179,7 @@ final class FetchableFluentQueryByExample<S, R> extends FluentQuerySupport<R> im
 
 		List<R> rawResult = findOperation.find(domainType)
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExampleWithScroll(mappingContext, example, condition, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
+				.matching(QueryFragmentsAndParameters.forExampleWithScrollPosition(mappingContext, example, condition, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
 				.all();
 
 		return scroll(scrollPosition, rawResult, entity);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
@@ -23,12 +23,14 @@ import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Cypher;
+import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Window;
 import org.springframework.data.neo4j.core.FluentFindOperation;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -60,19 +62,23 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 
 	private final Function<Predicate, Boolean> existsOperation;
 
+	private final Neo4jMappingContext mappingContext;
+
 	FetchableFluentQueryByPredicate(
 			Predicate predicate,
+			Neo4jMappingContext mappingContext,
 			Neo4jPersistentEntity<S> metaData,
 			Class<R> resultType,
 			FluentFindOperation findOperation,
 			Function<Predicate, Long> countOperation,
 			Function<Predicate, Boolean> existsOperation
 	) {
-		this(predicate, metaData, resultType, findOperation, countOperation, existsOperation, Sort.unsorted(), null, null);
+		this(predicate, mappingContext, metaData, resultType, findOperation, countOperation, existsOperation, Sort.unsorted(), null, null);
 	}
 
 	FetchableFluentQueryByPredicate(
 			Predicate predicate,
+			Neo4jMappingContext mappingContext,
 			Neo4jPersistentEntity<S> metaData,
 			Class<R> resultType,
 			FluentFindOperation findOperation,
@@ -84,6 +90,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 	) {
 		super(resultType, sort, limit, properties);
 		this.predicate = predicate;
+		this.mappingContext = mappingContext;
 		this.metaData = metaData;
 		this.findOperation = findOperation;
 		this.countOperation = countOperation;
@@ -94,14 +101,14 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 	@SuppressWarnings("HiddenField")
 	public FetchableFluentQuery<R> sortBy(Sort sort) {
 
-		return new FetchableFluentQueryByPredicate<>(this.predicate, this.metaData, this.resultType, this.findOperation,
+		return new FetchableFluentQueryByPredicate<>(this.predicate, this.mappingContext, this.metaData, this.resultType, this.findOperation,
 				this.countOperation, this.existsOperation, this.sort.and(sort), this.limit, this.properties);
 	}
 
 	@Override
 	@SuppressWarnings("HiddenField")
 	public FetchableFluentQuery<R> limit(int limit) {
-		return new FetchableFluentQueryByPredicate<>(this.predicate, this.metaData, this.resultType, this.findOperation,
+		return new FetchableFluentQueryByPredicate<>(this.predicate, this.mappingContext, this.metaData, this.resultType, this.findOperation,
 				this.countOperation, this.existsOperation, this.sort, limit, this.properties);
 	}
 
@@ -109,7 +116,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 	@SuppressWarnings("HiddenField")
 	public <NR> FetchableFluentQuery<NR> as(Class<NR> resultType) {
 
-		return new FetchableFluentQueryByPredicate<>(this.predicate, this.metaData, resultType, this.findOperation,
+		return new FetchableFluentQueryByPredicate<>(this.predicate, this.mappingContext, this.metaData, resultType, this.findOperation,
 				this.countOperation, this.existsOperation);
 	}
 
@@ -117,7 +124,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 	@SuppressWarnings("HiddenField")
 	public FetchableFluentQuery<R> project(Collection<String> properties) {
 
-		return new FetchableFluentQueryByPredicate<>(this.predicate, this.metaData, this.resultType, this.findOperation,
+		return new FetchableFluentQueryByPredicate<>(this.predicate, this.mappingContext, this.metaData, this.resultType, this.findOperation,
 				this.countOperation, this.existsOperation, this.sort, this.limit, mergeProperties(properties));
 	}
 
@@ -176,10 +183,13 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 	public Window<R> scroll(ScrollPosition scrollPosition) {
 
 		QueryFragmentsAndParameters queryFragmentsAndParameters = QueryFragmentsAndParameters.forConditionWithScrollPosition(metaData,
-					Cypher.adapt(predicate).asCondition(),
-					scrollPosition, sort,
-					limit == null ? 1 : limit + 1,
-					createIncludedFieldsPredicate());
+				Cypher.adapt(predicate).asCondition(),
+				(scrollPosition instanceof KeysetScrollPosition keysetScrollPosition
+						? CypherAdapterUtils.combineKeysetIntoCondition(metaData, keysetScrollPosition, sort, mappingContext.getConversionService())
+						: null),
+				scrollPosition, sort,
+				limit == null ? 1 : limit + 1,
+				createIncludedFieldsPredicate());
 
 		List<R> rawResult = findOperation.find(metaData.getType())
 				.as(resultType)

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
@@ -134,7 +134,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 		return findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndSort(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								sort,
 								limit,
@@ -155,7 +155,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 		return findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndSort(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								sort,
 								limit,
@@ -169,7 +169,7 @@ final class FetchableFluentQueryByPredicate<S, R> extends FluentQuerySupport<R> 
 		List<R> page = findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndPageable(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								pageable,
 								createIncludedFieldsPredicate()))

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
@@ -71,7 +71,7 @@ abstract class FluentQuerySupport<R> {
 	final Predicate<PropertyFilter.RelaxedPropertyPath> createIncludedFieldsPredicate() {
 
 		if (this.properties == null || this.properties.isEmpty()) {
-			return path -> true;
+			return PropertyFilter.NO_FILTER;
 		}
 		return path -> this.properties.contains(path.toDotPath());
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
@@ -18,10 +18,19 @@ package org.springframework.data.neo4j.repository.query;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Set;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
+import org.springframework.data.domain.KeysetScrollPosition;
+import org.springframework.data.domain.OffsetScrollPosition;
+import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Window;
+import org.springframework.data.neo4j.core.mapping.Constants;
+import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.neo4j.core.mapping.PropertyFilter;
 import org.springframework.lang.Nullable;
 
@@ -38,16 +47,20 @@ abstract class FluentQuerySupport<R> {
 
 	protected final Sort sort;
 
+	protected final Integer limit;
+
 	@Nullable
 	protected final Set<String> properties;
 
 	FluentQuerySupport(
 			Class<R> resultType,
 			Sort sort,
+			@Nullable Integer limit,
 			@Nullable Collection<String> properties
 	) {
 		this.resultType = resultType;
 		this.sort = sort;
+		this.limit = limit;
 		if (properties != null) {
 			this.properties = new HashSet<>(properties);
 		} else {
@@ -57,7 +70,7 @@ abstract class FluentQuerySupport<R> {
 
 	final Predicate<PropertyFilter.RelaxedPropertyPath> createIncludedFieldsPredicate() {
 
-		if (this.properties == null) {
+		if (this.properties == null || this.properties.isEmpty()) {
 			return path -> true;
 		}
 		return path -> this.properties.contains(path.toDotPath());
@@ -70,5 +83,50 @@ abstract class FluentQuerySupport<R> {
 		}
 		newProperties.addAll(additionalProperties);
 		return Collections.unmodifiableCollection(newProperties);
+	}
+
+	final Window<R> scroll(ScrollPosition scrollPosition, List<R> rawResult, Neo4jPersistentEntity<?> entity) {
+
+		var skip = scrollPosition.isInitial()
+				? 0
+				: (scrollPosition instanceof OffsetScrollPosition offsetScrollPosition) ? offsetScrollPosition.getOffset()
+				: 0;
+
+		var scrollDirection = scrollPosition instanceof KeysetScrollPosition keysetScrollPosition ? keysetScrollPosition.getDirection() : ScrollPosition.Direction.FORWARD;
+		if (scrollDirection == ScrollPosition.Direction.BACKWARD) {
+			Collections.reverse(rawResult);
+		}
+
+		IntFunction<? extends ScrollPosition> ding = null;
+
+		if (scrollPosition instanceof OffsetScrollPosition) {
+			ding = OffsetScrollPosition.positionFunction(skip);
+		} else {
+			ding = v -> {
+				var accessor = entity.getPropertyAccessor(rawResult.get(v));
+				var keys = new LinkedHashMap<String, Object>();
+				sort.forEach(o -> {
+					// Storing the graph property name here
+					var persistentProperty = entity.getRequiredPersistentProperty(o.getProperty());
+					keys.put(persistentProperty.getPropertyName(), accessor.getProperty(persistentProperty));
+				});
+				keys.put(Constants.NAME_OF_ADDITIONAL_SORT, accessor.getProperty(entity.getRequiredIdProperty()));
+				return ScrollPosition.forward(keys);
+			};
+		}
+		return Window.from(getSubList(rawResult, limit, scrollDirection), ding, hasMoreElements(rawResult, limit));
+	}
+
+	private static boolean hasMoreElements(List<?> result, @Nullable Integer limit) {
+		return !result.isEmpty() && result.size() > (limit != null ? limit : 0);
+	}
+
+	private static <T> List<T> getSubList(List<T> result, @Nullable Integer limit, ScrollPosition.Direction scrollDirection) {
+
+		if (limit != null && limit > 0 && result.size() > limit) {
+			return scrollDirection == ScrollPosition.Direction.FORWARD ? result.subList(0, limit) : result.subList(1, limit + 1);
+		}
+
+		return result;
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
-import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -298,9 +298,11 @@ abstract class Neo4jQuerySupport {
 				orderBy.getSort().forEach(o -> {
 					// Storing the graph property name here
 					var persistentProperty = neo4jPersistentEntity.getRequiredPersistentProperty(o.getProperty());
-					keys.put(persistentProperty.getPropertyName(), conversionService.convert(accessor.getProperty(persistentProperty), Value.class));
+					keys.put(persistentProperty.getPropertyName(), accessor.getProperty(persistentProperty));
+					// keys.put(persistentProperty.getPropertyName(), conversionService.convert(accessor.getProperty(persistentProperty), Value.class));
 				});
-				keys.put(Constants.NAME_OF_ADDITIONAL_SORT, conversionService.convert(accessor.getProperty(neo4jPersistentEntity.getRequiredIdProperty()), Value.class));
+				keys.put(Constants.NAME_OF_ADDITIONAL_SORT, accessor.getProperty(neo4jPersistentEntity.getRequiredIdProperty()));
+				// keys.put(Constants.NAME_OF_ADDITIONAL_SORT, conversionService.convert(accessor.getProperty(neo4jPersistentEntity.getRequiredIdProperty()), Value.class));
 				return ScrollPosition.forward(keys);
 			}
 		}, hasMoreElements(rawResult, limit));

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -292,7 +292,7 @@ abstract class Neo4jQuerySupport {
 		return Window.from(getSubList(rawResult, limit, scrollDirection), v -> {
 			if (scrollPosition instanceof OffsetScrollPosition offsetScrollPosition) {
 				return offsetScrollPosition.advanceBy(v + limit);
-			} else  {
+			} else {
 				var accessor = neo4jPersistentEntity.getPropertyAccessor(rawResult.get(v));
 				var keys = new LinkedHashMap<String, Object>();
 				orderBy.getSort().forEach(o -> {

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
@@ -192,15 +192,15 @@ public final class QueryFragmentsAndParameters {
 	}
 
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, sort, limit, null, null, includeField);
+		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, null, sort, limit, null, null, includeField);
 	}
 
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable Long skip, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, sort, limit, skip, null, includeField);
+		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, null, sort, limit, skip, null, includeField);
 	}
 
-	static QueryFragmentsAndParameters forExampleWithScroll(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable Long skip, ScrollPosition scrollPosition, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, sort, limit, skip, scrollPosition, includeField);
+	static QueryFragmentsAndParameters forExampleWithScroll(Neo4jMappingContext mappingContext, Example<?> example, @Nullable Condition keysetScrollPositionCondition, Sort sort, @Nullable Integer limit, @Nullable Long skip, ScrollPosition scrollPosition, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
+		return QueryFragmentsAndParameters.forExample(mappingContext, example, keysetScrollPositionCondition, null, sort, limit, skip, scrollPosition, includeField);
 	}
 
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Pageable pageable) {
@@ -208,7 +208,7 @@ public final class QueryFragmentsAndParameters {
 	}
 
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Pageable pageable, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, pageable, null, null, null, null, includeField);
+		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, pageable, null, null, null, null, includeField);
 	}
 
 	/**
@@ -257,6 +257,7 @@ public final class QueryFragmentsAndParameters {
 
 	static QueryFragmentsAndParameters forConditionWithScrollPosition(Neo4jPersistentEntity<?> entityMetaData,
 																	  Condition condition,
+																	  @Nullable Condition keysetCondition,
 																	  ScrollPosition scrollPosition,
 																	  @Nullable Sort sort,
 																	  @Nullable Integer limit,
@@ -274,7 +275,7 @@ public final class QueryFragmentsAndParameters {
 
 		if (scrollPosition instanceof KeysetScrollPosition keysetScrollPosition) {
 			if (!scrollPosition.isInitial()) {
-				condition = condition.and(CypherAdapterUtils.combineKeysetIntoCondition(entityMetaData, keysetScrollPosition, sort));
+				condition = condition.and(keysetCondition);
 			}
 			QueryFragmentsAndParameters queryFragmentsAndParameters = getQueryFragmentsAndParameters(entityMetaData, null,
 					sort, limit, skip, Collections.emptyMap(), condition, includeField, null);
@@ -312,6 +313,7 @@ public final class QueryFragmentsAndParameters {
 	}
 
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example,
+												  @Nullable Condition keysetScrollPositionCondition,
 												  @Nullable Pageable pageable, @Nullable Sort sort, @Nullable Integer limit,
 												  @Nullable Long skip, @Nullable ScrollPosition scrollPosition,
 												  java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
@@ -324,7 +326,7 @@ public final class QueryFragmentsAndParameters {
 		if (scrollPosition instanceof KeysetScrollPosition keysetScrollPosition) {
 
 			if (!keysetScrollPosition.isInitial()) {
-				condition = condition.and(CypherAdapterUtils.combineKeysetIntoCondition(persistentEntity, keysetScrollPosition, sort));
+				condition = condition.and(keysetScrollPositionCondition);
 			}
 			QueryFragmentsAndParameters queryFragmentsAndParameters = getQueryFragmentsAndParameters(persistentEntity, pageable,
 					sort, limit, skip, parameters, condition, includeField, propertyPathWrappers);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
@@ -175,40 +175,58 @@ public final class QueryFragmentsAndParameters {
 		return new QueryFragmentsAndParameters(entityMetaData, queryFragments, parameters, null);
 	}
 
+	public static QueryFragmentsAndParameters forPageableAndSort(Neo4jPersistentEntity<?> neo4jPersistentEntity,
+																 @Nullable Pageable pageable, @Nullable Sort sort) {
+
+		return getQueryFragmentsAndParameters(neo4jPersistentEntity, pageable, sort, null, null, null, Collections.emptyMap(), null, null, null);
+	}
+
 	/*
 	 * Following methods are used by the Simple(Reactive)QueryByExampleExecutor
 	 */
 	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example,
-				(java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath>) null);
+		return forExample(mappingContext, example, null, null, null, null, null, null, null);
 	}
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, null, null, includeField);
+	static QueryFragmentsAndParameters forExampleWithPageable(Neo4jMappingContext mappingContext, Example<?> example, Pageable pageable, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
+		return forExample(mappingContext, example, null, pageable, null, null, null, null, includeField);
 	}
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Sort sort) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, sort, null, null, null);
+	static QueryFragmentsAndParameters forExampleWithSort(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
+		return forExample(mappingContext, example, null, null, sort, limit, null, null, includeField);
 	}
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, null, sort, limit, null, null, includeField);
+	static QueryFragmentsAndParameters forExampleWithScrollPosition(Neo4jMappingContext mappingContext, Example<?> example, @Nullable Condition keysetScrollPositionCondition, Sort sort, @Nullable Integer limit, @Nullable Long skip, ScrollPosition scrollPosition, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
+		return forExample(mappingContext, example, keysetScrollPositionCondition, null, sort, limit, skip, scrollPosition, includeField);
 	}
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Sort sort, @Nullable Integer limit, @Nullable Long skip, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, null, sort, limit, skip, null, includeField);
-	}
+	private static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example,
+														  @Nullable Condition keysetScrollPositionCondition,
+														  @Nullable Pageable pageable,
+														  @Nullable Sort sort,
+														  @Nullable Integer limit,
+														  @Nullable Long skip,
+														  @Nullable ScrollPosition scrollPosition,
+														  @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
 
-	static QueryFragmentsAndParameters forExampleWithScroll(Neo4jMappingContext mappingContext, Example<?> example, @Nullable Condition keysetScrollPositionCondition, Sort sort, @Nullable Integer limit, @Nullable Long skip, ScrollPosition scrollPosition, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, keysetScrollPositionCondition, null, sort, limit, skip, scrollPosition, includeField);
-	}
+		Predicate predicate = Predicate.create(mappingContext, example);
+		Map<String, Object> parameters = predicate.getParameters();
+		Set<PropertyPathWrapper> propertyPathWrappers = predicate.getPropertyPathWrappers();
+		Condition condition = predicate.getCondition();
+		Neo4jPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(example.getProbeType());
+		if (scrollPosition instanceof KeysetScrollPosition keysetScrollPosition) {
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Pageable pageable) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, pageable, null);
-	}
+			if (!keysetScrollPosition.isInitial()) {
+				condition = condition.and(keysetScrollPositionCondition);
+			}
+			QueryFragmentsAndParameters queryFragmentsAndParameters = getQueryFragmentsAndParameters(persistentEntity, pageable,
+					sort, null, limit, skip, parameters, condition, includeField, propertyPathWrappers);
+			queryFragmentsAndParameters.getQueryFragments().setRequiresReverseSort(keysetScrollPosition.scrollsBackward());
+			return queryFragmentsAndParameters;
+		}
 
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example, Pageable pageable, @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return QueryFragmentsAndParameters.forExample(mappingContext, example, null, pageable, null, null, null, null, includeField);
+		return getQueryFragmentsAndParameters(persistentEntity, pageable,
+				sort, null, limit, skip, parameters, condition, includeField, propertyPathWrappers);
 	}
 
 	/**
@@ -225,33 +243,20 @@ public final class QueryFragmentsAndParameters {
 		return forCondition(entityMetaData, condition, null, null, null, null, null, null);
 	}
 
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData,
-													Condition condition,
-													Pageable pageable) {
-
-		return forCondition(entityMetaData, condition, pageable, null, null, null, null, null);
-	}
-
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData,
-													Condition condition, Pageable pageable,
-													java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
+	static QueryFragmentsAndParameters forConditionAndPageable(Neo4jPersistentEntity<?> entityMetaData,
+															   Condition condition, Pageable pageable,
+															   java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
 
 		return forCondition(entityMetaData, condition, pageable, null, null, null, null, includeField);
 	}
 
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData, Condition condition, Sort sort) {
-		return forCondition(entityMetaData, condition, null, sort, null, null, null, null);
-	}
+	static QueryFragmentsAndParameters forConditionAndSort(Neo4jPersistentEntity<?> entityMetaData, Condition condition, Sort sort, @Nullable Integer limit,
+														   @Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
 
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData, Condition condition, Sort sort, java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-		return forCondition(entityMetaData, condition, null, sort, null, null, null, includeField);
-	}
-
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData, Condition condition, Sort sort, Integer limit, java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
 		return forCondition(entityMetaData, condition, null, sort, null, limit, null, includeField);
 	}
 
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData, Condition condition, @Nullable Collection<SortItem> sortItems) {
+	static QueryFragmentsAndParameters forConditionAndSortItems(Neo4jPersistentEntity<?> entityMetaData, Condition condition, @Nullable Collection<SortItem> sortItems) {
 		return forCondition(entityMetaData, condition, null, null, sortItems, null, null, null);
 	}
 
@@ -278,7 +283,7 @@ public final class QueryFragmentsAndParameters {
 				condition = condition.and(keysetCondition);
 			}
 			QueryFragmentsAndParameters queryFragmentsAndParameters = getQueryFragmentsAndParameters(entityMetaData, null,
-					sort, limit, skip, Collections.emptyMap(), condition, includeField, null);
+					sort, null, limit, skip, Collections.emptyMap(), condition, includeField, null);
 			queryFragmentsAndParameters.getQueryFragments().setRequiresReverseSort(keysetScrollPosition.scrollsBackward());
 			return queryFragmentsAndParameters;
 		}
@@ -287,7 +292,8 @@ public final class QueryFragmentsAndParameters {
 
 	}
 
-	static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData,
+	// Parameter re-ordering helper
+	private static QueryFragmentsAndParameters forCondition(Neo4jPersistentEntity<?> entityMetaData,
 													Condition condition,
 													@Nullable Pageable pageable,
 													@Nullable Sort sort,
@@ -299,59 +305,6 @@ public final class QueryFragmentsAndParameters {
 
 
 		return getQueryFragmentsAndParameters(entityMetaData, pageable, sort, sortItems, limit, skip, Collections.emptyMap(), condition, includeField, null);
-	}
-
-	private static void adaptPageable(
-			Neo4jPersistentEntity<?> entityMetaData,
-			Pageable pageable,
-			QueryFragments queryFragments
-	) {
-		Sort pageableSort = pageable.getSort();
-		queryFragments.setSkip(pageable.getOffset());
-		queryFragments.setLimit(pageable.getPageSize());
-		queryFragments.setOrderBy(CypherAdapterUtils.toSortItems(entityMetaData, pageableSort));
-	}
-
-	static QueryFragmentsAndParameters forExample(Neo4jMappingContext mappingContext, Example<?> example,
-												  @Nullable Condition keysetScrollPositionCondition,
-												  @Nullable Pageable pageable, @Nullable Sort sort, @Nullable Integer limit,
-												  @Nullable Long skip, @Nullable ScrollPosition scrollPosition,
-												  java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField) {
-
-		Predicate predicate = Predicate.create(mappingContext, example);
-		Map<String, Object> parameters = predicate.getParameters();
-		Set<PropertyPathWrapper> propertyPathWrappers = predicate.getPropertyPathWrappers();
-		Condition condition = predicate.getCondition();
-		Neo4jPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(example.getProbeType());
-		if (scrollPosition instanceof KeysetScrollPosition keysetScrollPosition) {
-
-			if (!keysetScrollPosition.isInitial()) {
-				condition = condition.and(keysetScrollPositionCondition);
-			}
-			QueryFragmentsAndParameters queryFragmentsAndParameters = getQueryFragmentsAndParameters(persistentEntity, pageable,
-					sort, limit, skip, parameters, condition, includeField, propertyPathWrappers);
-			queryFragmentsAndParameters.getQueryFragments().setRequiresReverseSort(keysetScrollPosition.scrollsBackward());
-			return queryFragmentsAndParameters;
-		}
-
-		return getQueryFragmentsAndParameters(persistentEntity, pageable,
-				sort, limit, skip, parameters, condition, includeField, propertyPathWrappers);
-	}
-
-	public static QueryFragmentsAndParameters forPageableAndSort(Neo4jPersistentEntity<?> neo4jPersistentEntity,
-																 @Nullable Pageable pageable, @Nullable Sort sort) {
-
-		return getQueryFragmentsAndParameters(neo4jPersistentEntity, pageable, sort, null, null, Collections.emptyMap(), null, null, null);
-	}
-
-	private static QueryFragmentsAndParameters getQueryFragmentsAndParameters(
-			Neo4jPersistentEntity<?> entityMetaData, @Nullable Pageable pageable, @Nullable Sort sort,
-			@Nullable Integer limit, @Nullable Long skip,
-			@Nullable Map<String, Object> parameters, @Nullable Condition condition,
-			@Nullable java.util.function.Predicate<PropertyFilter.RelaxedPropertyPath> includeField,
-			@Nullable Set<PropertyPathWrapper> propertyPathWrappers) {
-
-		return getQueryFragmentsAndParameters(entityMetaData, pageable, sort, null, limit, skip, parameters, condition, includeField, propertyPathWrappers);
 	}
 
 	private static QueryFragmentsAndParameters getQueryFragmentsAndParameters(
@@ -406,6 +359,17 @@ public final class QueryFragmentsAndParameters {
 		}
 
 		return new QueryFragmentsAndParameters(entityMetaData, queryFragments, parameters, sort);
+	}
+
+	private static void adaptPageable(
+			Neo4jPersistentEntity<?> entityMetaData,
+			Pageable pageable,
+			QueryFragments queryFragments
+	) {
+		Sort pageableSort = pageable.getSort();
+		queryFragments.setSkip(pageable.getOffset());
+		queryFragments.setLimit(pageable.getPageSize());
+		queryFragments.setOrderBy(CypherAdapterUtils.toSortItems(entityMetaData, pageableSort));
 	}
 
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QuerydslNeo4jPredicateExecutor.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.neo4j.core.FluentFindOperation;
 import org.springframework.data.neo4j.core.Neo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.neo4j.repository.support.CypherdslConditionExecutor;
 import org.springframework.data.neo4j.repository.support.Neo4jEntityInformation;
@@ -65,9 +66,15 @@ public final class QuerydslNeo4jPredicateExecutor<T> implements QuerydslPredicat
 	 */
 	private final Neo4jPersistentEntity<T> metaData;
 
-	public QuerydslNeo4jPredicateExecutor(Neo4jEntityInformation<T, Object> entityInformation,
-			Neo4jOperations neo4jOperations) {
+	/**
+	 * Mapping context
+	 */
+	private final Neo4jMappingContext mappingContext;
 
+	public QuerydslNeo4jPredicateExecutor(Neo4jMappingContext mappingContext, Neo4jEntityInformation<T, Object> entityInformation,
+										  Neo4jOperations neo4jOperations) {
+
+		this.mappingContext = mappingContext;
 		this.delegate = new CypherdslConditionExecutorImpl<>(entityInformation, neo4jOperations);
 		this.neo4jOperations = neo4jOperations;
 		this.metaData = entityInformation.getEntityMetaData();
@@ -134,7 +141,7 @@ public final class QuerydslNeo4jPredicateExecutor<T> implements QuerydslPredicat
 		if (this.neo4jOperations instanceof FluentFindOperation ops) {
 			@SuppressWarnings("unchecked") // defaultResultType will be a supertype of S and at this stage, the same.
 			FetchableFluentQuery<S> fluentQuery =
-					(FetchableFluentQuery<S>) new FetchableFluentQueryByPredicate<>(predicate, metaData, metaData.getType(),
+					(FetchableFluentQuery<S>) new FetchableFluentQueryByPredicate<>(predicate, mappingContext, metaData, metaData.getType(),
 							ops, this::count, this::exists);
 			return queryFunction.apply(fluentQuery);
 		}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -63,7 +63,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition)
 		).flatMap(ReactiveNeo4jOperations.ExecutableQuery::getSingleResult);
 	}
 
@@ -72,7 +72,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null, null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
 
@@ -82,7 +82,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 		return this.neo4jOperations.toExecutableQuery(
 				metaData.getType(),
 				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, null, CypherAdapterUtils.toSortItems(this.metaData, sort)
+						this.metaData, condition, sort
 				)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
@@ -93,7 +93,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
 				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, null, Arrays.asList(sortItems)
+						this.metaData, condition, Arrays.asList(sortItems)
 				)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
@@ -103,7 +103,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(), null,
+				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(),
 						Arrays.asList(sortItems))
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.repository.query;
 import static org.neo4j.cypherdsl.core.Cypher.asterisk;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
@@ -29,6 +30,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
+import org.springframework.data.neo4j.core.mapping.PropertyFilter;
 import org.springframework.data.neo4j.repository.support.ReactiveCypherdslConditionExecutor;
 import org.springframework.data.neo4j.repository.support.Neo4jEntityInformation;
 
@@ -79,10 +81,11 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 	@Override
 	public Flux<T> findAll(Condition condition, Sort sort) {
 
+		Predicate<PropertyFilter.RelaxedPropertyPath> noFilter = PropertyFilter.NO_FILTER;
 		return this.neo4jOperations.toExecutableQuery(
 				metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(
-						this.metaData, condition, sort
+				QueryFragmentsAndParameters.forConditionAndSort(
+						this.metaData, condition, sort, null, noFilter
 				)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
@@ -92,7 +95,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(
+				QueryFragmentsAndParameters.forConditionAndSortItems(
 						this.metaData, condition, Arrays.asList(sortItems)
 				)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
@@ -103,7 +106,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Conditions.noCondition(),
+				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Conditions.noCondition(),
 						Arrays.asList(sortItems))
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
@@ -15,6 +15,10 @@
  */
 package org.springframework.data.neo4j.repository.query;
 
+import org.springframework.data.domain.OffsetScrollPosition;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
+import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -64,7 +68,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 			Function<Example<S>, Mono<Boolean>> existsOperation
 	) {
 		this(example, resultType, mappingContext, findOperation, countOperation, existsOperation, Sort.unsorted(),
-				null);
+				null, null);
 	}
 
 	ReactiveFluentQueryByExample(
@@ -75,9 +79,10 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 			Function<Example<S>, Mono<Long>> countOperation,
 			Function<Example<S>, Mono<Boolean>> existsOperation,
 			Sort sort,
+			@Nullable Integer limit,
 			@Nullable Collection<String> properties
 	) {
-		super(resultType, sort, properties);
+		super(resultType, sort, limit, properties);
 		this.mappingContext = mappingContext;
 		this.example = example;
 		this.findOperation = findOperation;
@@ -90,7 +95,15 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 	public ReactiveFluentQuery<R> sortBy(Sort sort) {
 
 		return new ReactiveFluentQueryByExample<>(this.example, this.resultType, this.mappingContext, this.findOperation,
-				this.countOperation, this.existsOperation, this.sort.and(sort), this.properties);
+				this.countOperation, this.existsOperation, this.sort.and(sort), this.limit, this.properties);
+	}
+
+	@Override
+	@SuppressWarnings("HiddenField")
+	public ReactiveFluentQuery<R> limit(int limit) {
+
+		return new ReactiveFluentQueryByExample<>(this.example, this.resultType, this.mappingContext, this.findOperation,
+				this.countOperation, this.existsOperation, this.sort, limit, this.properties);
 	}
 
 	@Override
@@ -106,7 +119,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 	public ReactiveFluentQuery<R> project(Collection<String> properties) {
 
 		return new ReactiveFluentQueryByExample<>(this.example, this.resultType, this.mappingContext, this.findOperation,
-				this.countOperation, this.existsOperation, sort, mergeProperties(properties));
+				this.countOperation, this.existsOperation, this.sort, this.limit, mergeProperties(properties));
 	}
 
 	@Override
@@ -114,7 +127,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort,
+				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.one();
 	}
@@ -130,7 +143,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort,
+				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.all();
 	}
@@ -147,6 +160,24 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 			Page<R> page = PageableExecutionUtils.getPage(tuple.getT1(), pageable, () -> tuple.getT2());
 			return page;
 		});
+	}
+
+	@Override
+	public Mono<Window<R>> scroll(ScrollPosition scrollPosition) {
+		Class<S> domainType = this.example.getProbeType();
+		Neo4jPersistentEntity<?> entity = mappingContext.getPersistentEntity(domainType);
+
+		var skip = scrollPosition.isInitial()
+				? 0
+				: (scrollPosition instanceof OffsetScrollPosition offsetScrollPosition) ? offsetScrollPosition.getOffset()
+				: 0;
+
+		return findOperation.find(domainType)
+				.as(resultType)
+				.matching(QueryFragmentsAndParameters.forExampleWithScroll(mappingContext, example, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
+				.all()
+				.collectList()
+				.map(rawResult -> scroll(scrollPosition, rawResult, entity));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
@@ -129,7 +129,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
+				.matching(QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.one();
 	}
@@ -145,7 +145,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		return findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, sort, limit,
+				.matching(QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, limit,
 						createIncludedFieldsPredicate()))
 				.all();
 	}
@@ -155,7 +155,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		Flux<R> results = findOperation.find(example.getProbeType())
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExample(mappingContext, example, pageable,
+				.matching(QueryFragmentsAndParameters.forExampleWithPageable(mappingContext, example, pageable,
 						createIncludedFieldsPredicate()))
 				.all();
 		return results.collectList().zipWith(countOperation.apply(example)).map(tuple -> {
@@ -180,7 +180,7 @@ final class ReactiveFluentQueryByExample<S, R> extends FluentQuerySupport<R> imp
 
 		return findOperation.find(domainType)
 				.as(resultType)
-				.matching(QueryFragmentsAndParameters.forExampleWithScroll(mappingContext, example, condition, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
+				.matching(QueryFragmentsAndParameters.forExampleWithScrollPosition(mappingContext, example, condition, sort, limit == null ? 1 : limit + 1, skip, scrollPosition, createIncludedFieldsPredicate()))
 				.all()
 				.collectList()
 				.map(rawResult -> scroll(scrollPosition, rawResult, entity));

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByPredicate.java
@@ -133,9 +133,10 @@ import com.querydsl.core.types.Predicate;
 		return findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndSort(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								sort,
+								limit,
 								createIncludedFieldsPredicate()))
 				.one();
 	}
@@ -152,9 +153,10 @@ import com.querydsl.core.types.Predicate;
 		return findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndSort(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								sort,
+								limit,
 								createIncludedFieldsPredicate()))
 				.all();
 	}
@@ -165,7 +167,7 @@ import com.querydsl.core.types.Predicate;
 		Flux<R> results = findOperation.find(metaData.getType())
 				.as(resultType)
 				.matching(
-						QueryFragmentsAndParameters.forCondition(metaData,
+						QueryFragmentsAndParameters.forConditionAndPageable(metaData,
 								Cypher.adapt(predicate).asCondition(),
 								pageable,
 								createIncludedFieldsPredicate()))

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.repository.query;
 
 import static org.neo4j.cypherdsl.core.Cypher.asterisk;
 
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -63,9 +64,15 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 
 	private final Neo4jPersistentEntity<T> metaData;
 
-	public ReactiveQuerydslNeo4jPredicateExecutor(Neo4jEntityInformation<T, Object> entityInformation,
+	/**
+	 * Mapping context
+	 */
+	private final Neo4jMappingContext mappingContext;
+
+	public ReactiveQuerydslNeo4jPredicateExecutor(Neo4jMappingContext mappingContext, Neo4jEntityInformation<T, Object> entityInformation,
 			ReactiveNeo4jOperations neo4jOperations) {
 
+		this.mappingContext = mappingContext;
 		this.entityInformation = entityInformation;
 		this.neo4jOperations = neo4jOperations;
 		this.metaData = this.entityInformation.getEntityMetaData();
@@ -131,7 +138,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 
 		if (this.neo4jOperations instanceof ReactiveFluentFindOperation ops) {
 			@SuppressWarnings("unchecked") // defaultResultType will be a supertype of S and at this stage, the same.
-			ReactiveFluentQuery<S> fluentQuery = (ReactiveFluentQuery<S>) new ReactiveFluentQueryByPredicate<>(predicate, metaData, metaData.getType(),
+			ReactiveFluentQuery<S> fluentQuery = (ReactiveFluentQuery<S>) new ReactiveFluentQueryByPredicate<>(predicate, mappingContext, metaData, metaData.getType(),
 							ops, this::count, this::exists);
 			return queryFunction.apply(fluentQuery);
 		}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
@@ -76,8 +76,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, Cypher.adapt(predicate).asCondition(), null,
-						null)
+				QueryFragmentsAndParameters.forCondition(this.metaData, Cypher.adapt(predicate).asCondition())
 		).flatMap(ReactiveNeo4jOperations.ExecutableQuery::getSingleResult);
 	}
 
@@ -108,7 +107,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 	private Flux<T> doFindAll(Condition condition, Collection<SortItem> sortItems) {
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition, null,
+				QueryFragmentsAndParameters.forCondition(this.metaData, condition,
 						sortItems)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
@@ -114,7 +114,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 	private Flux<T> doFindAll(Condition condition, Collection<SortItem> sortItems) {
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forCondition(this.metaData, condition,
+				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, condition,
 						sortItems)
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
@@ -26,6 +26,7 @@ import org.springframework.data.neo4j.core.FluentFindOperation;
 import org.springframework.data.neo4j.core.Neo4jOperations;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.mapping.PropertyFilter;
 import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -76,14 +77,14 @@ public final class SimpleQueryByExampleExecutor<T> implements QueryByExampleExec
 	@Override
 	public <S extends T> List<S> findAll(Example<S> example, Sort sort) {
 		return this.neo4jOperations.toExecutableQuery(example.getProbeType(),
-				QueryFragmentsAndParameters.forExample(mappingContext, example, sort)).getResults();
+				QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, null, PropertyFilter.NO_FILTER)).getResults();
 	}
 
 	@Override
 	public <S extends T> Page<S> findAll(Example<S> example, Pageable pageable) {
 
 		List<S> page = this.neo4jOperations.toExecutableQuery(example.getProbeType(),
-				QueryFragmentsAndParameters.forExample(mappingContext, example, pageable)).getResults();
+				QueryFragmentsAndParameters.forExampleWithPageable(mappingContext, example, pageable, PropertyFilter.NO_FILTER)).getResults();
 
 		LongSupplier totalCountSupplier = () -> this.count(example);
 		return PageableExecutionUtils.getPage(page, pageable, totalCountSupplier);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
@@ -25,6 +25,7 @@ import org.springframework.data.neo4j.core.ReactiveFluentFindOperation;
 import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
 import org.springframework.data.neo4j.core.mapping.CypherGenerator;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.mapping.PropertyFilter;
 import org.springframework.data.repository.query.FluentQuery.ReactiveFluentQuery;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import reactor.core.publisher.Flux;
@@ -75,7 +76,7 @@ public final class SimpleReactiveQueryByExampleExecutor<T> implements ReactiveQu
 	@Override
 	public <S extends T> Flux<S> findAll(Example<S> example, Sort sort) {
 		return this.neo4jOperations
-				.toExecutableQuery(example.getProbeType(), QueryFragmentsAndParameters.forExample(mappingContext, example, sort))
+				.toExecutableQuery(example.getProbeType(), QueryFragmentsAndParameters.forExampleWithSort(mappingContext, example, sort, null, PropertyFilter.NO_FILTER))
 				.flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
@@ -90,7 +90,7 @@ final class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 
 		if (isQueryDslRepository) {
 
-			fragments = fragments.append(createDSLExecutorFragment(metadata, QuerydslNeo4jPredicateExecutor.class));
+			fragments = fragments.append(createDSLPredicateExecutorFragment(metadata, QuerydslNeo4jPredicateExecutor.class));
 		}
 
 		if (CypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
@@ -99,6 +99,14 @@ final class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 		}
 
 		return fragments;
+	}
+
+	private RepositoryFragment<Object> createDSLPredicateExecutorFragment(RepositoryMetadata metadata, Class<?> implementor) {
+
+		Neo4jEntityInformation<?, Object> entityInformation = getEntityInformation(metadata.getDomainType());
+		Object querydslFragment = instantiateClass(implementor, mappingContext, entityInformation, neo4jOperations);
+
+		return RepositoryFragment.implemented(querydslFragment);
 	}
 
 	private RepositoryFragment<Object> createDSLExecutorFragment(RepositoryMetadata metadata, Class<?> implementor) {

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -92,7 +92,7 @@ final class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupp
 
 		if (isQueryDslRepository) {
 
-			fragments = fragments.append(createDSLExecutorFragment(metadata, ReactiveQuerydslNeo4jPredicateExecutor.class));
+			fragments = fragments.append(createDSLPredicateExecutorFragment(metadata, ReactiveQuerydslNeo4jPredicateExecutor.class));
 		}
 
 		if (ReactiveCypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
@@ -101,6 +101,14 @@ final class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupp
 		}
 
 		return fragments;
+	}
+
+	private RepositoryFragment<Object> createDSLPredicateExecutorFragment(RepositoryMetadata metadata, Class<?> implementor) {
+
+		Neo4jEntityInformation<?, Object> entityInformation = getEntityInformation(metadata.getDomainType());
+		Object querydslFragment = instantiateClass(implementor, mappingContext, entityInformation, neo4jOperations);
+
+		return RepositoryFragment.implemented(querydslFragment);
 	}
 
 	private RepositoryFragment<Object> createDSLExecutorFragment(RepositoryMetadata metadata, Class<?> implementor) {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
@@ -116,7 +116,7 @@ class ScrollingIT {
 		ScrollingEntity scrollingEntity = new ScrollingEntity();
 		Example<ScrollingEntity> example = Example.of(scrollingEntity, ExampleMatcher.matchingAll().withIgnoreNullValues());
 
-		var window = scrollingRepository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(ScrollPosition.keyset()));
+		var window = scrollingRepository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(ScrollPosition.keyset()));
 		assertThat(window.hasNext()).isTrue();
 		assertThat(window)
 				.hasSize(4)
@@ -124,13 +124,13 @@ class ScrollingIT {
 				.containsExactly("A0", "B0", "C0", "D0");
 
 		ScrollPosition newPosition = ScrollPosition.forward(((KeysetScrollPosition) window.positionAt(window.size() - 1)).getKeys());
-		window = scrollingRepository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(newPosition));
+		window = scrollingRepository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(newPosition));
 		assertThat(window)
 				.hasSize(4)
 				.extracting(ScrollingEntity::getA)
 				.containsExactly("D0", "E0", "F0", "G0");
 
-		window = scrollingRepository.findTop4By(ScrollingEntity.SORT_BY_B_AND_A, window.positionAt(window.size() - 1));
+		window = scrollingRepository.findTop4By(ScrollingEntity.SORT_BY_C, window.positionAt(window.size() - 1));
 		assertThat(window.isLast()).isTrue();
 		assertThat(window).extracting(ScrollingEntity::getA)
 				.containsExactly("H0", "I0");
@@ -199,12 +199,11 @@ class ScrollingIT {
 
 		var last = repository.findFirstByA("I0");
 		var keys = Map.of(
-				"foobar", last.getA(),
-				"b", last.getB(),
+				"c", last.getC(),
 				Constants.NAME_OF_ADDITIONAL_SORT, Values.value(last.getId().toString())
 		);
 
-		var window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(ScrollPosition.backward(keys)));
+		var window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(ScrollPosition.backward(keys)));
 		assertThat(window.hasNext()).isTrue();
 		assertThat(window)
 				.hasSize(4)
@@ -213,7 +212,7 @@ class ScrollingIT {
 
 		var pos = ((KeysetScrollPosition) window.positionAt(0));
 		var nextPos = ScrollPosition.backward(pos.getKeys());
-		window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextPos));
+		window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextPos));
 		assertThat(window.hasNext()).isTrue();
 		assertThat(window)
 				.hasSize(4)
@@ -222,7 +221,7 @@ class ScrollingIT {
 				.containsExactly("C0", "D0", "D0", "E0");
 
 		var nextNextPos = ScrollPosition.backward(((KeysetScrollPosition) window.positionAt(0)).getKeys());
-		window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextNextPos));
+		window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextNextPos));
 		assertThat(window.isLast()).isTrue();
 		assertThat(window).extracting(ScrollingEntity::getA)
 				.containsExactly("A0", "B0");

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
@@ -221,8 +221,7 @@ class ScrollingIT {
 				.extracting(ScrollingEntity::getA)
 				.containsExactly("C0", "D0", "D0", "E0");
 
-		var nextPosWindow = ((KeysetScrollPosition) window.positionAt(0));
-		var nextNextPos = ScrollPosition.backward(nextPosWindow.getKeys());
+		var nextNextPos = ScrollPosition.backward(((KeysetScrollPosition) window.positionAt(0)).getKeys());
 		window = repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextNextPos));
 		assertThat(window.isLast()).isTrue();
 		assertThat(window).extracting(ScrollingEntity::getA)

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
@@ -190,7 +190,7 @@ class ReactiveScrollingIT {
 		Example<ScrollingEntity> example = Example.of(scrollingEntity, ExampleMatcher.matchingAll().withIgnoreNullValues());
 
 		var windowContainer = new AtomicReference<Window<ScrollingEntity>>();
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(ScrollPosition.keyset()))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(ScrollPosition.keyset()))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();
@@ -202,7 +202,7 @@ class ReactiveScrollingIT {
 				.containsExactly("A0", "B0", "C0", "D0");
 
 		ScrollPosition nextScrollPosition = window.positionAt(window.size() - 1);
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextScrollPosition))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextScrollPosition))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();
@@ -214,7 +214,7 @@ class ReactiveScrollingIT {
 				.containsExactly("D0", "E0", "F0", "G0");
 
 		ScrollPosition nextNextScrollPosition = window.positionAt(window.size() - 1);
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextNextScrollPosition))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextNextScrollPosition))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();
@@ -233,13 +233,12 @@ class ReactiveScrollingIT {
 		// Recreate the last position
 		var last = repository.findFirstByA("I0").block();
 		var keys = Map.of(
-				"foobar", Values.value(last.getA()),
-				"b", Values.value(last.getB()),
+				"c", Values.value(last.getC()),
 				Constants.NAME_OF_ADDITIONAL_SORT, Values.value(last.getId().toString())
 		);
 
 		var windowContainer = new AtomicReference<Window<ScrollingEntity>>();
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(ScrollPosition.backward(keys)))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(ScrollPosition.backward(keys)))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();
@@ -251,7 +250,7 @@ class ReactiveScrollingIT {
 				.containsExactly("F0", "G0", "H0", "I0");
 
 		var nextPos = ScrollPosition.backward(((KeysetScrollPosition) window.positionAt(0)).getKeys());
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextPos))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextPos))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();
@@ -264,7 +263,7 @@ class ReactiveScrollingIT {
 				.containsExactly("C0", "D0", "D0", "E0");
 
 		var nextNextPos = ScrollPosition.backward(((KeysetScrollPosition) window.positionAt(0)).getKeys());
-		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_B_AND_A).limit(4).scroll(nextNextPos))
+		repository.findBy(example, q -> q.sortBy(ScrollingEntity.SORT_BY_C).limit(4).scroll(nextNextPos))
 				.as(StepVerifier::create)
 				.consumeNextWith(windowContainer::set)
 				.verifyComplete();

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ScrollingEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ScrollingEntity.java
@@ -37,6 +37,7 @@ public class ScrollingEntity {
 	 * Sorting by b and a will not be unique for 3 and D0, so this will trigger the additional condition based on the id
 	 */
 	public static final Sort SORT_BY_B_AND_A = Sort.by(Sort.Order.asc("b"), Sort.Order.desc("a"));
+	public static final Sort SORT_BY_C = Sort.by(Sort.Order.asc("c"));
 
 	public static void createTestData(QueryRunner queryRunner) {
 		queryRunner.run("MATCH (n) DETACH DELETE n");

--- a/src/test/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtilsTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtilsTest.java
@@ -44,7 +44,7 @@ class CypherAdapterUtilsTest {
 
 		var condition = CypherAdapterUtils.combineKeysetIntoCondition(entity,
 				ScrollPosition.forward(Map.of("foobar", "D0", "b", 3, "c", LocalDateTime.of(2023, 3, 19, 14, 21, 8, 716))),
-				Sort.by(Sort.Order.asc("b"), Sort.Order.desc("a"), Sort.Order.asc("c"))
+				Sort.by(Sort.Order.asc("b"), Sort.Order.desc("a"), Sort.Order.asc("c")), mappingContext.getConversionService()
 		);
 
 		var expected = """

--- a/src/test/java/org/springframework/data/neo4j/test/TestLogFilter.java
+++ b/src/test/java/org/springframework/data/neo4j/test/TestLogFilter.java
@@ -28,7 +28,9 @@ public class TestLogFilter extends Filter<ILoggingEvent> {
 
 	private static final List<String> FILTER_MESSAGES = List.of(
 			"ClientNotification.Statement.UnknownRelationshipTypeWarning",
-			"ClientNotification.Statement.UnknownPropertyKeyWarning"
+			"ClientNotification.Statement.UnknownLabelWarning",
+			"ClientNotification.Statement.UnknownPropertyKeyWarning",
+			"ClientNotification.Statement.FeatureDeprecationWarning"
 	);
 
 	@Override


### PR DESCRIPTION
This will add the missing support for scroll (and limit).
The API is mostly used in Spring for GraphQL but can also be invoked manually when using predicate or example executors.

Note: There is a dangling commit to add some additional filtering to the test logs. (deprecated id, unknown labels)