### PR TITLE
Remove locks in reactive bookmark related operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.2.0-SNAPSHOT</version>
+	<version>7.2.0-GH-2755-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>
@@ -244,6 +244,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor.tools</groupId>
+			<artifactId>blockhound</artifactId>
+			<version>1.0.8.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -627,6 +633,7 @@
 				<configuration>
 					<useSystemClassLoader>false</useSystemClassLoader>
 					<useFile>false</useFile>
+					<argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
 					<includes>
 						<include>**/*Test.java</include>
 						<include>**/*Tests.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<archunit.version>0.23.1</archunit.version>
 		<asciidoctor-maven-plugin.version>2.1.0</asciidoctor-maven-plugin.version>
 		<asciidoctorj-diagram.version>2.1.0</asciidoctorj-diagram.version>
+		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<byte-buddy.version>1.14.3</byte-buddy.version>
 		<cdi>3.0.1</cdi>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
@@ -237,6 +238,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>io.projectreactor.tools</groupId>
+				<artifactId>blockhound</artifactId>
+				<version>${blockhound.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -244,12 +250,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor.tools</groupId>
-			<artifactId>blockhound</artifactId>
-			<version>1.0.8.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -454,6 +454,11 @@
 					<groupId>org.projectlombok</groupId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor.tools</groupId>
+			<artifactId>blockhound</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
@@ -27,6 +27,7 @@ import org.springframework.data.neo4j.core.Neo4jOperations;
 import org.springframework.data.neo4j.core.Neo4jTemplate;
 import org.springframework.data.neo4j.core.UserSelectionProvider;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.lang.Nullable;
@@ -47,6 +48,9 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 	@Autowired
 	private ObjectProvider<UserSelectionProvider> userSelectionProviders;
 
+	@Autowired
+	private Neo4jBookmarkManager bookmarkManager;
+
 	/**
 	 * The driver to be used for interacting with Neo4j.
 	 *
@@ -66,6 +70,7 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 		return Neo4jClient.with(driver)
 				.withDatabaseSelectionProvider(databaseSelectionProvider)
 				.withUserSelectionProvider(getUserSelectionProvider())
+				.withNeo4jBookmarkManager(bookmarkManager)
 				.build();
 	}
 
@@ -94,7 +99,13 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 				.with(driver)
 				.withDatabaseSelectionProvider(databaseSelectionProvider)
 				.withUserSelectionProvider(getUserSelectionProvider())
+				.withBookmarkManager(bookmarkManager)
 				.build();
+	}
+
+	@Bean
+	public Neo4jBookmarkManager bookmarkManager() {
+		return Neo4jBookmarkManager.create();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
@@ -26,6 +26,7 @@ import org.springframework.data.neo4j.core.ReactiveNeo4jClient;
 import org.springframework.data.neo4j.core.ReactiveNeo4jTemplate;
 import org.springframework.data.neo4j.core.ReactiveUserSelectionProvider;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager;
 import org.springframework.data.neo4j.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
 import org.springframework.lang.Nullable;
@@ -47,6 +48,9 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 	@Autowired
 	private ObjectProvider<ReactiveUserSelectionProvider> userSelectionProviders;
 
+	@Autowired
+	private Neo4jBookmarkManager bookmarkManager;
+
 	/**
 	 * The driver to be used for interacting with Neo4j.
 	 *
@@ -66,6 +70,7 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 		return ReactiveNeo4jClient.with(driver)
 				.withDatabaseSelectionProvider(databaseSelectionProvider)
 				.withUserSelectionProvider(getUserSelectionProvider())
+				.withNeo4jBookmarkManager(bookmarkManager)
 				.build();
 	}
 
@@ -94,7 +99,13 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 		return ReactiveNeo4jTransactionManager.with(driver)
 				.withDatabaseSelectionProvider(databaseSelectionProvider)
 				.withUserSelectionProvider(getUserSelectionProvider())
+				.withBookmarkManager(bookmarkManager)
 				.build();
+	}
+
+	@Bean
+	public Neo4jBookmarkManager bookmarkManager() {
+		return Neo4jBookmarkManager.createReactive();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
@@ -65,13 +65,14 @@ final class DefaultNeo4jClient implements Neo4jClient {
 	private final Neo4jPersistenceExceptionTranslator persistenceExceptionTranslator = new Neo4jPersistenceExceptionTranslator();
 
 	// Local bookmark manager when using outside managed transactions
-	private final Neo4jBookmarkManager bookmarkManager = Neo4jBookmarkManager.create();
+	private final Neo4jBookmarkManager bookmarkManager;
 
 	DefaultNeo4jClient(Builder builder) {
 
 		this.driver = builder.driver;
 		this.databaseSelectionProvider = builder.databaseSelectionProvider;
 		this.userSelectionProvider = builder.userSelectionProvider;
+		this.bookmarkManager = builder.bookmarkManager != null ? builder.bookmarkManager : Neo4jBookmarkManager.create();
 
 		this.conversionService = new DefaultConversionService();
 		Optional.ofNullable(builder.neo4jConversions).orElseGet(Neo4jConversions::new).registerConvertersIn((ConverterRegistry) conversionService);

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
@@ -16,13 +16,9 @@
 package org.springframework.data.neo4j.core;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -45,6 +41,7 @@ import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.neo4j.core.convert.Neo4jConversions;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionUtils;
 import org.springframework.lang.Nullable;
@@ -67,9 +64,8 @@ final class DefaultNeo4jClient implements Neo4jClient {
 	private final ConversionService conversionService;
 	private final Neo4jPersistenceExceptionTranslator persistenceExceptionTranslator = new Neo4jPersistenceExceptionTranslator();
 
-	// Basically a local bookmark manager
-	private final Set<Bookmark> bookmarks = new HashSet<>();
-	private final ReentrantReadWriteLock bookmarksLock = new ReentrantReadWriteLock();
+	// Local bookmark manager when using outside managed transactions
+	private final Neo4jBookmarkManager bookmarkManager = Neo4jBookmarkManager.create();
 
 	DefaultNeo4jClient(Builder builder) {
 
@@ -85,29 +81,13 @@ final class DefaultNeo4jClient implements Neo4jClient {
 	public QueryRunner getQueryRunner(DatabaseSelection databaseSelection, UserSelection impersonatedUser) {
 
 		QueryRunner queryRunner = Neo4jTransactionManager.retrieveTransaction(driver, databaseSelection, impersonatedUser);
-		Collection<Bookmark> lastBookmarks = Collections.emptySet();
+		Collection<Bookmark> lastBookmarks = bookmarkManager.getBookmarks();
+
 		if (queryRunner == null) {
-			ReentrantReadWriteLock.ReadLock lock = bookmarksLock.readLock();
-			try {
-				lock.lock();
-				lastBookmarks = new HashSet<>(bookmarks);
-				queryRunner = driver.session(Neo4jTransactionUtils.sessionConfig(false, lastBookmarks, databaseSelection, impersonatedUser));
-			} finally {
-				lock.unlock();
-			}
+			queryRunner = driver.session(Neo4jTransactionUtils.sessionConfig(false, lastBookmarks, databaseSelection, impersonatedUser));
 		}
 
-		return new DelegatingQueryRunner(queryRunner, lastBookmarks, (usedBookmarks, newBookmarks) -> {
-
-			ReentrantReadWriteLock.WriteLock lock = bookmarksLock.writeLock();
-			try {
-				lock.lock();
-				bookmarks.removeAll(usedBookmarks);
-				bookmarks.addAll(newBookmarks);
-			} finally {
-				lock.unlock();
-			}
-		});
+		return new DelegatingQueryRunner(queryRunner, lastBookmarks, bookmarkManager::updateBookmarks);
 	}
 
 	private static class DelegatingQueryRunner implements QueryRunner {

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultReactiveNeo4jClient.java
@@ -68,7 +68,7 @@ final class DefaultReactiveNeo4jClient implements ReactiveNeo4jClient {
 	private final Neo4jPersistenceExceptionTranslator persistenceExceptionTranslator = new Neo4jPersistenceExceptionTranslator();
 
 	// Local bookmark manager when using outside managed transactions
-	private final Neo4jBookmarkManager bookmarkManager = Neo4jBookmarkManager.createReactive();
+	private final Neo4jBookmarkManager bookmarkManager;
 
 	DefaultReactiveNeo4jClient(Builder builder) {
 
@@ -78,6 +78,7 @@ final class DefaultReactiveNeo4jClient implements ReactiveNeo4jClient {
 
 		this.conversionService = new DefaultConversionService();
 		Optional.ofNullable(builder.neo4jConversions).orElseGet(Neo4jConversions::new).registerConvertersIn((ConverterRegistry) conversionService);
+		this.bookmarkManager = builder.bookmarkManager != null ? builder.bookmarkManager : Neo4jBookmarkManager.createReactive();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.data.neo4j.core.convert.Neo4jConversions;
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.lang.Nullable;
 
 /**
@@ -79,6 +80,9 @@ public interface Neo4jClient {
 		@Nullable
 		Neo4jConversions neo4jConversions;
 
+		@Nullable
+		Neo4jBookmarkManager bookmarkManager;
+
 		private Builder(Driver driver) {
 			this.driver = driver;
 		}
@@ -118,6 +122,20 @@ public interface Neo4jClient {
 		 */
 		public Builder withNeo4jConversions(Neo4jConversions neo4jConversions) {
 			this.neo4jConversions = neo4jConversions;
+			return this;
+		}
+
+		/**
+		 * Configures the {@link Neo4jBookmarkManager} to use.
+		 * This should be the same instance as provided for the {@link org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager}
+		 * respectively the {@link org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager}.
+		 *
+		 * @param bookmarkManager Neo4jBookmarkManager instance that is shared with the transaction manager.
+		 * @return The builder
+		 * @since 7.1.2
+		 */
+		public Builder withNeo4jBookmarkManager(Neo4jBookmarkManager bookmarkManager) {
+			this.bookmarkManager = bookmarkManager;
 			return this;
 		}
 

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.neo4j.core;
 
+import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -82,6 +83,9 @@ public interface ReactiveNeo4jClient {
 		@Nullable
 		Neo4jConversions neo4jConversions;
 
+		@Nullable
+		Neo4jBookmarkManager bookmarkManager;
+
 		private Builder(Driver driver) {
 			this.driver = driver;
 		}
@@ -121,6 +125,20 @@ public interface ReactiveNeo4jClient {
 		 */
 		public Builder withNeo4jConversions(Neo4jConversions neo4jConversions) {
 			this.neo4jConversions = neo4jConversions;
+			return this;
+		}
+
+		/**
+		 * Configures the {@link Neo4jBookmarkManager} to use.
+		 * This should be the same instance as provided for the {@link org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager}
+		 * respectively the {@link org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager}.
+		 *
+		 * @param bookmarkManager Neo4jBookmarkManager instance that is shared with the transaction manager.
+		 * @return The builder
+		 * @since 7.1.2
+		 */
+		public Builder withNeo4jBookmarkManager(Neo4jBookmarkManager bookmarkManager) {
+			this.bookmarkManager = bookmarkManager;
 			return this;
 		}
 

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManager.java
@@ -42,6 +42,13 @@ public sealed interface Neo4jBookmarkManager permits AbstractBookmarkManager, No
 	}
 
 	/**
+	 * @return default reactive version of bookmark manager
+	 */
+	static Neo4jBookmarkManager createReactive() {
+		return new ReactiveDefaultBookmarkManager(null);
+	}
+
+	/**
 	 * Use this factory method to add supplier of initial "seeding" bookmarks to the transaction managers
 	 * <p>
 	 * While this class will make sure that the supplier will be accessed in a thread-safe manner,
@@ -53,6 +60,20 @@ public sealed interface Neo4jBookmarkManager permits AbstractBookmarkManager, No
 	 */
 	static Neo4jBookmarkManager create(@Nullable Supplier<Set<Bookmark>> bookmarksSupplier) {
 		return new DefaultBookmarkManager(bookmarksSupplier);
+	}
+
+	/**
+	 * Use this factory method to add supplier of initial "seeding" bookmarks to the transaction managers
+	 * <p>
+	 * While this class will make sure that the supplier will be accessed in a thread-safe manner,
+	 * it is the caller's duty to provide a thread safe supplier (not changing the seed during a call, etc.).
+	 *
+	 * @param bookmarksSupplier A supplier for seeding bookmarks, can be null. The supplier is free to provide different
+	 *                          bookmarks on each call.
+	 * @return A reactive bookmark manager
+	 */
+	static Neo4jBookmarkManager createReactive(@Nullable Supplier<Set<Bookmark>> bookmarksSupplier) {
+		return new ReactiveDefaultBookmarkManager(bookmarksSupplier);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
@@ -48,7 +48,7 @@ final class ReactiveDefaultBookmarkManager extends AbstractBookmarkManager {
 	@Override
 	public Collection<Bookmark> getBookmarks() {
 		this.bookmarks.addAll(bookmarksSupplier.get());
-		return Collections.unmodifiableSet(this.bookmarks);
+		return Collections.synchronizedSet(Collections.unmodifiableSet(this.bookmarks));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.transaction;
+
+import org.neo4j.driver.Bookmark;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Default bookmark manager.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Helge Schneider - The Last Jazz
+ * @since 7.0
+ */
+final class ReactiveDefaultBookmarkManager extends AbstractBookmarkManager {
+
+	private final Set<Bookmark> bookmarks = Collections.synchronizedSet(new HashSet<>());
+
+	private final Supplier<Set<Bookmark>> bookmarksSupplier;
+
+	@Nullable
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	ReactiveDefaultBookmarkManager(@Nullable Supplier<Set<Bookmark>> bookmarksSupplier) {
+		this.bookmarksSupplier = bookmarksSupplier == null ? Collections::emptySet : bookmarksSupplier;
+	}
+
+	@Override
+	public Collection<Bookmark> getBookmarks() {
+		this.bookmarks.addAll(bookmarksSupplier.get());
+		return Collections.unmodifiableSet(this.bookmarks);
+	}
+
+	@Override
+	public void updateBookmarks(Collection<Bookmark> usedBookmarks, Collection<Bookmark> newBookmarks) {
+		bookmarks.removeAll(usedBookmarks);
+		bookmarks.addAll(newBookmarks);
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new Neo4jBookmarksUpdatedEvent(new HashSet<>(bookmarks)));
+		}
+	}
+
+	@Override
+	public void setApplicationEventPublisher(@Nullable ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManager.java
@@ -179,7 +179,7 @@ public final class ReactiveNeo4jTransactionManager extends AbstractReactiveTrans
 				ReactiveUserSelectionProvider.getDefaultSelectionProvider() :
 				builder.userSelectionProvider;
 		this.bookmarkManager =
-				builder.bookmarkManager == null ? Neo4jBookmarkManager.create() : builder.bookmarkManager;
+				builder.bookmarkManager == null ? Neo4jBookmarkManager.createReactive() : builder.bookmarkManager;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCompositePropertiesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCompositePropertiesIT.java
@@ -171,7 +171,7 @@ class ReactiveCompositePropertiesIT extends CompositePropertiesITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCustomTypesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCustomTypesIT.java
@@ -221,7 +221,7 @@ public class ReactiveCustomTypesIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
@@ -21,10 +21,7 @@ import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.executables.ExecutableResultStatement;
 import org.neo4j.cypherdsl.core.executables.ExecutableStatement;
-import org.neo4j.driver.AuthTokenManagers;
-import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
@@ -45,14 +42,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
@@ -111,14 +111,7 @@ class Neo4jClientIT {
 		@Bean
 		@Override
 		public Driver driver() {
-			Map<Integer, String> asdf = Map.of(1, "verysecret", 2, "password");
-			var count = new AtomicInteger(1);
-return GraphDatabase.driver("bolt://localhost:7687", AuthTokenManagers.expirationBased(() -> {
-	System.out.println("new call");
-	var token = AuthTokens.basic("neo4j", asdf.get(count.getAndIncrement()));
-	var now = OffsetDateTime.now().plusYears(1).atZoneSameInstant(ZoneOffset.UTC);
-	return token.expiringAt(now.toInstant().toEpochMilli());
-}));
+			return neo4jConnectionSupport.getDriver();
 		}
 
 		@Override // needed here because there is no implicit registration of entities upfront some methods under test

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
@@ -15,19 +15,16 @@
  */
 package org.springframework.data.neo4j.integration.imperative;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.executables.ExecutableResultStatement;
 import org.neo4j.cypherdsl.core.executables.ExecutableStatement;
+import org.neo4j.driver.AuthTokenManagers;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
@@ -47,6 +44,17 @@ import org.springframework.data.neo4j.test.TestIdentitySupport;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Michael J. Simons
@@ -103,7 +111,14 @@ class Neo4jClientIT {
 		@Bean
 		@Override
 		public Driver driver() {
-			return neo4jConnectionSupport.getDriver();
+			Map<Integer, String> asdf = Map.of(1, "verysecret", 2, "password");
+			var count = new AtomicInteger(1);
+return GraphDatabase.driver("bolt://localhost:7687", AuthTokenManagers.expirationBased(() -> {
+	System.out.println("new call");
+	var token = AuthTokens.basic("neo4j", asdf.get(count.getAndIncrement()));
+	var now = OffsetDateTime.now().plusYears(1).atZoneSameInstant(ZoneOffset.UTC);
+	return token.expiringAt(now.toInstant().toEpochMilli());
+}));
 		}
 
 		@Override // needed here because there is no implicit registration of entities upfront some methods under test

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/ReactiveIssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/ReactiveIssuesIT.java
@@ -447,7 +447,7 @@ class ReactiveIssuesIT extends TestBase {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
 			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider,
-					Neo4jBookmarkManager.create(bookmarkCapture));
+					Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractReactiveTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractReactiveTestBase.java
@@ -97,7 +97,7 @@ public abstract class AbstractReactiveTestBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ReactiveElementIdIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ReactiveElementIdIT.java
@@ -358,7 +358,7 @@ public class ReactiveElementIdIT extends AbstractElementIdTestBase {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
 			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider,
-					Neo4jBookmarkManager.create(bookmarkCapture));
+					Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Bean

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
@@ -499,7 +499,7 @@ class ReactiveAdvancedMappingIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/properties/ReactivePropertyIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/properties/ReactivePropertyIT.java
@@ -304,7 +304,7 @@ class ReactivePropertyIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingIT.java
@@ -184,7 +184,7 @@ class ReactiveAuditingIT extends AuditingITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingWithoutDatesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingWithoutDatesIT.java
@@ -119,7 +119,7 @@ class ReactiveAuditingWithoutDatesIT extends AuditingITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCallbacksIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCallbacksIT.java
@@ -194,7 +194,7 @@ class ReactiveCallbacksIT extends CallbacksITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
@@ -181,7 +181,7 @@ class ReactiveCypherdslConditionExecutorIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
@@ -212,7 +212,7 @@ class ReactiveCypherdslStatementExecutorIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -504,7 +504,7 @@ public class ReactiveDynamicLabelsIT {
 			public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 				BookmarkCapture bookmarkCapture = bookmarkCapture();
-				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 			}
 
 			@Bean

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicRelationshipsIT.java
@@ -305,7 +305,7 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase<PersonWi
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveIdGeneratorsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveIdGeneratorsIT.java
@@ -159,7 +159,7 @@ class ReactiveIdGeneratorsIT extends IdGeneratorsITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableAssignedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableAssignedIdsIT.java
@@ -429,7 +429,7 @@ public class ReactiveImmutableAssignedIdsIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
@@ -401,7 +401,7 @@ public class ReactiveImmutableExternallyGeneratedIdsIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
@@ -377,7 +377,7 @@ public class ReactiveImmutableGeneratedIdsIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
@@ -17,7 +17,6 @@ package org.springframework.data.neo4j.integration.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
@@ -72,6 +72,7 @@ import reactor.test.StepVerifier;
 /**
  * @author Michael J. Simons
  */
+@Disabled // we cannot use BlockHound right now in the Maven build
 @Neo4jIntegrationTest
 class ReactiveNeo4jClientIT {
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
@@ -1042,7 +1042,7 @@ class ReactiveNeo4jTemplateIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTransactionManagerTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTransactionManagerTestIT.java
@@ -106,7 +106,7 @@ class ReactiveNeo4jTransactionManagerTestIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveOptimisticLockingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveOptimisticLockingIT.java
@@ -380,7 +380,7 @@ class ReactiveOptimisticLockingIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveProjectionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveProjectionIT.java
@@ -469,7 +469,7 @@ class ReactiveProjectionIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveQuerydslNeo4jPredicateExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveQuerydslNeo4jPredicateExecutorIT.java
@@ -369,7 +369,7 @@ class ReactiveQuerydslNeo4jPredicateExecutorIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRelationshipsIT.java
@@ -244,7 +244,7 @@ class ReactiveRelationshipsIT extends RelationshipsITBase {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -2882,7 +2882,7 @@ class ReactiveRepositoryIT {
 			return ReactiveNeo4jTransactionManager.with(driver)
 					.withDatabaseSelectionProvider(databaseSelectionProvider)
 					.withUserSelectionProvider(getUserSelectionProvider())
-					.withBookmarkManager(Neo4jBookmarkManager.create(bookmarkCapture()))
+					.withBookmarkManager(Neo4jBookmarkManager.createReactive(bookmarkCapture()))
 					.build();
 		}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
@@ -292,7 +292,7 @@ class ReactiveScrollingIT {
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveStringlyTypeDynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveStringlyTypeDynamicRelationshipsIT.java
@@ -301,7 +301,7 @@ class ReactiveStringlyTypeDynamicRelationshipsIT extends DynamicRelationshipsITB
 		public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/ReactiveOptimisticLockingOfSelfReferencesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/ReactiveOptimisticLockingOfSelfReferencesIT.java
@@ -316,7 +316,7 @@ class ReactiveOptimisticLockingOfSelfReferencesIT extends TestBase {
 				ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
 			return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider,
-					Neo4jBookmarkManager.create(bookmarkCapture));
+					Neo4jBookmarkManager.createReactive(bookmarkCapture));
 		}
 
 		@Bean


### PR DESCRIPTION
Cannot be merged before the driver has a fix in place. Otherwise the operations will not break in SDN but in the driver.