### PR TITLE
CypherGenerator: Use id() instead of toString(id(element))

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.1.4-SNAPSHOT</version>
+	<version>7.1.4-elementid-again-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2011-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.core.mapping;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.FunctionInvocation;
+import org.neo4j.cypherdsl.core.Functions;
+import org.neo4j.cypherdsl.core.Named;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.Relationship;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
+
+import java.util.function.Function;
+
+/**
+ * Supporting class for CypherDSL related customizations.
+ *
+ * @author Gerrit Meier
+ */
+@API(status = API.Status.INTERNAL)
+public final class SpringDataCypherDsl {
+
+	private SpringDataCypherDsl() {
+	}
+
+	public static Function<Dialect, Function<Named, FunctionInvocation>> elementIdOrIdFunction = dialect -> {
+		if (dialect == Dialect.NEO4J_5) {
+			return SpringDataCypherDsl::elementId;
+		} else if (dialect == Dialect.DEFAULT) {
+			return SpringDataCypherDsl::id;
+		} else {
+			return named -> {
+				if (named instanceof Node node) {
+					return Functions.elementId(node);
+				} else if (named instanceof Relationship relationship) {
+					return Functions.elementId(relationship);
+				} else {
+					throw new IllegalArgumentException("Unsupported CypherDSL type: " + named.getClass());
+				}
+			};
+		}
+	};
+
+	private static FunctionInvocation id(Named expression) {
+		return FunctionInvocation.create(new ElementIdOrIdFunctionDefinition("id"), expression.getRequiredSymbolicName());
+	}
+
+	private static FunctionInvocation elementId(Named expression) {
+		return FunctionInvocation.create(new ElementIdOrIdFunctionDefinition("elementId"), expression.getRequiredSymbolicName());
+	}
+
+	private static final class ElementIdOrIdFunctionDefinition implements FunctionInvocation.FunctionDefinition {
+
+		final String identifierFunction;
+
+		private ElementIdOrIdFunctionDefinition(String identifierFunction) {
+			this.identifierFunction = identifierFunction;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return identifierFunction;
+		}
+
+		@Override
+		public boolean isAggregate() {
+			return false;
+		}
+
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
@@ -30,6 +30,8 @@ import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.driver.Driver;
 import org.springframework.data.neo4j.config.Neo4jCdiExtension;
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
@@ -54,6 +56,16 @@ class Neo4jCdiExtensionIT {
 		@Singleton
 		public Driver driver() {
 			return connectionSupport.getDriver();
+		}
+
+		@Produces
+		@Singleton
+		public Configuration cypherDslConfiguration() {
+			if (connectionSupport.isCypher5SyntaxCompatible()) {
+				return Configuration.newConfig().withDialect(Dialect.NEO4J_5).build();
+			}
+
+			return Configuration.newConfig().withDialect(Dialect.DEFAULT).build();
 		}
 	}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
@@ -20,12 +20,14 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.neo4j.test.BookmarkCapture;
 import org.springframework.data.neo4j.test.Neo4jExtension;
 
+@Tag(Neo4jExtension.NEEDS_VERSION_SUPPORTING_ELEMENT_ID)
 abstract class AbstractElementIdTestBase {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -63,6 +63,7 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 
 	public final static String NEEDS_REACTIVE_SUPPORT = "reactive-test";
+	public final static String NEEDS_VERSION_SUPPORTING_ELEMENT_ID = "elementid-test";
 	public final static String COMMUNITY_EDITION_ONLY = "community-edition";
 	public final static String COMMERCIAL_EDITION_ONLY = "commercial-edition";
 	/**
@@ -136,6 +137,10 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		if (tags.contains(NEEDS_REACTIVE_SUPPORT)) {
 			assumeThat(neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.v4_0_0))
 					.describedAs("This test requires at least Neo4j 4.0 for reactive database connectivity.").isTrue();
+		}
+		if (tags.contains(NEEDS_VERSION_SUPPORTING_ELEMENT_ID)) {
+			assumeThat(neo4jConnectionSupport.getServerVersion().greaterThan(ServerVersion.v5_3_0))
+					.describedAs("This test requires a version greater than Neo4j 5.3.0 for correct elementId handling.").isTrue();
 		}
 
 		if (tags.contains(COMMUNITY_EDITION_ONLY)) {

--- a/src/test/java/org/springframework/data/neo4j/test/ServerVersion.java
+++ b/src/test/java/org/springframework/data/neo4j/test/ServerVersion.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 public final class ServerVersion {
 	public static final String NEO4J_PRODUCT = "Neo4j";
 
+	public static final ServerVersion v5_3_0 = new ServerVersion(NEO4J_PRODUCT, 5, 3, 0);
 	public static final ServerVersion v5_0_0 = new ServerVersion(NEO4J_PRODUCT, 5, 0, 0);
 	public static final ServerVersion v4_4_0 = new ServerVersion(NEO4J_PRODUCT, 4, 4, 0);
 	public static final ServerVersion v4_3_0 = new ServerVersion(NEO4J_PRODUCT, 4, 3, 0);

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
@@ -32,6 +32,7 @@ import org.springframework.data.neo4j.repository.Neo4jRepository
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories
 import org.springframework.data.neo4j.test.BookmarkCapture
 import org.springframework.data.neo4j.test.Neo4jExtension
+import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
@@ -119,7 +120,7 @@ class ImmutableRelationshipsIT @Autowired constructor(
     @Configuration
     @EnableTransactionManagement
     @EnableNeo4jRepositories
-    open class MyConfig : AbstractNeo4jConfig() {
+    open class MyConfig : Neo4jImperativeTestConfiguration() {
         @Bean
         override fun driver(): Driver {
             return neo4jConnectionSupport.driver
@@ -134,6 +135,10 @@ class ImmutableRelationshipsIT @Autowired constructor(
         override fun transactionManager(driver: Driver, databaseNameProvider: DatabaseSelectionProvider): PlatformTransactionManager {
             val bookmarkCapture = bookmarkCapture()
             return Neo4jTransactionManager(driver, databaseNameProvider, Neo4jBookmarkManager.create(bookmarkCapture))
+        }
+
+        override fun isCypher5Compatible(): Boolean {
+            return neo4jConnectionSupport.isCypher5SyntaxCompatible
         }
     }
 


### PR DESCRIPTION
Related issue #2784 

Instead of having a unified return type (String) in the Cypher result,
SDN accepts now `Long` for id() and `String`.
The conversion will take place in the library code.

To switch between id() and elementId(), SDN will inspect the selected
CypherDSL dialect and select the needed identifier function accordingly.