### PR TITLE
Find the right id/element id function for assigned ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.2.0-SNAPSHOT</version>
+	<version>7.2.0-GH-2809-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
@@ -427,10 +427,10 @@ public final class TemplateSupport {
 	 * @return {@literal true} if renderer will use elementId
 	 */
 	static boolean rendererCanUseElementIdIfPresent(Renderer renderer, Neo4jPersistentEntity<?> targetEntity) {
-		return !targetEntity.isUsingDeprecatedInternalId() && targetEntity.isUsingInternalIds() && rendererRendersElementId(renderer);
+		return !targetEntity.isUsingDeprecatedInternalId() && rendererRendersElementId(renderer);
 	}
 
-	private static boolean rendererRendersElementId(Renderer renderer) {
+	static boolean rendererRendersElementId(Renderer renderer) {
 		return renderer.render(Cypher.returning(Functions.elementId(Cypher.anyNode("n"))).build())
 				.equals("RETURN elementId(n)");
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -60,6 +60,12 @@ public interface Neo4jPersistentEntity<T>
 	 * @return True if the underlying domain classes uses {@code id()} to compute internally generated ids.
 	 */
 	default boolean isUsingDeprecatedInternalId() {
+		for (NodeDescription<?> nodeDescription : getChildNodeDescriptionsInHierarchy()) {
+			if (nodeDescription.isUsingInternalIds() && ((Neo4jPersistentEntity<?>) nodeDescription).getIdProperty() != null
+					&& Neo4jPersistentEntity.DEPRECATED_GENERATED_ID_TYPES.contains(((Neo4jPersistentEntity<?>) nodeDescription).getIdProperty().getType())) {
+				return true;
+			}
+		}
 		return isUsingInternalIds() && Neo4jPersistentEntity.DEPRECATED_GENERATED_ID_TYPES.contains(getRequiredIdProperty().getType());
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
@@ -56,7 +56,7 @@ class CypherGeneratorTest {
 		when(relationshipDescription.isDynamic()).thenReturn(true);
 
 		Statement statement = CypherGenerator.INSTANCE.prepareSaveOfRelationship(persistentEntity,
-				relationshipDescription, "REL");
+				relationshipDescription, "REL", true);
 
 		String expectedQuery = "MATCH (startNode:`Entity1`) WHERE startNode.id = $fromId MATCH (endNode)"
 							   + " WHERE elementId(endNode) = $toId MERGE (startNode)<-[relProps:`REL`]-(endNode) RETURN elementId(relProps) AS __elementId__";
@@ -71,7 +71,7 @@ class CypherGeneratorTest {
 		when(relationshipDescription.isDynamic()).thenReturn(true);
 
 		Statement statement = CypherGenerator.INSTANCE.prepareSaveOfRelationship(persistentEntity,
-				relationshipDescription, "REL");
+				relationshipDescription, "REL", true);
 
 		String expectedQuery =
 				"MATCH (startNode:`Entity1`:`MultipleLabel`) WHERE startNode.id = $fromId MATCH (endNode)"
@@ -92,7 +92,7 @@ class CypherGeneratorTest {
 		when(persistentEntity.isUsingDeprecatedInternalId()).thenReturn(true);
 
 		Statement statement = CypherGenerator.INSTANCE.prepareSaveOfRelationship(persistentEntity,
-				relationshipDescription, "REL");
+				relationshipDescription, "REL", true);
 
 		String expectedQuery = "MATCH (startNode) WHERE id(startNode) = $fromId MATCH (endNode)"
 							   + " WHERE elementId(endNode) = $toId MERGE (startNode)<-[relProps:`REL`]-(endNode) RETURN elementId(relProps) AS __elementId__";
@@ -106,7 +106,7 @@ class CypherGeneratorTest {
 		RelationshipDescription relationshipDescription = Mockito.mock(RelationshipDescription.class);
 		doReturn(relatedEntity).when(relationshipDescription).getTarget();
 
-		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription);
+		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription, true);
 
 		String expectedQuery = "MATCH (startNode:`Entity1`)<-[rel]-(:`Entity2`) WHERE (startNode.id = $fromId AND NOT (elementId(rel) IN $__knownRelationShipIds__)) DELETE rel";
 		Assertions.assertEquals(expectedQuery, Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build()).render(statement));
@@ -121,7 +121,7 @@ class CypherGeneratorTest {
 		RelationshipDescription relationshipDescription = Mockito.mock(RelationshipDescription.class);
 		doReturn(relatedEntity).when(relationshipDescription).getTarget();
 
-		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription);
+		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription, true);
 
 		String expectedQuery = "MATCH (startNode:`Entity1`:`MultipleLabel`)<-[rel]-(:`Entity2`:`MultipleLabel`) WHERE (startNode.id = $fromId AND NOT (elementId(rel) IN $__knownRelationShipIds__)) DELETE rel";
 		Assertions.assertEquals(expectedQuery, Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build()).render(statement));
@@ -143,7 +143,7 @@ class CypherGeneratorTest {
 		when(persistentEntity.getRequiredIdProperty()).thenReturn(persistentProperty);
 		when(persistentEntity.isUsingDeprecatedInternalId()).thenReturn(true);
 
-		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription);
+		Statement statement = CypherGenerator.INSTANCE.prepareDeleteOf(persistentEntity, relationshipDescription, true);
 
 		String expectedQuery = "MATCH (startNode)<-[rel]-(:`Entity2`) WHERE (id(startNode) = $fromId AND NOT (elementId(rel) IN $__knownRelationShipIds__)) DELETE rel";
 		Assertions.assertEquals(expectedQuery, Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build()).render(statement));


### PR DESCRIPTION
* Avoid using the outdated id function wherever possible.
* Never fall back to `toString(id((element))` (in Neo4j 4.4 scenarios)

Well, I personally hate the passing of the `canUseElementId` all over the place and am open for better suggestions.