### PR TITLE
Support ResultSummaries with Notifications with no InputPosition reported by the driver.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
@@ -111,13 +111,14 @@ final class ResultSummaries {
 	static String format(Notification notification, String forQuery) {
 
 		InputPosition position = notification.position();
+		boolean hasPosition = position != null;
 
 		StringBuilder queryHint = new StringBuilder();
 		String[] lines = forQuery.split("(\r\n|\n)");
 		for (int i = 0; i < lines.length; i++) {
 			String line = lines[i];
 			queryHint.append("\t").append(line).append(LINE_SEPARATOR);
-			if (i + 1 == position.line()) {
+			if (hasPosition && i + 1 == position.line()) {
 				queryHint.append("\t").append(Stream.generate(() -> " ").limit(position.column() - 1)
 						.collect(Collectors.joining())).append("^").append(System.lineSeparator());
 			}

--- a/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
@@ -54,17 +54,24 @@ class ResultSummariesTest {
 						+ "\tmatch (n)                  " + LINE_SEPARATOR
 						+ "\t-        [r:FOO*] -> (m) " + LINE_SEPARATOR
 						+ "\t^" + LINE_SEPARATOR
-						+ "\tRETURN r" + LINE_SEPARATOR)
+						+ "\tRETURN r" + LINE_SEPARATOR),
+				Arguments.of("match (n) - [r] -> (m) RETURN r", null, null, ""
+						+ "\tmatch (n) - [r] -> (m) RETURN r" + LINE_SEPARATOR)
 		);
 	}
 
 	@ParameterizedTest(name = "{index}: Notifications for \"{0}\"")
 	@MethodSource("params")
-	void shouldFormatNotifications(String query, int line, int column, String expected) {
+	void shouldFormatNotifications(String query, Integer line, Integer column, String expected) {
 
-		InputPosition inputPosition = mock(InputPosition.class);
-		when(inputPosition.line()).thenReturn(line);
-		when(inputPosition.column()).thenReturn(column);
+		InputPosition inputPosition;
+		if (line == null || column == null) {
+			inputPosition = null;
+		} else {
+			inputPosition = mock(InputPosition.class);
+			when(inputPosition.line()).thenReturn(line);
+			when(inputPosition.column()).thenReturn(column);
+		}
 
 		Notification notification = mock(Notification.class);
 		when(notification.severity()).thenReturn("WARNING");


### PR DESCRIPTION
The Neo4j Java driver may report null for `Notification.position()`. SDN's `ResultSummaries `log formatting did not support this case yet.