### PR TITLE
fix: Several issues wrt JavaDoc and the module-path.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
 				</exclusions>
 			</dependency>
 			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+				<version>${cypher-dsl.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.neo4j.driver</groupId>
 				<artifactId>neo4j-java-driver</artifactId>
 				<version>${neo4j-java-driver.version}</version>
@@ -369,6 +374,10 @@
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j.driver</groupId>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -60,7 +60,6 @@ import org.neo4j.cypherdsl.core.StatementBuilder.OngoingUpdate;
 import org.neo4j.cypherdsl.core.SymbolicName;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
-import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentProperty;
@@ -701,7 +700,7 @@ public enum CypherGenerator {
 						expression = Cypher.property(property.substring(0, firstDot), tail);
 					} else {
 						try {
-							Assertions.isTrue(SourceVersion.isIdentifier(property), "Name must be a valid identifier.");
+							Assert.isTrue(SourceVersion.isIdentifier(property), "Name must be a valid identifier.");
 							expression = Cypher.name(property);
 						} catch (IllegalArgumentException e) {
 							if (e.getMessage().endsWith(".")) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -38,7 +38,6 @@ import java.util.stream.StreamSupport;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Relationship;
@@ -895,7 +894,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			} else if (propertyContainer.containsKey(Constants.NAME_OF_ALL_PROPERTIES)) {
 				return propertyContainer.get(Constants.NAME_OF_ALL_PROPERTIES).get(graphPropertyName);
 			} else {
-				return NullValue.NULL;
+				return Values.NULL;
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/MapValueWrapper.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/MapValueWrapper.java
@@ -19,7 +19,7 @@ import org.apiguardian.api.API;
 import org.neo4j.driver.Value;
 
 /**
- * A wrapper or marker for a Neo4j {@link org.neo4j.driver.internal.value.MapValue} that needs to be unwrapped when used
+ * A wrapper or marker for a Neo4j {@code org.neo4j.driver.internal.value.MapValue} that needs to be unwrapped when used
  * for properties.
  * This class exists solely for projection / filtering purposes: It allows the {@link DefaultNeo4jEntityConverter} to keep
  * the composite properties together as long as possible (in the form of above's {@code MapValue}. Thus, the key in the


### PR DESCRIPTION
The latest version of the Maven JavaDoc plugin and JavaDoc itself have been rightfully complaining that some pieces of SDN have been using internal API of the driver and Cypher-DSL which would not be available on the module-path.

This has been fixed. The schema-name support from Cypher-DSL is now a direct dependency and not relying on the shaded version any long.

Several issues in the `Neo4jSpelSupport` have been fixed along the way.
