### PR TITLE
Skip entity detection for converted properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
+	<version>7.3.0-GH-2869-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -16,6 +16,7 @@
 package org.springframework.data.neo4j.core.mapping;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.springframework.data.annotation.ReadOnlyProperty;
@@ -209,7 +210,13 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 	@Override
 	public boolean isEntity() {
-		return super.isEntity() && !isWritableProperty.get();
+		return super.isEntity() && !isWritableProperty.get() && !this.isAnnotationPresent(ConvertWith.class);
+	}
+
+	@Override
+	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypeInformation() {
+		return this.isAnnotationPresent(ConvertWith.class) ? Collections.emptyList()
+				: super.getPersistentEntityTypeInformation();
 	}
 
 	@Override
@@ -219,7 +226,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 	@Override
 	public Neo4jPersistentPropertyConverter<?> getOptionalConverter() {
-		return customConversion.getOptional()
+		return isEntity() ? null : customConversion.getOptional()
 				.map(Neo4jPersistentPropertyConverter.class::cast)
 				.orElse(null);
 	}

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntityTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntityTest.java
@@ -34,6 +34,7 @@ import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mapping.AssociationHandler;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.neo4j.core.convert.ConvertWith;
 import org.springframework.data.neo4j.core.schema.DynamicLabels;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
@@ -55,6 +56,16 @@ class DefaultNeo4jPersistentEntityTest {
 		Neo4jMappingContext neo4jMappingContext = new Neo4jMappingContext();
 		neo4jMappingContext.getPersistentEntity(CorrectEntity1.class);
 		neo4jMappingContext.getPersistentEntity(CorrectEntity2.class);
+	}
+
+	@Test
+	void skipsEntityTypeDetectionForConvertedProperties() {
+
+		Neo4jPersistentEntity<?> entity = new Neo4jMappingContext().getRequiredPersistentEntity(WithConvertedProperty.class);
+		Neo4jPersistentProperty property = entity.getRequiredPersistentProperty("converted");
+
+		assertThat(property.isEntity()).isFalse();
+		assertThat(property.getPersistentEntityTypeInformation()).isEmpty();
 	}
 
 	@Nested
@@ -729,5 +740,15 @@ class DefaultNeo4jPersistentEntityTest {
 		@SuppressWarnings("DefaultAnnotationParam")
 		@Property(readOnly = false)
 		private String writableProperty;
+	}
+
+	static class WithConvertedProperty {
+
+		@ConvertWith
+		IWillBeConverted converted;
+	}
+
+	static class IWillBeConverted {
+
 	}
 }


### PR DESCRIPTION
DefaultNeo4jPersistentProperty.isEntity() and getPersistentEntityTypeInformation() now return that the property does not map to an entity if a converter is registered.

Closes #2869