### PR TITLE
refactor: Move away from deprecated Cypher-DSL constructs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
 		<classgraph.version>4.8.149</classgraph.version>
-		<cypher-dsl.version>2023.2.0</cypher-dsl.version>
+		<cypher-dsl.version>2023.9.5</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
@@ -118,6 +118,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-cypher-dsl-bom</artifactId>
+				<version>${cypher-dsl.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
@@ -186,22 +193,6 @@
 				<groupId>org.neo4j</groupId>
 				<artifactId>neo4j</artifactId>
 				<version>${neo4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.neo4j</groupId>
-				<artifactId>neo4j-cypher-dsl</artifactId>
-				<version>${cypher-dsl.version}</version>
-				<exclusions>
-					<exclusion>
-						<artifactId>annotations</artifactId>
-						<groupId>org.jetbrains</groupId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.neo4j</groupId>
-				<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
-				<version>${cypher-dsl.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.neo4j.driver</groupId>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -43,7 +43,6 @@ import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.FunctionInvocation;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Named;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Statement;
@@ -190,7 +189,7 @@ public final class Neo4jTemplate implements
 	public long count(Class<?> domainType) {
 
 		Neo4jPersistentEntity<?> entityMetaData = neo4jMappingContext.getRequiredPersistentEntity(domainType);
-		Statement statement = cypherGenerator.prepareMatchOf(entityMetaData).returning(Functions.count(asterisk()))
+		Statement statement = cypherGenerator.prepareMatchOf(entityMetaData).returning(Cypher.count(asterisk()))
 				.build();
 
 		return count(statement);

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -20,7 +20,6 @@ import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.FunctionInvocation;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Named;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Statement;
@@ -179,7 +178,7 @@ public final class ReactiveNeo4jTemplate implements
 	public Mono<Long> count(Class<?> domainType) {
 
 		Neo4jPersistentEntity<?> entityMetaData = neo4jMappingContext.getRequiredPersistentEntity(domainType);
-		Statement statement = cypherGenerator.prepareMatchOf(entityMetaData).returning(Functions.count(asterisk())).build();
+		Statement statement = cypherGenerator.prepareMatchOf(entityMetaData).returning(Cypher.count(asterisk())).build();
 
 		return count(statement);
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
@@ -36,7 +36,6 @@ import java.util.stream.StreamSupport;
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.FunctionInvocation;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Named;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Relationship;
@@ -187,7 +186,7 @@ public final class TemplateSupport {
 		private final static String RELATED_NODE_IDS = "relatedNodeIds";
 
 		final static NodesAndRelationshipsByIdStatementProvider EMPTY =
-				new NodesAndRelationshipsByIdStatementProvider(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), new QueryFragments(), SpringDataCypherDsl.elementIdOrIdFunction.apply(Dialect.DEFAULT));
+				new NodesAndRelationshipsByIdStatementProvider(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), new QueryFragments(), SpringDataCypherDsl.elementIdOrIdFunction.apply(Dialect.NEO4J_4));
 
 		private final Map<String, Collection<String>> parameters = new HashMap<>(3);
 		private final QueryFragments queryFragments;
@@ -223,16 +222,16 @@ public final class TemplateSupport {
 			Relationship relationships = Cypher.anyNode().relationshipBetween(Cypher.anyNode()).named(RELATIONSHIP_IDS);
 			return Cypher.match(rootNodes)
 					.where(elementIdFunction.apply(rootNodes).in(Cypher.parameter(ROOT_NODE_IDS)))
-					.with(Functions.collect(rootNodes).as(Constants.NAME_OF_ROOT_NODE))
+					.with(Cypher.collect(rootNodes).as(Constants.NAME_OF_ROOT_NODE))
 					.optionalMatch(relationships)
 					.where(elementIdFunction.apply(relationships).in(Cypher.parameter(RELATIONSHIP_IDS)))
-					.with(Constants.NAME_OF_ROOT_NODE, Functions.collectDistinct(relationships).as(Constants.NAME_OF_SYNTHESIZED_RELATIONS))
+					.with(Constants.NAME_OF_ROOT_NODE, Cypher.collectDistinct(relationships).as(Constants.NAME_OF_SYNTHESIZED_RELATIONS))
 					.optionalMatch(relatedNodes)
 					.where(elementIdFunction.apply(relatedNodes).in(Cypher.parameter(RELATED_NODE_IDS)))
 					.with(
 							Constants.NAME_OF_ROOT_NODE,
 							Cypher.name(Constants.NAME_OF_SYNTHESIZED_RELATIONS).as(Constants.NAME_OF_SYNTHESIZED_RELATIONS),
-							Functions.collectDistinct(relatedNodes).as(Constants.NAME_OF_SYNTHESIZED_RELATED_NODES)
+							Cypher.collectDistinct(relatedNodes).as(Constants.NAME_OF_SYNTHESIZED_RELATED_NODES)
 					)
 					.unwind(Constants.NAME_OF_ROOT_NODE).as(ROOT_NODE_IDS)
 					.with(
@@ -431,7 +430,7 @@ public final class TemplateSupport {
 	}
 
 	static boolean rendererRendersElementId(Renderer renderer) {
-		return renderer.render(Cypher.returning(Functions.elementId(Cypher.anyNode("n"))).build())
+		return renderer.render(Cypher.returning(Cypher.elementId(Cypher.anyNode("n"))).build())
 				.equals("RETURN elementId(n)");
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/IdDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/IdDescription.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Expression;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.SymbolicName;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
@@ -99,7 +98,8 @@ public final class IdDescription {
 		this.idExpression = Lazy.of(() -> {
 			final Node rootNode = Cypher.anyNode(symbolicName);
 			if (this.isInternallyGeneratedId()) {
-				return isDeprecated ? Functions.id(rootNode) : Functions.elementId(rootNode);
+				//noinspection deprecation
+				return isDeprecated ? rootNode.internalId() : rootNode.elementId();
 			} else {
 				return this.getOptionalGraphPropertyName()
 						.map(propertyName -> Cypher.property(symbolicName, propertyName)).get();
@@ -121,7 +121,8 @@ public final class IdDescription {
 	public Expression asIdExpression(String nodeName) {
 		final Node rootNode = Cypher.anyNode(nodeName);
 		if (this.isInternallyGeneratedId()) {
-			return isDeprecated ? Functions.id(rootNode) : Functions.elementId(rootNode);
+			//noinspection deprecation
+			return isDeprecated ? rootNode.internalId() : rootNode.elementId();
 		} else {
 			return this.getOptionalGraphPropertyName()
 					.map(propertyName -> Cypher.property(nodeName, propertyName)).get();

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
@@ -16,8 +16,8 @@
 package org.springframework.data.neo4j.core.mapping;
 
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.FunctionInvocation;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Named;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Relationship;
@@ -39,14 +39,14 @@ public final class SpringDataCypherDsl {
 	public static Function<Dialect, Function<Named, FunctionInvocation>> elementIdOrIdFunction = dialect -> {
 		if (dialect == Dialect.NEO4J_5) {
 			return SpringDataCypherDsl::elementId;
-		} else if (dialect == Dialect.DEFAULT) {
+		} else if (dialect == Dialect.NEO4J_4) {
 			return SpringDataCypherDsl::id;
 		} else {
 			return named -> {
 				if (named instanceof Node node) {
-					return Functions.elementId(node);
+					return Cypher.elementId(node);
 				} else if (named instanceof Relationship relationship) {
-					return Functions.elementId(relationship);
+					return Cypher.elementId(relationship);
 				} else {
 					throw new IllegalArgumentException("Unsupported CypherDSL type: " + named.getClass());
 				}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
@@ -27,10 +27,8 @@ import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Expression;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.SortItem;
 import org.neo4j.cypherdsl.core.StatementBuilder;
 import org.neo4j.cypherdsl.core.SymbolicName;
@@ -104,7 +102,7 @@ public final class CypherAdapterUtils {
 			} else {
 				expression = property(root, graphProperty.getPropertyName());
 				if (order.isIgnoreCase()) {
-					expression = Functions.toLower(expression);
+					expression = Cypher.toLower(expression);
 				}
 			}
 			SortItem sortItem = Cypher.sort(expression);
@@ -141,11 +139,11 @@ public final class CypherAdapterUtils {
 
 		var root = Constants.NAME_OF_TYPED_ROOT_NODE.apply(entity);
 
-		var resultingCondition = Conditions.noCondition();
+		var resultingCondition = Cypher.noCondition();
 		// This is the next equality pair if previous sort key was equal
-		var nextEquals = Conditions.noCondition();
+		var nextEquals = Cypher.noCondition();
 		// This is the condition for when all the sort orderedKeys are equal, and we must filter via id
-		var allEqualsWithArtificialSort = Conditions.noCondition();
+		var allEqualsWithArtificialSort = Cypher.noCondition();
 
 		for (Map.Entry<String, Object> entry : orderedKeys.entrySet()) {
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
@@ -26,8 +26,7 @@ import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
-import org.neo4j.cypherdsl.core.Functions;
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.SortItem;
 import org.neo4j.cypherdsl.core.Statement;
 import org.springframework.data.domain.Page;
@@ -109,7 +108,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Conditions.noCondition(), Arrays.asList(sortItems))
+				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Cypher.noCondition(), Arrays.asList(sortItems))
 		).getResults();
 	}
 
@@ -129,7 +128,7 @@ public final class CypherdslConditionExecutorImpl<T> implements CypherdslConditi
 	public long count(Condition condition) {
 
 		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 		return this.neo4jOperations.count(statement, statement.getCatalog().getParameters());
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
@@ -30,9 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Expression;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.StatementBuilder;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
@@ -177,8 +176,8 @@ final class Predicate {
 			if (String.class.equals(graphProperty.getActualType())) {
 
 				if (matcherAccessor.isIgnoreCaseForPath(currentPath)) {
-					property = Functions.toLower(property);
-					parameter = Functions.toLower(parameter);
+					property = Cypher.toLower(property);
+					parameter = Cypher.toLower(parameter);
 				}
 
 				condition = switch (matcherAccessor.getStringMatcherForPath(currentPath)) {
@@ -206,7 +205,7 @@ final class Predicate {
 
 	private final Neo4jPersistentEntity neo4jPersistentEntity;
 
-	private Condition condition = Conditions.noCondition();
+	private Condition condition = Cypher.noCondition();
 
 	private final Map<String, Object> parameters = new HashMap<>();
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragments.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragments.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.PatternElement;
@@ -77,7 +76,7 @@ public final class QueryFragments {
 	}
 
 	public void setCondition(@Nullable Condition condition) {
-		this.condition = Optional.ofNullable(condition).orElse(Conditions.noCondition());
+		this.condition = Optional.ofNullable(condition).orElse(Cypher.noCondition());
 	}
 
 	public Condition getCondition() {

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
@@ -17,7 +17,6 @@ package org.springframework.data.neo4j.repository.query;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.PatternElement;
@@ -152,7 +151,7 @@ public final class QueryFragmentsAndParameters {
 	public static QueryFragmentsAndParameters forFindAll(Neo4jPersistentEntity<?> entityMetaData) {
 		QueryFragments queryFragments = new QueryFragments();
 		queryFragments.addMatchOn(cypherGenerator.createRootNode(entityMetaData));
-		queryFragments.setCondition(Conditions.noCondition());
+		queryFragments.setCondition(Cypher.noCondition());
 		queryFragments.setReturnExpressions(cypherGenerator.createReturnStatementForMatch(entityMetaData));
 		return new QueryFragmentsAndParameters(entityMetaData, queryFragments, Collections.emptyMap(), null);
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -22,8 +22,7 @@ import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
-import org.neo4j.cypherdsl.core.Functions;
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.SortItem;
 import org.neo4j.cypherdsl.core.Statement;
 import org.springframework.data.domain.Sort;
@@ -106,7 +105,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 
 		return this.neo4jOperations.toExecutableQuery(
 				this.metaData.getType(),
-				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Conditions.noCondition(),
+				QueryFragmentsAndParameters.forConditionAndSortItems(this.metaData, Cypher.noCondition(),
 						Arrays.asList(sortItems))
 		).flatMapMany(ReactiveNeo4jOperations.ExecutableQuery::getResults);
 	}
@@ -115,7 +114,7 @@ public final class ReactiveCypherdslConditionExecutorImpl<T> implements Reactive
 	public Mono<Long> count(Condition condition) {
 
 		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData, condition)
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 		return this.neo4jOperations.count(statement, statement.getCatalog().getParameters());
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
@@ -27,9 +27,7 @@ import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Condition;
-import org.neo4j.cypherdsl.core.Conditions;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.SortItem;
 import org.neo4j.cypherdsl.core.Statement;
 import org.reactivestreams.Publisher;
@@ -108,7 +106,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 	@Override
 	public Flux<T> findAll(OrderSpecifier<?>... orders) {
 
-		return doFindAll(Conditions.noCondition(), Arrays.asList(QuerydslNeo4jPredicateExecutor.toSortItems(orders)));
+		return doFindAll(Cypher.noCondition(), Arrays.asList(QuerydslNeo4jPredicateExecutor.toSortItems(orders)));
 	}
 
 	private Flux<T> doFindAll(Condition condition, Collection<SortItem> sortItems) {
@@ -124,7 +122,7 @@ public final class ReactiveQuerydslNeo4jPredicateExecutor<T> implements Reactive
 
 		Statement statement = CypherGenerator.INSTANCE.prepareMatchOf(this.metaData,
 						Cypher.adapt(predicate).asCondition())
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 		return this.neo4jOperations.count(statement, statement.getCatalog().getParameters());
 	}
 

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
@@ -16,7 +16,8 @@
 package org.springframework.data.neo4j.repository.query;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.Functions;
+
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Statement;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
@@ -95,7 +96,7 @@ public final class SimpleQueryByExampleExecutor<T> implements QueryByExampleExec
 
 		Predicate predicate = Predicate.create(mappingContext, example);
 		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 
 		return this.neo4jOperations.count(statement, predicate.getParameters());
 	}
@@ -105,7 +106,7 @@ public final class SimpleQueryByExampleExecutor<T> implements QueryByExampleExec
 
 		Predicate predicate = Predicate.create(mappingContext, example);
 		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 
 		return this.neo4jOperations.count(statement, predicate.getParameters()) > 0;
 	}

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
@@ -16,7 +16,8 @@
 package org.springframework.data.neo4j.repository.query;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.Functions;
+
+import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Statement;
 import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Example;
@@ -85,7 +86,7 @@ public final class SimpleReactiveQueryByExampleExecutor<T> implements ReactiveQu
 
 		Predicate predicate = Predicate.create(mappingContext, example);
 		Statement statement = predicate.useWithReadingFragment(cypherGenerator::prepareMatchOf)
-				.returning(Functions.count(asterisk())).build();
+				.returning(Cypher.count(asterisk())).build();
 
 		return this.neo4jOperations.count(statement, predicate.getParameters());
 	}

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 // tag::domain-results-impl[]
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 
 // end::domain-results-impl[]
 
@@ -89,7 +88,7 @@ class DomainResultsImpl implements DomainResults {
 		var p = shortestPath.getRequiredSymbolicName();
 		var statement = Cypher.match(shortestPath)
 				.with(p, listWith(name("n"))
-						.in(Functions.nodes(shortestPath))
+						.in(Cypher.nodes(shortestPath))
 						.where(anyNode().named("n").hasLabels("Movie")).returning().as("mn")
 				)
 				.unwind(name("mn")).as("m")
@@ -97,7 +96,7 @@ class DomainResultsImpl implements DomainResults {
 				.match(node("Person").named("d")
 						.relationshipTo(anyNode("m"), "DIRECTED").named("r")
 				)
-				.returning(p, Functions.collect(name("r")), Functions.collect(name("d")))
+				.returning(p, Cypher.collect(name("r")), Cypher.collect(name("d")))
 				.build();
 
 		Map<String, Object> parameters = new HashMap<>();

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
@@ -65,7 +65,7 @@ class Neo4jCdiExtensionIT {
 				return Configuration.newConfig().withDialect(Dialect.NEO4J_5).build();
 			}
 
-			return Configuration.newConfig().withDialect(Dialect.DEFAULT).build();
+			return Configuration.newConfig().withDialect(Dialect.NEO4J_4).build();
 		}
 	}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslStatementExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslStatementExecutorIT.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Relationship;
 import org.neo4j.cypherdsl.core.Statement;
@@ -86,8 +85,8 @@ class CypherdslStatementExecutorIT {
 				.where(p.property("firstName").isEqualTo(Cypher.anonParameter(name))) // <.>
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				)
 				.build();
 	}
@@ -100,8 +99,8 @@ class CypherdslStatementExecutorIT {
 		return Cypher.match(p).optionalMatch(r)
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				)
 				.orderBy(p.property("firstName").ascending())
 				.build();
@@ -114,8 +113,8 @@ class CypherdslStatementExecutorIT {
 		return Cypher.match(p).optionalMatch(r)
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				);
 	}
 
@@ -193,7 +192,7 @@ class CypherdslStatementExecutorIT {
 
 		Node person = Cypher.node("Person");
 		Page<Person> result = repository.findAll(
-				byCustomQueryWithoutOrder(), Cypher.match(person).returning(Functions.count(person)).build(),
+				byCustomQueryWithoutOrder(), Cypher.match(person).returning(Cypher.count(person)).build(),
 				PageRequest.of(1, 2, Sort.by("p.firstName").ascending())
 		);
 
@@ -209,7 +208,7 @@ class CypherdslStatementExecutorIT {
 
 		Node person = Cypher.node("Person");
 		Page<NamesOnly> result = repository.findAll(
-				byCustomQueryWithoutOrder(), Cypher.match(person).returning(Functions.count(person)).build(),
+				byCustomQueryWithoutOrder(), Cypher.match(person).returning(Cypher.count(person)).build(),
 				PageRequest.of(1, 2, Sort.by("p.firstName").ascending()),
 				NamesOnly.class
 		);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicLabelsIT.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 import org.neo4j.driver.Driver;
@@ -508,7 +507,7 @@ public class DynamicLabelsIT {
 		}
 
 		protected final List<String> getLabels(Long id) {
-			return getLabels(Functions.id(Cypher.anyNode().named("n")).isEqualTo(parameter("id")), id);
+			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(parameter("id")), id);
 		}
 
 		protected final List<String> getLabels(Condition idCondition, Object id) {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
@@ -18,7 +18,6 @@ package org.springframework.data.neo4j.integration.imperative;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.driver.Driver;
@@ -130,7 +129,7 @@ class Neo4jTemplateIT {
 	@Test
 	void countWithStatement() {
 		Node node = Cypher.node("PersonWithAllConstructor").named("n");
-		Statement statement = Cypher.match(node).returning(Functions.count(node)).build();
+		Statement statement = Cypher.match(node).returning(Cypher.count(node)).build();
 
 		assertThat(neo4jTemplate.count(statement)).isEqualTo(2);
 	}
@@ -139,7 +138,7 @@ class Neo4jTemplateIT {
 	void countWithStatementAndParameters() {
 		Node node = Cypher.node("PersonWithAllConstructor").named("n");
 		Statement statement = Cypher.match(node).where(node.property("name").isEqualTo(Cypher.parameter("name")))
-				.returning(Functions.count(node)).build();
+				.returning(Cypher.count(node)).build();
 
 		assertThat(neo4jTemplate.count(statement, Collections.singletonMap("name", TEST_PERSON1_NAME))).isEqualTo(1);
 	}

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Property;
 import org.neo4j.cypherdsl.core.Relationship;
@@ -102,8 +101,8 @@ class ReactiveCypherdslStatementExecutorIT {
 				.where(p.property("firstName").isEqualTo(Cypher.anonParameter(name)))
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				)
 				.build();
 	}
@@ -115,8 +114,8 @@ class ReactiveCypherdslStatementExecutorIT {
 		return Cypher.match(p).optionalMatch(r)
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				)
 				.orderBy(p.property("firstName").ascending())
 				.build();
@@ -129,8 +128,8 @@ class ReactiveCypherdslStatementExecutorIT {
 		return Cypher.match(p).optionalMatch(r)
 				.returning(
 						p.getRequiredSymbolicName(),
-						Functions.collect(r),
-						Functions.collect(a)
+						Cypher.collect(r),
+						Cypher.collect(a)
 				);
 	}
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -17,7 +17,6 @@ package org.springframework.data.neo4j.integration.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.driver.TransactionContext;
 import org.junit.jupiter.api.RepeatedTest;
 import org.neo4j.driver.reactive.ReactiveSession;
@@ -471,8 +470,9 @@ public class ReactiveDynamicLabelsIT {
 			}
 		}
 
+		@SuppressWarnings("deprecation")
 		protected final Flux<String> getLabels(Long id) {
-			return getLabels(Functions.id(Cypher.anyNode().named("n")).isEqualTo(Cypher.parameter("id")), id);
+			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(Cypher.parameter("id")), id);
 		}
 
 		protected final Flux<String> getLabels(Condition idCondition, Object id) {

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
@@ -261,17 +261,17 @@ class ReactiveNeo4jClientIT {
 		}
 
 		Query createQuery() {
-			return new Query(this.delegate.getCypher(), this.delegate.getParameters());
+			return new Query(this.delegate.getCypher(), this.delegate.getCatalog().getParameters());
 		}
 
 		@Override
 		public Map<String, Object> getParameters() {
-			return this.delegate.getParameters();
+			return this.delegate.getCatalog().getParameters();
 		}
 
 		@Override
 		public Collection<String> getParameterNames() {
-			return this.delegate.getParameterNames();
+			return this.delegate.getCatalog().getParameterNames();
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.driver.Driver;
@@ -150,7 +149,7 @@ class ReactiveNeo4jTemplateIT {
 	@Test
 	void countWithStatement() {
 		Node node = Cypher.node("PersonWithAllConstructor").named("n");
-		Statement statement = Cypher.match(node).returning(Functions.count(node)).build();
+		Statement statement = Cypher.match(node).returning(Cypher.count(node)).build();
 
 		StepVerifier.create(neo4jTemplate.count(statement)).assertNext(count -> assertThat(count).isEqualTo(2))
 				.verifyComplete();
@@ -160,7 +159,7 @@ class ReactiveNeo4jTemplateIT {
 	void countWithStatementAndParameters() {
 		Node node = Cypher.node("PersonWithAllConstructor").named("n");
 		Statement statement = Cypher.match(node).where(node.property("name").isEqualTo(parameter("name")))
-				.returning(Functions.count(node)).build();
+				.returning(Cypher.count(node)).build();
 
 		StepVerifier.create(neo4jTemplate.count(statement, Collections.singletonMap("name", TEST_PERSON1_NAME)))
 				.assertNext(count -> assertThat(count).isEqualTo(1)).verifyComplete();

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.provider.Arguments;
 import org.neo4j.cypherdsl.core.Cypher;
-import org.neo4j.cypherdsl.core.Functions;
+
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.ResultStatement;
 import org.neo4j.cypherdsl.core.executables.ExecutableStatement;
@@ -136,7 +136,8 @@ abstract class TestBase {
 			if (isExternal) {
 				statement = Cypher.create(nodeTemplate).returning(nodeTemplate.property("id")).build();
 			} else {
-				statement = Cypher.create(nodeTemplate).returning(Functions.id(nodeTemplate)).build();
+				//noinspection deprecation
+				statement = Cypher.create(nodeTemplate).returning(nodeTemplate.internalId()).build();
 			}
 
 			long id = ExecutableStatement.makeExecutable(statement).fetchWith(tx).get(0).get(0).asLong();
@@ -173,10 +174,11 @@ abstract class TestBase {
 						.returning(n1.property("id"), n2.property("id"))
 						.build();
 			} else {
+				//noinspection deprecation
 				statement = Cypher.create(n1).create(n2)
 						.merge(n1.relationshipTo(n2, "RELATED"))
 						.merge(n2.relationshipTo(n1, "RELATED"))
-						.returning(Functions.id(n1), Functions.id(n2))
+						.returning(n1.internalId(), n2.internalId())
 						.build();
 			}
 
@@ -257,9 +259,9 @@ abstract class TestBase {
 		Node nodeTemplate = Cypher.node(type.getSimpleName());
 		Node n1 = nodeTemplate.named("n1");
 		Node n2 = nodeTemplate.named("n2");
-		ResultStatement statement =
+		@SuppressWarnings("deprecation") ResultStatement statement =
 				Cypher.match(n1.relationshipTo(n2, "RELATED"))
-						.where(Functions.id(n1).isEqualTo(Cypher.anonParameter(id))
+						.where(n1.internalId().isEqualTo(Cypher.anonParameter(id))
 								.and(n2.relationshipTo(n1, "RELATED")))
 						.returning(n1.property("version")).build();
 


### PR DESCRIPTION
All relevant Cypher integrations is available on `Cypher` for a while now.
To be able to remove them in Cypher-DSL 2024.0.0, we must make sure they are not used here anymore, as Cypher-DSL has a couple of integration tests with SDN6.
Also, leading by example is always nice.
