### PR TITLE
feat: Allow cascading updates to be disabled.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
 		<springdata.commons>3.3.0-SNAPSHOT</springdata.commons>
+		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
 	<dependencyManagement>
@@ -133,6 +134,11 @@
 				<artifactId>junit-jupiter-causal-cluster-testcontainer-extension</artifactId>
 				<version>${junit-cc-testcontainer}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit-pioneer</groupId>
+				<artifactId>junit-pioneer</artifactId>
+				<version>${junit-pioneer.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.github.classgraph</groupId>
@@ -448,6 +454,11 @@
 		<dependency>
 			<groupId>io.projectreactor.tools</groupId>
 			<artifactId>blockhound</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit-pioneer</groupId>
+			<artifactId>junit-pioneer</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -891,8 +891,7 @@ public final class Neo4jTemplate implements
 				// here a map entry is not always anymore a dynamic association
 				Object relatedObjectBeforeCallbacksApplied = relationshipContext.identifyAndExtractRelationshipTargetNode(relatedValueToStore);
 				Neo4jPersistentEntity<?> targetEntity = neo4jMappingContext.getRequiredPersistentEntity(relatedObjectBeforeCallbacksApplied.getClass());
-
-				boolean isEntityNew = targetEntity.isNew(relatedObjectBeforeCallbacksApplied);
+				boolean isNewEntity = targetEntity.isNew(relatedObjectBeforeCallbacksApplied);
 
 				Object newRelatedObject = stateMachine.hasProcessedValue(relatedObjectBeforeCallbacksApplied)
 						? stateMachine.getProcessedAs(relatedObjectBeforeCallbacksApplied)
@@ -904,7 +903,7 @@ public final class Neo4jTemplate implements
 				if (stateMachine.hasProcessedValue(relatedValueToStore)) {
 					relatedInternalId = stateMachine.getObjectId(relatedValueToStore);
 				} else {
-					if (isEntityNew || relationshipDescription.cascadeUpdates()) {
+					if (isNewEntity || relationshipDescription.cascadeUpdates()) {
 						savedEntity = saveRelatedNode(newRelatedObject, targetEntity, includeProperty, currentPropertyPath);
 					} else {
 						var targetPropertyAccessor = targetEntity.getPropertyAccessor(newRelatedObject);
@@ -994,7 +993,7 @@ public final class Neo4jTemplate implements
 				}
 
 				if (processState != ProcessState.PROCESSED_ALL_VALUES) {
-					processNestedRelations(targetEntity, targetPropertyAccessor, isEntityNew, stateMachine, includeProperty, currentPropertyPath);
+					processNestedRelations(targetEntity, targetPropertyAccessor, isNewEntity, stateMachine, includeProperty, currentPropertyPath);
 				}
 
 				Object potentiallyRecreatedNewRelatedObject = MappingSupport.getRelationshipOrRelationshipPropertiesObject(neo4jMappingContext,

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -752,6 +752,12 @@ public enum CypherGenerator {
 		return returnExpressions;
 	}
 
+
+	public StatementBuilder.OngoingReading prepareFindOf(NodeDescription<?> nodeDescription, @Nullable List<PatternElement> initialMatchOn, @Nullable Condition condition) {
+		var rootNode = createRootNode(nodeDescription);
+		return prepareMatchOfRootNode(rootNode, initialMatchOn).where(conditionOrNoCondition(condition));
+	}
+
 	private MapProjection projectPropertiesAndRelationships(PropertyFilter.RelaxedPropertyPath parentPath, Neo4jPersistentEntity<?> nodeDescription, SymbolicName nodeName,
 															Predicate<PropertyFilter.RelaxedPropertyPath> includedProperties, @Nullable RelationshipDescription relationshipDescription, List<RelationshipDescription> processedRelationships) {
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -169,7 +169,7 @@ final class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProp
 
 		DefaultRelationshipDescription relationshipDescription = new DefaultRelationshipDescription(this,
 				obverseRelationshipDescription.orElse(null), type, dynamicAssociation, (NodeDescription<?>) getOwner(),
-				this.getName(), obverseOwner, direction, relationshipPropertiesClass);
+				this.getName(), obverseOwner, direction, relationshipPropertiesClass, relationship == null || relationship.cascadeUpdates());
 
 		// Update the previous found, if any, relationship with the newly created one as its counterpart.
 		obverseRelationshipDescription

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultRelationshipDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultRelationshipDescription.java
@@ -44,9 +44,12 @@ final class DefaultRelationshipDescription extends Association<Neo4jPersistentPr
 
 	private RelationshipDescription relationshipObverse;
 
+	private final boolean cascadeUpdates;
+
 	DefaultRelationshipDescription(Neo4jPersistentProperty inverse, @Nullable RelationshipDescription relationshipObverse,
 			String type, boolean dynamic, NodeDescription<?> source, String fieldName, NodeDescription<?> target,
-			Relationship.Direction direction, @Nullable NodeDescription<?> relationshipProperties) {
+			Relationship.Direction direction, @Nullable NodeDescription<?> relationshipProperties,
+			boolean cascadeUpdates) {
 
 		// the immutable obverse association-wise is always null because we cannot determine them on both sides
 		// if we consider to support bidirectional relationships.
@@ -60,6 +63,7 @@ final class DefaultRelationshipDescription extends Association<Neo4jPersistentPr
 		this.target = target;
 		this.direction = direction;
 		this.relationshipPropertiesClass = relationshipProperties;
+		this.cascadeUpdates = cascadeUpdates;
 	}
 
 	@Override
@@ -115,6 +119,11 @@ final class DefaultRelationshipDescription extends Association<Neo4jPersistentPr
 	@Override
 	public boolean hasRelationshipObverse() {
 		return this.relationshipObverse != null;
+	}
+
+	@Override
+	public boolean cascadeUpdates() {
+		return cascadeUpdates;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/RelationshipDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/RelationshipDescription.java
@@ -138,4 +138,9 @@ public interface RelationshipDescription {
 	 * @return true if a logically same relationship in the target entity exists, otherwise false.
 	 */
 	boolean hasRelationshipObverse();
+
+	/**
+	 * {@return true if updates should be cascaded along this relationship}
+	 */
+	boolean cascadeUpdates();
 }

--- a/src/main/java/org/springframework/data/neo4j/core/schema/Relationship.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/Relationship.java
@@ -82,4 +82,13 @@ public @interface Relationship {
 	 * @return The direction of the relationship.
 	 */
 	Direction direction() default Direction.OUTGOING;
+
+	/**
+	 * Set this attribute to {@literal false} if you don't want updates on an aggregate root to be cascaded to related objects.
+	 * Be aware that in this case you are responsible to manually save the related objects and that you might end up with a local
+	 * object graph that is not in sync with the actual graph.
+	 *
+	 * @return whether updates to the owning instance should be cascaded to the related objects
+	 */
+	boolean cascadeUpdates() default true;
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.types.TypeSystem;
+import org.springframework.beans.factory.annotation.Autowired;
+
+abstract class AbstractCascadingTestBase {
+
+	@Autowired
+	Driver driver;
+
+	static Map<Class<? extends Parent>, String> EXISTING_IDS = new HashMap<>();
+
+	@BeforeAll
+	static void clean(@Autowired Driver driver) {
+
+		EXISTING_IDS.clear();
+		driver.executableQuery("MATCH (n) DETACH DELETE n").execute();
+		for (Class<? extends Parent> type : List.of(PUI.class, PUE.class, PVI.class, PVE.class)) {
+			var label = type.getSimpleName();
+			var id = "";
+			var idReturn = "elementId(p) AS id";
+			var version = "";
+			if (ExternalId.class.isAssignableFrom(type)) {
+				id = "SET p.id = randomUUID()";
+				idReturn = "p.id AS id";
+			}
+			if (Versioned.class.isAssignableFrom(type)) {
+				version = "SET p.version = 1";
+
+			}
+			var newId = driver.executableQuery("""
+					WITH 'ParentDB' AS name
+					CREATE (p:%s {id: randomUUID(), name: name})
+					%s
+					%s
+					CREATE (p) -[:HAS_SINGLE_CUI]-> (sCUI:CUI {name: name + '.singleCUI'})
+					CREATE (p) -[:HAS_SINGLE_CUE]-> (sCUE:CUE {name: name + '.singleCUE', id: randomUUID()})
+					CREATE (p) -[:HAS_MANY_CUI]->   (mCUI1:CUI {name: name + '.cUI1'})
+					CREATE (p) -[:HAS_MANY_CUI]->   (mCUI2:CUI {name: name + '.cUI2'})
+					CREATE (p) -[:HAS_SINGLE_CVI]-> (sCVI:CVI {name: name + '.singleCVI', version: 0})
+					CREATE (p) -[:HAS_SINGLE_CVE]-> (sCVE:CVE {name: name + '.singleCVE', version: 0, id: randomUUID()})
+					CREATE (p) -[:HAS_MANY_CVI]->   (mCVI1:CVI {name: name + '.cVI1', version: 0})
+					CREATE (p) -[:HAS_MANY_CVI]->   (mCVI2:CVI {name: name + '.cVI2', version: 0})
+					CREATE (sCUI) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.singleCUI.c1'})
+					CREATE (sCUI) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.singleCUI.c2'})
+					CREATE (mCUI1) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI1.cc1'})
+					CREATE (mCUI1) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI1.cc2'})
+					CREATE (mCUI2) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI2.cc1'})
+					CREATE (mCUI2) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI2.cc2'})
+					RETURN %s
+					""".formatted(label, id, version, idReturn)).execute().records().get(0).get("id").asString();
+			EXISTING_IDS.put(type, newId);
+		}
+	}
+
+
+	<T extends Parent> void assertAllRelationshipsHaveBeenCreated(T instance) {
+
+		var type = instance.getClass();
+		try (var session = driver.session()) {
+			var result = session.run("""
+							MATCH (p:%s WHERE %s)
+							MATCH (p) -[:HAS_SINGLE_CUI]-> (sCUI)
+							MATCH (p) -[:HAS_SINGLE_CUE]-> (sCUE)
+							MATCH (p) -[:HAS_MANY_CUI]->   (mCUI)
+							MATCH (p) -[:HAS_SINGLE_CVI]-> (sCVI {version: 0})
+							MATCH (p) -[:HAS_SINGLE_CVE]-> (sCVE {version: 0})
+							MATCH (p) -[:HAS_MANY_CVI]->    (mCVI {version: 0})
+							MATCH (sCUI) -[:HAS_NESTED_CHILDREN]-> (nc1)
+							MATCH (mCUI) -[:HAS_NESTED_CHILDREN]-> (nc2)
+							RETURN p, sCUI, sCUE, collect(DISTINCT mCUI) AS mCUI, collect(DISTINCT nc1) AS nc1, collect(DISTINCT nc2) AS nc2,
+							          sCVI, sCVE, collect(DISTINCT mCVI) AS mCVI
+							""".formatted(type.getSimpleName(), instance instanceof ExternalId ? "p.id = $id" : "elementId(p) = $id"), Map.of("id", instance.getId()))
+					.list();
+
+			assertThat(result).hasSize(1).element(0)
+					.satisfies(r -> {
+						if (instance instanceof Versioned) {
+							assertThat(r.get("p").asNode().get("version").asLong()).isZero();
+						}
+						if (instance instanceof ExternalId) {
+							assertThat(r.get("p").asNode().get("id").asString()).isEqualTo(instance.getId());
+						} else {
+							assertThat(r.get("p").asNode().elementId()).isEqualTo(instance.getId());
+						}
+						assertThat(r.get("sCUI").hasType(TypeSystem.getDefault().NODE())).isTrue();
+						assertThat(r.get("sCUE").hasType(TypeSystem.getDefault().NODE())).isTrue();
+						assertThat(r.get("mCUI").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.cUI1", "Parent.cUI2");
+						assertThat(r.get("nc1").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.singleCUI.cc1", "Parent.singleCUI.cc2");
+						assertThat(r.get("nc2").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.cUI1.cc1", "Parent.cUI1.cc2", "Parent.cUI2.cc1", "Parent.cUI2.cc2");
+						assertThat(r.get("sCVI").asNode().get("version").asLong()).isZero();
+						assertThat(r.get("sCVE").asNode().get("version").asLong()).isZero();
+						assertThat(r.get("mCVI").asList(v -> {
+							var node = v.asNode();
+							return node.get("name").asString() + "." + node.get("version").asLong();
+						}))
+								.containsExactlyInAnyOrder("Parent.cVI1.0", "Parent.cVI2.0");
+					});
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.support.UUIDStringGenerator;
+
+/**
+ * Children / Unversioned / Externally generated id
+ */
+public class CUE implements ExternalId {
+
+	@Id
+	@GeneratedValue(UUIDStringGenerator.class)
+	private String id;
+
+	private String name;
+
+	@Relationship("HAS_NESTED_CHILDREN")
+	private List<CUE> nested;
+
+	public CUE(String name) {
+		this.name = name;
+		this.nested = List.of(
+				new CUE(name + ".cc1", List.of()),
+				new CUE(name + ".cc2", List.of())
+		);
+	}
+
+	public CUE(String name, List<CUE> nested) {
+		this.name = name;
+		this.nested = nested;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.integration.cascading;
 
 import java.util.List;
 
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Relationship;
@@ -44,6 +45,7 @@ public class CUE implements ExternalId {
 		);
 	}
 
+	@PersistenceCreator
 	public CUE(String name, List<CUE> nested) {
 		this.name = name;
 		this.nested = nested;
@@ -55,5 +57,9 @@ public class CUE implements ExternalId {
 
 	public String getName() {
 		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+/**
+ * Children / Unversioned / Internally generated id
+ */
+public class CUI {
+
+	@Id
+	@GeneratedValue
+	private String id;
+
+	private String name;
+
+	@Relationship("HAS_NESTED_CHILDREN")
+	private List<CUI> nested;
+
+	public CUI(String name) {
+		this.name = name;
+		this.nested = List.of(
+				new CUI(name + ".cc1", List.of()),
+				new CUI(name + ".cc2", List.of())
+				);
+	}
+
+	public CUI(String name, List<CUI> nested) {
+		this.name = name;
+		this.nested = nested;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
@@ -17,6 +17,7 @@ package org.springframework.data.neo4j.integration.cascading;
 
 import java.util.List;
 
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Relationship;
@@ -32,7 +33,7 @@ public class CUI {
 
 	private String name;
 
-	@Relationship("HAS_NESTED_CHILDREN")
+	@Relationship(value = "HAS_NESTED_CHILDREN", cascadeUpdates = false)
 	private List<CUI> nested;
 
 	public CUI(String name) {
@@ -43,6 +44,7 @@ public class CUI {
 				);
 	}
 
+	@PersistenceCreator
 	public CUI(String name, List<CUI> nested) {
 		this.name = name;
 		this.nested = nested;
@@ -54,5 +56,13 @@ public class CUI {
 
 	public String getName() {
 		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<CUI> getNested() {
+		return nested;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CVE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CVE.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import org.springframework.data.annotation.Version;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.support.UUIDStringGenerator;
+
+/**
+ * Children / Unversioned / Externally generated id
+ */
+public class CVE implements Versioned, ExternalId {
+
+	@Id
+	@GeneratedValue(UUIDStringGenerator.class)
+	private String id;
+
+	@Version
+	private Long version;
+
+	private String name;
+
+	public CVE(String name) {
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CVI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CVI.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import org.springframework.data.annotation.Version;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+
+/**
+ * Children / Unversioned / Internally generated id
+ */
+public class CVI implements Versioned {
+
+	@Id
+	@GeneratedValue
+	private String id;
+
+	@Version
+	private Long version;
+
+	private String name;
+
+	public CVI(String name) {
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.types.TypeSystem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.core.Neo4jTemplate;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
+import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Neo4jIntegrationTest
+class CascadingIT {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	@Configuration
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	@ComponentScan
+	static class Config extends Neo4jImperativeTestConfiguration {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		public boolean isCypher5Compatible() {
+			return neo4jConnectionSupport.isCypher5SyntaxCompatible();
+		}
+	}
+
+	@Autowired
+	private Neo4jTemplate template;
+
+	@Autowired
+	private Driver driver;
+
+	@BeforeAll
+	static void clean(@Autowired Driver driver) {
+		driver.executableQuery("MATCH (n) DETACH DELETE n").execute();
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {PUI.class, PUE.class, PVI.class, PVE.class})
+	<T extends Parent> void newItemsMustBePersistedRegardlessOfCascadeSingleSave(Class<T> type) throws Exception {
+
+		T instance = template.save(type.getDeclaredConstructor(String.class).newInstance("Parent"));
+
+		try (var session = driver.session()) {
+			var result = session.run("""
+							MATCH (p:%s)
+							MATCH (p) -[:HAS_SINGLE_CUI]-> (sCUI)
+							MATCH (p) -[:HAS_SINGLE_CUE]-> (sCUE)
+							MATCH (p) -[:HAS_MANY_CUI]->   (mCUI)
+							MATCH (p) -[:HAS_SINGLE_CVI]-> (sCVI)
+							MATCH (p) -[:HAS_SINGLE_CVE]-> (sCVE)
+							MATCH (p) -[:HAS_MANY_CVI]->    (mCVI)
+							MATCH (sCUI) -[:HAS_NESTED_CHILDREN]-> (nc1)
+							MATCH (mCUI) -[:HAS_NESTED_CHILDREN]-> (nc2)
+							RETURN p, sCUI, sCUE, collect(DISTINCT mCUI) AS mCUI, collect(DISTINCT nc1) AS nc1, collect(DISTINCT nc2) AS nc2,
+							          sCVI, sCVE, collect(DISTINCT mCVI) AS mCVI
+							""".formatted(type.getSimpleName()))
+					.list();
+
+			assertThat(result).hasSize(1).element(0)
+					.satisfies(r -> {
+						if (instance instanceof Versioned) {
+							assertThat(r.get("p").asNode().get("version").asLong()).isZero();
+						}
+						if (instance instanceof ExternalId) {
+							assertThat(r.get("p").asNode().get("id").asString()).isEqualTo(instance.getId());
+						} else {
+							assertThat(r.get("p").asNode().elementId()).isEqualTo(instance.getId());
+						}
+						assertThat(r.get("sCUI").hasType(TypeSystem.getDefault().NODE())).isTrue();
+						assertThat(r.get("sCUE").hasType(TypeSystem.getDefault().NODE())).isTrue();
+						assertThat(r.get("mCUI").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.cUI1", "Parent.cUI2");
+						assertThat(r.get("nc1").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.singleCUI.cc1", "Parent.singleCUI.cc2");
+						assertThat(r.get("nc2").asList(v -> v.asNode().get("name").asString()))
+								.containsExactlyInAnyOrder("Parent.cUI1.cc1", "Parent.cUI1.cc2", "Parent.cUI2.cc1", "Parent.cUI2.cc2");
+						assertThat(r.get("sCVI").asNode().get("version").asLong()).isZero();
+						assertThat(r.get("sCVE").asNode().get("version").asLong()).isZero();
+						assertThat(r.get("mCVI").asList(v -> {
+							var node = v.asNode();
+							return node.get("name").asString() + "." + node.get("version").asLong();
+						}))
+								.containsExactlyInAnyOrder("Parent.cVI1.0", "Parent.cVI2.0");
+					});
+		}
+	}
+
+	// Left todo
+	// write actual code
+	// Test that the update doesn't update
+	// just the reactive part
+	// and the circles, done.
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
@@ -17,6 +17,10 @@ package org.springframework.data.neo4j.integration.cascading;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -61,9 +65,78 @@ class CascadingIT {
 	@Autowired
 	private Driver driver;
 
+	private static Map<Class<? extends Parent>, String> ids = new HashMap<>();
+
 	@BeforeAll
 	static void clean(@Autowired Driver driver) {
+
+		ids.clear();
 		driver.executableQuery("MATCH (n) DETACH DELETE n").execute();
+		for (Class<? extends Parent> type : List.of(PUI.class, PUE.class, PVI.class, PVE.class)) {
+			var label = type.getSimpleName();
+			var id = "";
+			var idReturn = "elementId(p) AS id";
+			var version = "";
+			if (ExternalId.class.isAssignableFrom(type)) {
+				id = "SET p.id = randomUUID()";
+				idReturn = "p.id AS id";
+			}
+			if (Versioned.class.isAssignableFrom(type)) {
+				version = "SET p.version = 1";
+
+			}
+			var newId = driver.executableQuery("""
+					WITH 'ParentDB' AS name
+					CREATE (p:%s {id: randomUUID(), name: name})
+					%s
+					%s
+					CREATE (p) -[:HAS_SINGLE_CUI]-> (sCUI:CUI {name: name + '.singleCUI'})
+					CREATE (p) -[:HAS_SINGLE_CUE]-> (sCUE:CUE {name: name + '.singleCUE', id: randomUUID()})
+					CREATE (p) -[:HAS_MANY_CUI]->   (mCUI1:CUI {name: name + '.cUI1'})
+					CREATE (p) -[:HAS_MANY_CUI]->   (mCUI2:CUI {name: name + '.cUI2'})
+					CREATE (p) -[:HAS_SINGLE_CVI]-> (sCVI:CVI {name: name + '.singleCVI', version: 0})
+					CREATE (p) -[:HAS_SINGLE_CVE]-> (sCVE:CVE {name: name + '.singleCVE', version: 0, id: randomUUID()})
+					CREATE (p) -[:HAS_MANY_CVI]->   (mCVI1:CVI {name: name + '.cVI1', version: 0})
+					CREATE (p) -[:HAS_MANY_CVI]->   (mCVI2:CVI {name: name + '.cVI2', version: 0})
+					CREATE (sCUI) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.singleCUI.c1'})
+					CREATE (sCUI) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.singleCUI.c2'})
+					CREATE (mCUI1) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI1.cc1'})
+					CREATE (mCUI1) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI1.cc2'})
+					CREATE (mCUI2) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI2.cc1'})
+					CREATE (mCUI2) -[:HAS_NESTED_CHILDREN]-> (:CUI {name: name + '.cUI2.cc2'})
+					RETURN %s
+					""".formatted(label, id, version, idReturn)).execute().records().get(0).get("id").asString();
+			ids.put(type, newId);
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {PUI.class, PUE.class, PVI.class, PVE.class})
+	<T extends Parent> void updatesMustNotCascade(Class<T> type) {
+
+		var id = ids.get(type);
+		var instance = this.template.findById(id, type).orElseThrow();
+
+		instance.setName("Updated parent");
+		instance.getSingleCUE().setName("Updated single CUE");
+		instance.getSingleCUI().setName("Updated single CUI");
+		instance.getManyCUI().forEach(cui -> {
+			cui.setName(cui.getName() + ".updatedNested1");
+			cui.getNested().forEach(nested -> nested.setName(nested + ".updatedNested2"));
+		});
+
+		this.template.save(instance);
+
+		// Can't assert on the instance above, as that would ofc be the purposefully modified state
+		var reloadedInstance = this.template.findById(id, type).orElseThrow();
+		assertThat(reloadedInstance.getName()).isEqualTo("Updated parent");
+
+		assertThat(reloadedInstance.getSingleCUE().getName()).isEqualTo("ParentDB.singleCUE");
+		assertThat(reloadedInstance.getSingleCUI().getName()).isEqualTo("ParentDB.singleCUI");
+		assertThat(reloadedInstance.getSingleCVE().getVersion()).isZero();
+		assertThat(reloadedInstance.getSingleCVI().getVersion()).isZero();
+		assertThat(reloadedInstance.getManyCUI()).allMatch(cui -> cui.getName().endsWith(".updatedNested1") && cui.getNested().stream().noneMatch(nested -> nested.getName().endsWith(".updatedNested2")));
+		assertThat(reloadedInstance.getManyCVI()).allMatch(cvi -> cvi.getVersion() == 0L);
 	}
 
 	@ParameterizedTest
@@ -74,18 +147,18 @@ class CascadingIT {
 
 		try (var session = driver.session()) {
 			var result = session.run("""
-							MATCH (p:%s)
+							MATCH (p:%s WHERE %s)
 							MATCH (p) -[:HAS_SINGLE_CUI]-> (sCUI)
 							MATCH (p) -[:HAS_SINGLE_CUE]-> (sCUE)
 							MATCH (p) -[:HAS_MANY_CUI]->   (mCUI)
-							MATCH (p) -[:HAS_SINGLE_CVI]-> (sCVI)
-							MATCH (p) -[:HAS_SINGLE_CVE]-> (sCVE)
-							MATCH (p) -[:HAS_MANY_CVI]->    (mCVI)
+							MATCH (p) -[:HAS_SINGLE_CVI]-> (sCVI {version: 0})
+							MATCH (p) -[:HAS_SINGLE_CVE]-> (sCVE {version: 0})
+							MATCH (p) -[:HAS_MANY_CVI]->    (mCVI {version: 0})
 							MATCH (sCUI) -[:HAS_NESTED_CHILDREN]-> (nc1)
 							MATCH (mCUI) -[:HAS_NESTED_CHILDREN]-> (nc2)
 							RETURN p, sCUI, sCUE, collect(DISTINCT mCUI) AS mCUI, collect(DISTINCT nc1) AS nc1, collect(DISTINCT nc2) AS nc2,
 							          sCVI, sCVE, collect(DISTINCT mCVI) AS mCVI
-							""".formatted(type.getSimpleName()))
+							""".formatted(type.getSimpleName(), instance instanceof ExternalId ? "p.id = $id" : "elementId(p) = $id"), Map.of("id", instance.getId()))
 					.list();
 
 			assertThat(result).hasSize(1).element(0)

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/ExternalId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/ExternalId.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+/**
+ * Marker for external id.
+ */
+public interface ExternalId {
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.support.UUIDStringGenerator;
+
+/**
+ * Parent / Unversioned / Externally generated id
+ */
+@Node
+public class PUE implements Parent, ExternalId {
+
+	@Id
+	@GeneratedValue(UUIDStringGenerator.class)
+	private String id;
+
+	private String name;
+
+	@Relationship("HAS_SINGLE_CUI")
+	private CUI singleCUI;
+
+	@Relationship("HAS_SINGLE_CUE")
+	private CUE singleCUE;
+
+	@Relationship("HAS_MANY_CUI")
+	private List<CUI> manyCUI;
+
+	@Relationship("HAS_SINGLE_CVI")
+	private CVI singleCVI;
+
+	@Relationship("HAS_SINGLE_CVE")
+	private CVE singleCVE;
+
+	@Relationship("HAS_MANY_CVI")
+	private List<CVI> manyCVI;
+
+	public PUE(String name) {
+		this.name = name;
+		this.singleCUI = new CUI(name + ".singleCUI");
+		this.singleCUE = new CUE(name + ".singleCUE");
+		this.manyCUI = List.of(
+				new CUI(name + ".cUI1"),
+				new CUI(name + ".cUI2")
+		);
+		this.singleCVI = new CVI(name + ".singleCVI");
+		this.singleCVE = new CVE(name + ".singleCVE");
+		this.manyCVI = List.of(
+				new CVI(name + ".cVI1"),
+				new CVI(name + ".cVI2")
+		);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
@@ -35,22 +35,22 @@ public class PUE implements Parent, ExternalId {
 
 	private String name;
 
-	@Relationship("HAS_SINGLE_CUI")
+	@Relationship(value = "HAS_SINGLE_CUI", cascadeUpdates = false)
 	private CUI singleCUI;
 
-	@Relationship("HAS_SINGLE_CUE")
+	@Relationship(value = "HAS_SINGLE_CUE", cascadeUpdates = false)
 	private CUE singleCUE;
 
 	@Relationship("HAS_MANY_CUI")
 	private List<CUI> manyCUI;
 
-	@Relationship("HAS_SINGLE_CVI")
+	@Relationship(value = "HAS_SINGLE_CVI", cascadeUpdates = false)
 	private CVI singleCVI;
 
-	@Relationship("HAS_SINGLE_CVE")
+	@Relationship(value = "HAS_SINGLE_CVE", cascadeUpdates = false)
 	private CVE singleCVE;
 
-	@Relationship("HAS_MANY_CVI")
+	@Relationship(value = "HAS_MANY_CVI", cascadeUpdates = false)
 	private List<CVI> manyCVI;
 
 	public PUE(String name) {
@@ -75,5 +75,40 @@ public class PUE implements Parent, ExternalId {
 
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public List<CUI> getManyCUI() {
+		return manyCUI;
+	}
+
+	@Override
+	public List<CVI> getManyCVI() {
+		return manyCVI;
+	}
+
+	@Override
+	public CUE getSingleCUE() {
+		return singleCUE;
+	}
+
+	@Override
+	public CUI getSingleCUI() {
+		return singleCUI;
+	}
+
+	@Override
+	public CVE getSingleCVE() {
+		return singleCVE;
+	}
+
+	@Override
+	public CVI getSingleCVI() {
+		return singleCVI;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
@@ -34,22 +34,22 @@ public class PUI implements Parent {
 
 	private String name;
 
-	@Relationship("HAS_SINGLE_CUI")
+	@Relationship(value = "HAS_SINGLE_CUI", cascadeUpdates = false)
 	private CUI singleCUI;
 
-	@Relationship("HAS_SINGLE_CUE")
+	@Relationship(value = "HAS_SINGLE_CUE", cascadeUpdates = false)
 	private CUE singleCUE;
 
 	@Relationship("HAS_MANY_CUI")
 	private List<CUI> manyCUI;
 
-	@Relationship("HAS_SINGLE_CVI")
+	@Relationship(value = "HAS_SINGLE_CVI", cascadeUpdates = false)
 	private CVI singleCVI;
 
-	@Relationship("HAS_SINGLE_CVE")
+	@Relationship(value = "HAS_SINGLE_CVE", cascadeUpdates = false)
 	private CVE singleCVE;
 
-	@Relationship("HAS_MANY_CVI")
+	@Relationship(value = "HAS_MANY_CVI", cascadeUpdates = false)
 	private List<CVI> manyCVI;
 
 	public PUI(String name) {
@@ -72,7 +72,43 @@ public class PUI implements Parent {
 		return id;
 	}
 
+	@Override
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public List<CUI> getManyCUI() {
+		return manyCUI;
+	}
+
+	@Override
+	public List<CVI> getManyCVI() {
+		return manyCVI;
+	}
+
+	@Override
+	public CUE getSingleCUE() {
+		return singleCUE;
+	}
+
+	@Override
+	public CUI getSingleCUI() {
+		return singleCUI;
+	}
+
+	@Override
+	public CVE getSingleCVE() {
+		return singleCVE;
+	}
+
+	@Override
+	public CVI getSingleCVI() {
+		return singleCVI;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+/**
+ * Parent / Unversioned / Internally generated id
+ */
+@Node
+public class PUI implements Parent {
+
+	@Id
+	@GeneratedValue
+	private String id;
+
+	private String name;
+
+	@Relationship("HAS_SINGLE_CUI")
+	private CUI singleCUI;
+
+	@Relationship("HAS_SINGLE_CUE")
+	private CUE singleCUE;
+
+	@Relationship("HAS_MANY_CUI")
+	private List<CUI> manyCUI;
+
+	@Relationship("HAS_SINGLE_CVI")
+	private CVI singleCVI;
+
+	@Relationship("HAS_SINGLE_CVE")
+	private CVE singleCVE;
+
+	@Relationship("HAS_MANY_CVI")
+	private List<CVI> manyCVI;
+
+	public PUI(String name) {
+		this.name = name;
+		this.singleCUI = new CUI(name + ".singleCUI");
+		this.singleCUE = new CUE(name + ".singleCUE");
+		this.manyCUI = List.of(
+				new CUI(name + ".cUI1"),
+				new CUI(name + ".cUI2")
+		);
+		this.singleCVI = new CVI(name + ".singleCVI");
+		this.singleCVE = new CVE(name + ".singleCVE");
+		this.manyCVI = List.of(
+				new CVI(name + ".cVI1"),
+				new CVI(name + ".cVI2")
+		);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
@@ -39,22 +39,22 @@ public class PVE implements Parent, Versioned, ExternalId {
 
 	private String name;
 
-	@Relationship("HAS_SINGLE_CUI")
+	@Relationship(value = "HAS_SINGLE_CUI", cascadeUpdates = false)
 	private CUI singleCUI;
 
-	@Relationship("HAS_SINGLE_CUE")
+	@Relationship(value = "HAS_SINGLE_CUE", cascadeUpdates = false)
 	private CUE singleCUE;
 
 	@Relationship("HAS_MANY_CUI")
 	private List<CUI> manyCUI;
 
-	@Relationship("HAS_SINGLE_CVI")
+	@Relationship(value = "HAS_SINGLE_CVI", cascadeUpdates = false)
 	private CVI singleCVI;
 
-	@Relationship("HAS_SINGLE_CVE")
+	@Relationship(value = "HAS_SINGLE_CVE", cascadeUpdates = false)
 	private CVE singleCVE;
 
-	@Relationship("HAS_MANY_CVI")
+	@Relationship(value = "HAS_MANY_CVI", cascadeUpdates = false)
 	private List<CVI> manyCVI;
 
 	public PVE(String name) {
@@ -77,11 +77,48 @@ public class PVE implements Parent, Versioned, ExternalId {
 		return id;
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}
 
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
 	public Long getVersion() {
 		return version;
+	}
+
+	@Override
+	public List<CUI> getManyCUI() {
+		return manyCUI;
+	}
+
+	@Override
+	public List<CVI> getManyCVI() {
+		return manyCVI;
+	}
+
+	@Override
+	public CUE getSingleCUE() {
+		return singleCUE;
+	}
+
+	@Override
+	public CUI getSingleCUI() {
+		return singleCUI;
+	}
+
+	@Override
+	public CVE getSingleCVE() {
+		return singleCVE;
+	}
+
+	@Override
+	public CVI getSingleCVI() {
+		return singleCVI;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Version;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.support.UUIDStringGenerator;
+
+/**
+ * Parent / Versioned / Externally generated id
+ */
+@Node
+public class PVE implements Parent, Versioned, ExternalId {
+
+	@Id
+	@GeneratedValue(UUIDStringGenerator.class)
+	private String id;
+
+	@Version
+	private Long version;
+
+	private String name;
+
+	@Relationship("HAS_SINGLE_CUI")
+	private CUI singleCUI;
+
+	@Relationship("HAS_SINGLE_CUE")
+	private CUE singleCUE;
+
+	@Relationship("HAS_MANY_CUI")
+	private List<CUI> manyCUI;
+
+	@Relationship("HAS_SINGLE_CVI")
+	private CVI singleCVI;
+
+	@Relationship("HAS_SINGLE_CVE")
+	private CVE singleCVE;
+
+	@Relationship("HAS_MANY_CVI")
+	private List<CVI> manyCVI;
+
+	public PVE(String name) {
+		this.name = name;
+		this.singleCUI = new CUI(name + ".singleCUI");
+		this.singleCUE = new CUE(name + ".singleCUE");
+		this.manyCUI = List.of(
+				new CUI(name + ".cUI1"),
+				new CUI(name + ".cUI2")
+		);
+		this.singleCVI = new CVI(name + ".singleCVI");
+		this.singleCVE = new CVE(name + ".singleCVE");
+		this.manyCVI = List.of(
+				new CVI(name + ".cVI1"),
+				new CVI(name + ".cVI2")
+		);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
@@ -38,22 +38,22 @@ public class PVI implements Parent, Versioned {
 
 	private String name;
 
-	@Relationship("HAS_SINGLE_CUI")
+	@Relationship(value = "HAS_SINGLE_CUI", cascadeUpdates = false)
 	private CUI singleCUI;
 
-	@Relationship("HAS_SINGLE_CUE")
+	@Relationship(value = "HAS_SINGLE_CUE", cascadeUpdates = false)
 	private CUE singleCUE;
 
 	@Relationship("HAS_MANY_CUI")
 	private List<CUI> manyCUI;
 
-	@Relationship("HAS_SINGLE_CVI")
+	@Relationship(value = "HAS_SINGLE_CVI", cascadeUpdates = false)
 	private CVI singleCVI;
 
-	@Relationship("HAS_SINGLE_CVE")
+	@Relationship(value = "HAS_SINGLE_CVE", cascadeUpdates = false)
 	private CVE singleCVE;
 
-	@Relationship("HAS_MANY_CVI")
+	@Relationship(value = "HAS_MANY_CVI", cascadeUpdates = false)
 	private List<CVI> manyCVI;
 
 	public PVI(String name) {
@@ -76,11 +76,48 @@ public class PVI implements Parent, Versioned {
 		return id;
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}
 
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
 	public Long getVersion() {
 		return version;
+	}
+
+	@Override
+	public List<CUI> getManyCUI() {
+		return manyCUI;
+	}
+
+	@Override
+	public List<CVI> getManyCVI() {
+		return manyCVI;
+	}
+
+	@Override
+	public CUE getSingleCUE() {
+		return singleCUE;
+	}
+
+	@Override
+	public CUI getSingleCUI() {
+		return singleCUI;
+	}
+
+	@Override
+	public CVE getSingleCVE() {
+		return singleCVE;
+	}
+
+	@Override
+	public CVI getSingleCVI() {
+		return singleCVI;
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Version;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+/**
+ * Parent / Versioned / Internally generated id
+ */
+@Node
+public class PVI implements Parent, Versioned {
+
+	@Id
+	@GeneratedValue
+	private String id;
+
+	@Version
+	private Long version;
+
+	private String name;
+
+	@Relationship("HAS_SINGLE_CUI")
+	private CUI singleCUI;
+
+	@Relationship("HAS_SINGLE_CUE")
+	private CUE singleCUE;
+
+	@Relationship("HAS_MANY_CUI")
+	private List<CUI> manyCUI;
+
+	@Relationship("HAS_SINGLE_CVI")
+	private CVI singleCVI;
+
+	@Relationship("HAS_SINGLE_CVE")
+	private CVE singleCVE;
+
+	@Relationship("HAS_MANY_CVI")
+	private List<CVI> manyCVI;
+
+	public PVI(String name) {
+		this.name = name;
+		this.singleCUI = new CUI(name + ".singleCUI");
+		this.singleCUE = new CUE(name + ".singleCUE");
+		this.manyCUI = List.of(
+				new CUI(name + ".cUI1"),
+				new CUI(name + ".cUI2")
+		);
+		this.singleCVI = new CVI(name + ".singleCVI");
+		this.singleCVE = new CVE(name + ".singleCVE");
+		this.manyCVI = List.of(
+				new CVI(name + ".cVI1"),
+				new CVI(name + ".cVI2")
+		);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+/**
+ * Marker for parent
+ */
+public interface Parent {
+
+	String getId();
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
@@ -15,10 +15,28 @@
  */
 package org.springframework.data.neo4j.integration.cascading;
 
+import java.util.List;
+
 /**
  * Marker for parent
  */
 public interface Parent {
 
 	String getId();
+
+	String getName();
+
+	void setName(String name);
+
+	List<CUI> getManyCUI();
+
+	List<CVI> getManyCVI();
+
+	CUE getSingleCUE();
+
+	CUI getSingleCUI();
+
+	CVE getSingleCVE();
+
+	CVI getSingleCVI();
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/Versioned.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/Versioned.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2011-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.cascading;
+
+/**
+ * Marker for versioned
+ */
+public interface Versioned {
+
+	Long getVersion();
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeIdsIT.java
@@ -97,8 +97,7 @@ class CompositeIdsIT {
 	@Test
 	void compositeIdsShouldWork(@Autowired ThingWithCompositeIdRepository repository) {
 
-		ThingWithCompositeId thing = new ThingWithCompositeId(new CompositeValue("a,", 1), "first entity");
-		ThingWithCompositeId saved = repository.save(thing);
+		ThingWithCompositeId saved = repository.save(new ThingWithCompositeId(new CompositeValue("a,", 1), "first entity"));
 		assertThat(saved.getVersion()).isGreaterThanOrEqualTo(0);
 
 		saved.setName("foobar");


### PR DESCRIPTION
This adds a boolean attribute `cascadeUpdates` to `@Relationship`, selectively preventing the cascade of updates. This attribute will be `false` by default.

It does not have an effect when storing new entities.
It does not affect the deletion of relationships.
It does not affect the storing of relationships with or without properties.

Be aware that with a non-cascading update, you can bring your aggregate root in a state in which it is no longer in sync with the actual state of it in the graph.

Closes #2604