### PR TITLE
fix: update spring-boot-version to 3.3.0 to fix gzip extraction error

### DIFF
--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -24,7 +24,7 @@ asciidoc:
     groupIdStarter: org.springframework.boot
     artifactIdStarter: spring-boot-starter-data-neo4j
     docs-neo4j-docker-version: 5
-    spring-boot-version: 3.3.0
+    spring-boot-version: 3.4.5
     docs-neo4j-4-version: 4.4.25
     docs-neo4j-3-version: 3.5.33
     java-driver-starter-href: https://github.com/neo4j/neo4j-java-driver-spring-boot-starter

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -24,7 +24,7 @@ asciidoc:
     groupIdStarter: org.springframework.boot
     artifactIdStarter: spring-boot-starter-data-neo4j
     docs-neo4j-docker-version: 5
-    spring-boot-version: 3.2.0
+    spring-boot-version: 3.3.0
     docs-neo4j-4-version: 4.4.25
     docs-neo4j-3-version: 3.5.33
     java-driver-starter-href: https://github.com/neo4j/neo4j-java-driver-spring-boot-starter


### PR DESCRIPTION
The version `3.2.0` is no longer listed as a supported version by start.spring.io. Updating to `3.3.0`, which is officially supported, resolves this issue.

## Overview

This pull request updates the Spring Boot version used for generating starter projects from `3.2.0` to `3.3.0`.

## Problem Description

While generating a starter project using `start.spring.io`, the following command was executed:

![image](https://github.com/user-attachments/assets/9168460f-09ca-4932-a824-f741e2b11861)


I can't create this project correctly

```bash
➜  ~ curl https://start.spring.io/starter.tgz \
  -d dependencies=webflux,data-neo4j  \
  -d bootVersion=3.2.0 \
  -d baseDir=Neo4jSpringBootExample \
  -d name=Neo4j%20SpringBoot%20Example | tar -xzvf -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   308    0   194  100   114     78     46  0:00:02  0:00:02 --:--:--   125

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

Investigation revealed:

- The downloaded file was unusually small (~300 bytes).
- file starter.tgz indicated that the content was not a valid gzip archive.
- Inspecting the content showed an HTML error page rather than a project archive.
- The cause was that bootVersion=3.2.0 is no longer a valid option on start.spring.io.


## Changes
https://github.com/spring-projects/spring-data-neo4j/blob/28d2623aff296afef6c671b26c02ac8ab2d2af98/src/main/antora/resources/antora-resources/antora.yml#L27

- Updated the `spring-boot-version` setting to `3.3.0`.