### PR TITLE
Add Vector type support

### DIFF
--- a/src/main/antora/modules/ROOT/pages/appendix/conversions.adoc
+++ b/src/main/antora/modules/ROOT/pages/appendix/conversions.adoc
@@ -188,6 +188,10 @@ If you require the time zone, use a type that supports it (i.e. `ZoneDateTime`) 
 |Point with CRS 4326 and x/y corresponding to lat/long
 |
 
+|`org.springframework.data.domain.Vector`
+|persisted through `setNodeVectorProperty`
+|
+
 |Instances of `Enum`
 |String (The name value of the enum)
 |
@@ -209,6 +213,17 @@ If you require the time zone, use a type that supports it (i.e. `ZoneDateTime`) 
 |
 
 |===
+
+[[build-in.conversions.vector]]
+=== Vector type
+Spring Data has its own type for vector representation `org.springframework.data.domain.Vector`.
+While this can be used as a wrapper around a `float` or `double` array, Spring Data Neo4j supports only the `double` variant right now.
+From a user perspective, it is possible to only define the `Vector` interface on the property definition and use either `double` or `float`.
+Neo4j will store both `double` and `float` variants as a 64-bit Cypher `FLOAT` value, which is consistent with values persisted through Cypher and the dedicated `setNodeVectorProperty` function that Spring Data Neo4j uses to persist the property.
+
+NOTE: Spring Data Neo4j only allows one `Vector` property to be present in an entity definition.
+
+NOTE: Please be aware that a persisted `float` value differs from a read back value due to the nature of floating numbers.
 
 [[custom.conversions]]
 == Custom conversions

--- a/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
@@ -50,6 +50,7 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.convert.ConverterBuilder;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -104,12 +105,16 @@ final class AdditionalTypes {
 		hlp.add(ConverterBuilder.reading(Value.class, Node.class, Value::asNode));
 		hlp.add(ConverterBuilder.reading(Value.class, Relationship.class, Value::asRelationship));
 		hlp.add(ConverterBuilder.reading(Value.class, Map.class, Value::asMap).andWriting(AdditionalTypes::value));
-
+		hlp.add(ConverterBuilder.reading(Value.class, Vector.class, AdditionalTypes::asVector).andWriting(AdditionalTypes::value));
 		CONVERTERS = Collections.unmodifiableList(hlp);
 	}
 
 	static Value value(Map<?, ?> map) {
 		return Values.value(map);
+	}
+
+	static Value value(Vector vector) {
+		return Values.value(vector.toDoubleArray());
 	}
 
 	static TimeZone asTimeZone(Value value) {
@@ -460,6 +465,11 @@ final class AdditionalTypes {
 			array[i++] = v;
 		}
 		return array;
+	}
+
+	static Vector asVector(Value value) {
+		double[] array = asDoubleArray(value);
+		return Vector.of(array);
 	}
 
 	static Value value(short[] aShortArray) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
@@ -58,6 +58,8 @@ public final class Constants {
 	public static final String NAME_OF_ID = "__id__";
 	public static final String NAME_OF_VERSION_PARAM = "__version__";
 	public static final String NAME_OF_PROPERTIES_PARAM = "__properties__";
+	public static final String NAME_OF_VECTOR_PROPERTY = "__vectorProperty__";
+	public static final String NAME_OF_VECTOR_VALUE = "__vectorValue__";
 	/**
 	 * Indicates the parameter that contains the static labels which are required to correctly compute the difference
 	 * in the list of dynamic labels when saving a node.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -75,4 +75,9 @@ public interface Neo4jPersistentEntity<T>
 		}
 		return isUsingInternalIds() && Neo4jPersistentEntity.DEPRECATED_GENERATED_ID_TYPES.contains(getRequiredIdProperty().getType());
 	}
+
+	boolean hasVectorProperty();
+
+	Neo4jPersistentProperty getVectorProperty();
+	Neo4jPersistentProperty getRequiredVectorProperty();
 }

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.core.mapping;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
 import org.springframework.data.neo4j.core.schema.CompositeProperty;
@@ -65,6 +66,10 @@ public interface Neo4jPersistentProperty extends PersistentProperty<Neo4jPersist
 	 */
 	default boolean isDynamicLabels() {
 		return this.isAnnotationPresent(DynamicLabels.class) && this.isCollectionLike();
+	}
+
+	default boolean isVectorProperty() {
+		return this.getType().isAssignableFrom(Vector.class);
 	}
 
 	@Nullable

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.integration.shared.conversion;
 import org.junit.jupiter.api.BeforeAll;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.geo.Point;
 import org.springframework.data.neo4j.integration.shared.conversion.ThingWithAllAdditionalTypes.SomeEnum;
 import org.springframework.data.neo4j.test.BookmarkCapture;
@@ -126,6 +127,7 @@ public abstract class Neo4jConversionsITBase {
 		hlp.put("aZoneId", ZoneId.of("America/New_York"));
 		hlp.put("aZeroPeriod", Period.of(0, 0, 0));
 		hlp.put("aZeroDuration", Duration.ZERO);
+		hlp.put("aVector", Vector.of(0.1d, 0.2d));
 		ADDITIONAL_TYPES = Collections.unmodifiableMap(hlp);
 	}
 
@@ -278,7 +280,8 @@ public abstract class Neo4jConversionsITBase {
 						n.anEnum = 'TheUsualMisfit', n.anArrayOfEnums = ['ValueA', 'ValueB'],
 						n.aCollectionOfEnums = ['ValueC', 'TheUsualMisfit'],
 						n.aTimeZone = 'America/Los_Angeles',\s
-						n.aZoneId = 'America/New_York', n.aZeroPeriod = duration('PT0S'), n.aZeroDuration = duration('PT0S')
+						n.aZoneId = 'America/New_York', n.aZeroPeriod = duration('PT0S'), n.aZeroDuration = duration('PT0S'),
+						n.aVector = [0.1, 0.2]
 					RETURN id(n) AS id
 					""", parameters).single().get("id").asLong();
 

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import org.springframework.data.domain.Vector;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
@@ -43,7 +44,7 @@ import org.springframework.data.neo4j.core.schema.Node;
 @Node("AdditionalTypes")
 public class ThingWithAllAdditionalTypes {
 
-	private ThingWithAllAdditionalTypes(Long id, boolean[] booleanArray, byte aByte, char aChar, char[] charArray, Date aDate, BigDecimal aBigDecimal, BigInteger aBigInteger, double[] doubleArray, float aFloat, float[] floatArray, int anInt, int[] intArray, Locale aLocale, long[] longArray, short aShort, short[] shortArray, Period aPeriod, Duration aDuration, String[] stringArray, List<String> listOfStrings, Set<String> setOfStrings, Instant anInstant, UUID aUUID, URL aURL, URI aURI, SomeEnum anEnum, SomeEnum[] anArrayOfEnums, List<Double> listOfDoubles, List<SomeEnum> aCollectionOfEnums, TimeZone aTimeZone, ZoneId aZoneId, Period aZeroPeriod, Duration aZeroDuration) {
+	private ThingWithAllAdditionalTypes(Long id, boolean[] booleanArray, byte aByte, char aChar, char[] charArray, Date aDate, BigDecimal aBigDecimal, BigInteger aBigInteger, double[] doubleArray, float aFloat, float[] floatArray, int anInt, int[] intArray, Locale aLocale, long[] longArray, short aShort, short[] shortArray, Period aPeriod, Duration aDuration, String[] stringArray, List<String> listOfStrings, Set<String> setOfStrings, Instant anInstant, UUID aUUID, URL aURL, URI aURI, SomeEnum anEnum, SomeEnum[] anArrayOfEnums, List<Double> listOfDoubles, List<SomeEnum> aCollectionOfEnums, TimeZone aTimeZone, ZoneId aZoneId, Period aZeroPeriod, Duration aZeroDuration, Vector aVector) {
 		this.id = id;
 		this.booleanArray = booleanArray;
 		this.aByte = aByte;
@@ -78,6 +79,7 @@ public class ThingWithAllAdditionalTypes {
 		this.aZoneId = aZoneId;
 		this.aZeroPeriod = aZeroPeriod;
 		this.aZeroDuration = aZeroDuration;
+		this.aVector = aVector;
 	}
 
 	public static ThingWithAllAdditionalTypesBuilder builder() {
@@ -220,6 +222,10 @@ public class ThingWithAllAdditionalTypes {
 		return this.aZeroDuration;
 	}
 
+	public Vector getAVector() {
+		return this.aVector;
+	}
+
 	public void setBooleanArray(boolean[] booleanArray) {
 		this.booleanArray = booleanArray;
 	}
@@ -350,6 +356,10 @@ public class ThingWithAllAdditionalTypes {
 
 	public void setAZeroDuration(Duration aZeroDuration) {
 		this.aZeroDuration = aZeroDuration;
+	}
+
+	public void setAVector(Vector aVector) {
+		this.aVector = aVector;
 	}
 
 	public boolean equals(final Object o) {
@@ -505,6 +515,12 @@ public class ThingWithAllAdditionalTypes {
 		if (this$aZeroDuration == null ? other$aZeroDuration != null : !this$aZeroDuration.equals(other$aZeroDuration)) {
 			return false;
 		}
+
+		final Object this$aVector = this.getAVector();
+		final Object other$aVector = other.getAVector();
+		if (this$aVector == null ? other$aVector != null : !this$aVector.equals(other$aVector)) {
+			return false;
+		}
 		return true;
 	}
 
@@ -569,6 +585,8 @@ public class ThingWithAllAdditionalTypes {
 		result = result * PRIME + ($aZeroPeriod == null ? 43 : $aZeroPeriod.hashCode());
 		final Object $aZeroDuration = this.getAZeroDuration();
 		result = result * PRIME + ($aZeroDuration == null ? 43 : $aZeroDuration.hashCode());
+		final Object $aVector = this.getAVector();
+		result = result * PRIME + ($aVector == null ? 43 : $aVector.hashCode());
 		return result;
 	}
 
@@ -577,7 +595,7 @@ public class ThingWithAllAdditionalTypes {
 	}
 
 	public ThingWithAllAdditionalTypes withId(Long id) {
-		return this.id == id ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration);
+		return this.id == id ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
 	}
 
 	enum SomeEnum {
@@ -654,6 +672,8 @@ public class ThingWithAllAdditionalTypes {
 
 	private Duration aZeroDuration;
 
+	private Vector aVector;
+
 	/**
 	 * the builder
 	 */
@@ -692,6 +712,7 @@ public class ThingWithAllAdditionalTypes {
 		private ZoneId aZoneId;
 		private Period aZeroPeriod;
 		private Duration aZeroDuration;
+		private Vector aVector;
 
 		ThingWithAllAdditionalTypesBuilder() {
 		}
@@ -866,12 +887,17 @@ public class ThingWithAllAdditionalTypes {
 			return this;
 		}
 
+		public ThingWithAllAdditionalTypesBuilder aVector(Vector vector) {
+			this.aVector = aVector;
+			return this;
+		}
+
 		public ThingWithAllAdditionalTypes build() {
-			return new ThingWithAllAdditionalTypes(this.id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration);
+			return new ThingWithAllAdditionalTypes(this.id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
 		}
 
 		public String toString() {
-			return "ThingWithAllAdditionalTypes.ThingWithAllAdditionalTypesBuilder(id=" + this.id + ", booleanArray=" + java.util.Arrays.toString(this.booleanArray) + ", aByte=" + this.aByte + ", aChar=" + this.aChar + ", charArray=" + java.util.Arrays.toString(this.charArray) + ", aDate=" + this.aDate + ", aBigDecimal=" + this.aBigDecimal + ", aBigInteger=" + this.aBigInteger + ", doubleArray=" + java.util.Arrays.toString(this.doubleArray) + ", aFloat=" + this.aFloat + ", floatArray=" + java.util.Arrays.toString(this.floatArray) + ", anInt=" + this.anInt + ", intArray=" + java.util.Arrays.toString(this.intArray) + ", aLocale=" + this.aLocale + ", longArray=" + java.util.Arrays.toString(this.longArray) + ", aShort=" + this.aShort + ", shortArray=" + java.util.Arrays.toString(this.shortArray) + ", aPeriod=" + this.aPeriod + ", aDuration=" + this.aDuration + ", stringArray=" + java.util.Arrays.deepToString(this.stringArray) + ", listOfStrings=" + this.listOfStrings + ", setOfStrings=" + this.setOfStrings + ", anInstant=" + this.anInstant + ", aUUID=" + this.aUUID + ", aURL=" + this.aURL + ", aURI=" + this.aURI + ", anEnum=" + this.anEnum + ", anArrayOfEnums=" + java.util.Arrays.deepToString(this.anArrayOfEnums) + ", listOfDoubles=" + this.listOfDoubles + ", aCollectionOfEnums=" + this.aCollectionOfEnums + ", aTimeZone=" + this.aTimeZone + ", aZoneId=" + this.aZoneId + ", aZeroPeriod=" + this.aZeroPeriod + ", aZeroDuration=" + this.aZeroDuration + ")";
+			return "ThingWithAllAdditionalTypes.ThingWithAllAdditionalTypesBuilder(id=" + this.id + ", booleanArray=" + java.util.Arrays.toString(this.booleanArray) + ", aByte=" + this.aByte + ", aChar=" + this.aChar + ", charArray=" + java.util.Arrays.toString(this.charArray) + ", aDate=" + this.aDate + ", aBigDecimal=" + this.aBigDecimal + ", aBigInteger=" + this.aBigInteger + ", doubleArray=" + java.util.Arrays.toString(this.doubleArray) + ", aFloat=" + this.aFloat + ", floatArray=" + java.util.Arrays.toString(this.floatArray) + ", anInt=" + this.anInt + ", intArray=" + java.util.Arrays.toString(this.intArray) + ", aLocale=" + this.aLocale + ", longArray=" + java.util.Arrays.toString(this.longArray) + ", aShort=" + this.aShort + ", shortArray=" + java.util.Arrays.toString(this.shortArray) + ", aPeriod=" + this.aPeriod + ", aDuration=" + this.aDuration + ", stringArray=" + java.util.Arrays.deepToString(this.stringArray) + ", listOfStrings=" + this.listOfStrings + ", setOfStrings=" + this.setOfStrings + ", anInstant=" + this.anInstant + ", aUUID=" + this.aUUID + ", aURL=" + this.aURL + ", aURI=" + this.aURI + ", anEnum=" + this.anEnum + ", anArrayOfEnums=" + java.util.Arrays.deepToString(this.anArrayOfEnums) + ", listOfDoubles=" + this.listOfDoubles + ", aCollectionOfEnums=" + this.aCollectionOfEnums + ", aTimeZone=" + this.aTimeZone + ", aZoneId=" + this.aZoneId + ", aZeroPeriod=" + this.aZeroPeriod + ", aZeroDuration=" + this.aZeroDuration + ", aVector=" + this.aVector + ")";
 		}
 	}
 }


### PR DESCRIPTION
Map `org.springframework.data.domain.Vector` to `setNodeVectorProperty` procedure call.

Open documentation tasks

- [x] `double` vector in SDN only
- [x] precision on rest/representation
- [x] only one vector property allowed for an entity definition

Note to myself, there should be a close the issue commit on squash.