### PR TITLE
Add support for `RepositoryFragmentsContributor`.

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/repository/support/BuiltinContributor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/BuiltinContributor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import static org.springframework.data.querydsl.QuerydslUtils.*;
+
+import org.springframework.data.neo4j.core.Neo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.repository.query.CypherdslConditionExecutorImpl;
+import org.springframework.data.neo4j.repository.query.QuerydslNeo4jPredicateExecutor;
+import org.springframework.data.neo4j.repository.query.SimpleQueryByExampleExecutor;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
+import org.springframework.data.repository.core.support.RepositoryFragment;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
+
+/**
+ * Built-in {@link RepositoryFragmentsContributor} contributing Query by Example, Querydsl, and Cypher condition
+ * fragments if a repository implements the corresponding interfaces.
+ *
+ * @author Mark Paluch
+ * @since 8.0
+ */
+enum BuiltinContributor implements Neo4jRepositoryFragmentsContributor {
+
+	INSTANCE;
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public RepositoryFragments contribute(RepositoryMetadata metadata, Neo4jEntityInformation<?, ?> entityInformation,
+			Neo4jOperations operations, Neo4jMappingContext mappingContext) {
+
+		RepositoryFragments fragments = RepositoryFragments
+				.of(RepositoryFragment.implemented(new SimpleQueryByExampleExecutor(operations, mappingContext)));
+
+		if (isQuerydslRepository(metadata)) {
+			fragments = fragments.append(RepositoryFragment
+					.implemented(new QuerydslNeo4jPredicateExecutor(mappingContext, entityInformation, operations)));
+		}
+
+		if (CypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+			fragments = fragments
+					.append(RepositoryFragment.implemented(new CypherdslConditionExecutorImpl(entityInformation, operations)));
+		}
+
+		return fragments;
+	}
+
+	@Override
+	public RepositoryFragments describe(RepositoryMetadata metadata) {
+
+		RepositoryFragments fragments = RepositoryFragments
+				.of(RepositoryFragment.structural(SimpleQueryByExampleExecutor.class));
+
+		if (isQuerydslRepository(metadata)) {
+			fragments = fragments.append(RepositoryFragment.structural(QuerydslNeo4jPredicateExecutor.class));
+		}
+
+		if (CypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+			fragments = fragments.append(RepositoryFragment.structural(CypherdslConditionExecutorImpl.class));
+		}
+
+		return fragments;
+	}
+
+	private static boolean isQuerydslRepository(RepositoryMetadata metadata) {
+		return QUERY_DSL_PRESENT && QuerydslPredicateExecutor.class.isAssignableFrom(metadata.getRepositoryInterface());
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -30,6 +30,7 @@ import org.springframework.data.repository.core.support.TransactionalRepositoryF
  *
  * @author Michael J. Simons
  * @author Gerrit Meier
+ * @author Mark Paluch
  * @param <T> the type of the repository
  * @param <S> type of the domain class to map
  * @param <ID> identifier type in the domain class
@@ -42,6 +43,8 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 	private Neo4jOperations neo4jOperations;
 
 	private Neo4jMappingContext neo4jMappingContext;
+
+	private Neo4jRepositoryFragmentsContributor repositoryFragmentsContributor = Neo4jRepositoryFragmentsContributor.DEFAULT;
 
 	/**
 	 * Creates a new {@link TransactionalRepositoryFactoryBeanSupport} for the given repository interface.
@@ -62,7 +65,16 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 	}
 
 	@Override
+	public Neo4jRepositoryFragmentsContributor getRepositoryFragmentsContributor() {
+		return repositoryFragmentsContributor;
+	}
+
+	public void setRepositoryFragmentsContributor(Neo4jRepositoryFragmentsContributor repositoryFragmentsContributor) {
+		this.repositoryFragmentsContributor = repositoryFragmentsContributor;
+	}
+
+	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new Neo4jRepositoryFactory(neo4jOperations, neo4jMappingContext);
+		return new Neo4jRepositoryFactory(neo4jOperations, neo4jMappingContext, repositoryFragmentsContributor);
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryCdiBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryCdiBean.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.config.CustomRepositoryImplementation
  * The CDI pendant to the {@link Neo4jRepositoryFactoryBean}. It creates instances of {@link Neo4jRepositoryFactory}.
  *
  * @author Michael J. Simons
+ * @author Mark Paluch
  * @param <T> The type of the repository being created
  * @soundtrack Various - TRON Legacy R3conf1gur3d
  * @since 6.0
@@ -57,7 +58,7 @@ public final class Neo4jRepositoryFactoryCdiBean<T> extends CdiRepositoryBean<T>
 		Neo4jOperations neo4jOperations = getReference(Neo4jOperations.class, creationalContext);
 		Neo4jMappingContext mappingContext = getReference(Neo4jMappingContext.class, creationalContext);
 
-		return create(() -> new Neo4jRepositoryFactory(neo4jOperations, mappingContext), repositoryType);
+		return create(() -> new Neo4jRepositoryFactory(neo4jOperations, mappingContext, Neo4jRepositoryFragmentsContributor.DEFAULT), repositoryType);
 	}
 
 	private <RT> RT getReference(Class<RT> clazz, CreationalContext<?> creationalContext) {

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFragmentsContributor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFragmentsContributor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import org.springframework.data.neo4j.core.Neo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
+import org.springframework.util.Assert;
+
+/**
+ * Neo4j-specific {@link RepositoryFragmentsContributor} contributing fragments based on the repository. Typically,
+ * contributes Query by Example Executor, Querydsl, and Cypher condition DSL fragments.
+ * <p>
+ * Implementations must define a no-args constructor.
+ *
+ * @author Mark Paluch
+ * @since 8.0
+ * @see org.springframework.data.repository.query.QueryByExampleExecutor
+ * @see org.springframework.data.querydsl.QuerydslPredicateExecutor
+ * @see CypherdslConditionExecutor
+ */
+public interface Neo4jRepositoryFragmentsContributor extends RepositoryFragmentsContributor {
+
+	Neo4jRepositoryFragmentsContributor DEFAULT = BuiltinContributor.INSTANCE;
+
+	/**
+	 * Returns a composed {@code Neo4jRepositoryFragmentsContributor} that first applies this contributor to its inputs,
+	 * and then applies the {@code after} contributor concatenating effectively both results. If evaluation of either
+	 * contributors throws an exception, it is relayed to the caller of the composed contributor.
+	 *
+	 * @param after the contributor to apply after this contributor is applied.
+	 * @return a composed contributor that first applies this contributor and then applies the {@code after} contributor.
+	 */
+	default Neo4jRepositoryFragmentsContributor andThen(Neo4jRepositoryFragmentsContributor after) {
+
+		Assert.notNull(after, "Neo4jRepositoryFragmentsContributor must not be null");
+
+		return new Neo4jRepositoryFragmentsContributor() {
+
+			@Override
+			public RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+					Neo4jEntityInformation<?, ?> entityInformation, Neo4jOperations operations,
+					Neo4jMappingContext mappingContext) {
+				return Neo4jRepositoryFragmentsContributor.this
+						.contribute(metadata, entityInformation, operations, mappingContext)
+						.append(after.contribute(metadata, entityInformation, operations, mappingContext));
+			}
+
+			@Override
+			public RepositoryComposition.RepositoryFragments describe(RepositoryMetadata metadata) {
+				return Neo4jRepositoryFragmentsContributor.this.describe(metadata).append(after.describe(metadata));
+			}
+		};
+	}
+
+	/**
+	 * Creates {@link RepositoryComposition.RepositoryFragments} based on {@link RepositoryMetadata} to add Neo4j-specific
+	 * extensions.
+	 *
+	 * @param metadata repository metadata.
+	 * @param entityInformation must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @return {@link RepositoryComposition.RepositoryFragments} to be added to the repository.
+	 */
+	RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+			Neo4jEntityInformation<?, ?> entityInformation, Neo4jOperations operations, Neo4jMappingContext mappingContext);
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveBuiltinContributor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveBuiltinContributor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import static org.springframework.data.querydsl.QuerydslUtils.*;
+
+import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.repository.query.ReactiveCypherdslConditionExecutorImpl;
+import org.springframework.data.neo4j.repository.query.ReactiveQuerydslNeo4jPredicateExecutor;
+import org.springframework.data.neo4j.repository.query.SimpleReactiveQueryByExampleExecutor;
+import org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
+import org.springframework.data.repository.core.support.RepositoryFragment;
+
+/**
+ * Reactive Built-in {@link ReactiveNeo4jRepositoryFragmentsContributor} contributing Query by Example, Querydsl, and
+ * Cypher condition fragments if a repository implements the corresponding interfaces.
+ *
+ * @author Mark Paluch
+ * @since 8.0
+ */
+enum ReactiveBuiltinContributor implements ReactiveNeo4jRepositoryFragmentsContributor {
+
+	INSTANCE;
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public RepositoryFragments contribute(RepositoryMetadata metadata, Neo4jEntityInformation<?, ?> entityInformation,
+			ReactiveNeo4jOperations operations, Neo4jMappingContext mappingContext) {
+
+		RepositoryFragments fragments = RepositoryFragments
+				.of(RepositoryFragment.implemented(new SimpleReactiveQueryByExampleExecutor(operations, mappingContext)));
+
+		if (isQuerydslRepository(metadata)) {
+			fragments = fragments.append(RepositoryFragment
+					.implemented(new ReactiveQuerydslNeo4jPredicateExecutor(mappingContext, entityInformation, operations)));
+		}
+
+		if (ReactiveCypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+			fragments = fragments.append(
+					RepositoryFragment.implemented(new ReactiveCypherdslConditionExecutorImpl(entityInformation, operations)));
+		}
+
+		return fragments;
+	}
+
+	@Override
+	public RepositoryFragments describe(RepositoryMetadata metadata) {
+
+		RepositoryFragments fragments = RepositoryFragments
+				.of(RepositoryFragment.structural(SimpleReactiveQueryByExampleExecutor.class));
+
+		if (isQuerydslRepository(metadata)) {
+			fragments = fragments.append(RepositoryFragment.structural(ReactiveQuerydslNeo4jPredicateExecutor.class));
+		}
+
+		if (ReactiveCypherdslConditionExecutor.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+			fragments = fragments.append(RepositoryFragment.structural(ReactiveCypherdslConditionExecutorImpl.class));
+		}
+
+		return fragments;
+	}
+
+	private static boolean isQuerydslRepository(RepositoryMetadata metadata) {
+		return QUERY_DSL_PRESENT
+				&& ReactiveQuerydslPredicateExecutor.class.isAssignableFrom(metadata.getRepositoryInterface());
+	}
+}

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -30,6 +30,7 @@ import org.springframework.data.repository.core.support.TransactionalRepositoryF
  *
  * @author Gerrit Meier
  * @author Michael J. Simons
+ * @author Mark Paluch
  * @param <T> the type of the repository
  * @param <S> type of the domain class to map
  * @param <ID> identifier type in the domain class
@@ -42,6 +43,8 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 	private ReactiveNeo4jOperations neo4jOperations;
 
 	private Neo4jMappingContext neo4jMappingContext;
+
+	private ReactiveNeo4jRepositoryFragmentsContributor repositoryFragmentsContributor = ReactiveNeo4jRepositoryFragmentsContributor.DEFAULT;
 
 	/**
 	 * Creates a new {@link TransactionalRepositoryFactoryBeanSupport} for the given repository interface.
@@ -62,7 +65,16 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 	}
 
 	@Override
+	public ReactiveNeo4jRepositoryFragmentsContributor getRepositoryFragmentsContributor() {
+		return repositoryFragmentsContributor;
+	}
+
+	public void setRepositoryFragmentsContributor(ReactiveNeo4jRepositoryFragmentsContributor repositoryFragmentsContributor) {
+		this.repositoryFragmentsContributor = repositoryFragmentsContributor;
+	}
+
+	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new ReactiveNeo4jRepositoryFactory(neo4jOperations, neo4jMappingContext);
+		return new ReactiveNeo4jRepositoryFactory(neo4jOperations, neo4jMappingContext, repositoryFragmentsContributor);
 	}
 }

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFragmentsContributor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFragmentsContributor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
+import org.springframework.util.Assert;
+
+/**
+ * Reactive Neo4j-specific {@link RepositoryFragmentsContributor} contributing fragments based on the repository.
+ * Typically, contributes Query by Example Executor, Querydsl, and Cypher condition DSL fragments.
+ * <p>
+ * Implementations must define a no-args constructor.
+ *
+ * @author Mark Paluch
+ * @since 8.0
+ * @see org.springframework.data.repository.query.QueryByExampleExecutor
+ * @see org.springframework.data.querydsl.QuerydslPredicateExecutor
+ * @see CypherdslConditionExecutor
+ */
+public interface ReactiveNeo4jRepositoryFragmentsContributor extends RepositoryFragmentsContributor {
+
+	ReactiveNeo4jRepositoryFragmentsContributor DEFAULT = ReactiveBuiltinContributor.INSTANCE;
+
+	/**
+	 * Returns a composed {@code ReactiveNeo4jRepositoryFragmentsContributor} that first applies this contributor to its
+	 * inputs, and then applies the {@code after} contributor concatenating effectively both results. If evaluation of
+	 * either contributors throws an exception, it is relayed to the caller of the composed contributor.
+	 *
+	 * @param after the contributor to apply after this contributor is applied.
+	 * @return a composed contributor that first applies this contributor and then applies the {@code after} contributor.
+	 */
+	default ReactiveNeo4jRepositoryFragmentsContributor andThen(ReactiveNeo4jRepositoryFragmentsContributor after) {
+
+		Assert.notNull(after, "Neo4jRepositoryFragmentsContributor must not be null");
+
+		return new ReactiveNeo4jRepositoryFragmentsContributor() {
+
+			@Override
+			public RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+					Neo4jEntityInformation<?, ?> entityInformation, ReactiveNeo4jOperations operations,
+					Neo4jMappingContext mappingContext) {
+				return ReactiveNeo4jRepositoryFragmentsContributor.this
+						.contribute(metadata, entityInformation, operations, mappingContext)
+						.append(after.contribute(metadata, entityInformation, operations, mappingContext));
+			}
+
+			@Override
+			public RepositoryComposition.RepositoryFragments describe(RepositoryMetadata metadata) {
+				return ReactiveNeo4jRepositoryFragmentsContributor.this.describe(metadata).append(after.describe(metadata));
+			}
+		};
+	}
+
+	/**
+	 * Creates {@link RepositoryComposition.RepositoryFragments} based on {@link RepositoryMetadata} to add Neo4j-specific
+	 * extensions.
+	 *
+	 * @param metadata repository metadata.
+	 * @param entityInformation must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @return {@link RepositoryComposition.RepositoryFragments} to be added to the repository.
+	 */
+	RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+			Neo4jEntityInformation<?, ?> entityInformation, ReactiveNeo4jOperations operations,
+			Neo4jMappingContext mappingContext);
+
+}

--- a/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryTest.java
@@ -58,7 +58,7 @@ class Neo4jRepositoryFactoryTest {
 	 */
 	@Nested
 	class IdentifierTypeCheck {
-		@Spy private Neo4jRepositoryFactory neo4jRepositoryFactory = new Neo4jRepositoryFactory(null, null);
+		@Spy private Neo4jRepositoryFactory neo4jRepositoryFactory = new Neo4jRepositoryFactory(null, null, null);
 		private Neo4jEntityInformation entityInformation;
 		private RepositoryInformation metadata;
 
@@ -109,7 +109,7 @@ class Neo4jRepositoryFactoryTest {
 					Arrays.asList(ThingWithAllAdditionalTypes.class,
 							ThingWithAllCypherTypes.class,
 							ThingWithCompositeProperties.class)));
-			repositoryFactory = new Neo4jRepositoryFactory(Mockito.mock(Neo4jTemplate.class), mappingContext);
+			repositoryFactory = new Neo4jRepositoryFactory(Mockito.mock(Neo4jTemplate.class), mappingContext, Neo4jRepositoryFragmentsContributor.DEFAULT);
 		}
 
 		@Test

--- a/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFragmentsContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFragmentsContributorUnitTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.neo4j.core.Neo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.integration.shared.conversion.ThingWithAllAdditionalTypes;
+import org.springframework.data.neo4j.repository.query.CypherdslConditionExecutorImpl;
+import org.springframework.data.neo4j.repository.query.QuerydslNeo4jPredicateExecutor;
+import org.springframework.data.neo4j.repository.query.SimpleQueryByExampleExecutor;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryFragment;
+
+/**
+ * Unit tests for {@link Neo4jRepositoryFragmentsContributor}.
+ *
+ * @author Mark Paluch
+ */
+class Neo4jRepositoryFragmentsContributorUnitTests {
+
+	Neo4jMappingContext mappingContext = new Neo4jMappingContext();
+	Neo4jOperations operations = mock(Neo4jOperations.class);
+
+	@Test
+	void builtInContributorShouldCreateFragments() {
+
+		RepositoryComposition.RepositoryFragments fragments = Neo4jRepositoryFragmentsContributor.DEFAULT.contribute(
+				AbstractRepositoryMetadata.getMetadata(CypherdslRepository.class),
+				new DefaultNeo4jEntityInformation<>(mappingContext.getPersistentEntity(ThingWithAllAdditionalTypes.class)),
+				operations, mappingContext);
+
+		assertThat(fragments).hasSize(2);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> cypherdsl = iterator.next();
+		assertThat(cypherdsl.getImplementationClass()).contains(CypherdslConditionExecutorImpl.class);
+	}
+
+	@Test
+	void builtInContributorShouldDescribeFragments() {
+
+		RepositoryComposition.RepositoryFragments fragments = Neo4jRepositoryFragmentsContributor.DEFAULT
+				.describe(AbstractRepositoryMetadata.getMetadata(ComposedRepository.class));
+
+		assertThat(fragments).hasSize(3);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> querydsl = iterator.next();
+		assertThat(querydsl.getImplementationClass()).contains(QuerydslNeo4jPredicateExecutor.class);
+
+		RepositoryFragment<?> cypherdsl = iterator.next();
+		assertThat(cypherdsl.getImplementationClass()).contains(CypherdslConditionExecutorImpl.class);
+	}
+
+	@Test
+	void composedContributorShouldCreateFragments() {
+
+		Neo4jRepositoryFragmentsContributor contributor = Neo4jRepositoryFragmentsContributor.DEFAULT
+				.andThen(MyNeo4jRepositoryFragmentsContributor.INSTANCE);
+
+		RepositoryComposition.RepositoryFragments fragments = contributor.contribute(
+				AbstractRepositoryMetadata.getMetadata(QuerydslRepository.class),
+				new DefaultNeo4jEntityInformation<>(mappingContext.getPersistentEntity(ThingWithAllAdditionalTypes.class)),
+				operations, mappingContext);
+
+		assertThat(fragments).hasSize(3);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> querydsl = iterator.next();
+		assertThat(querydsl.getImplementationClass()).contains(QuerydslNeo4jPredicateExecutor.class);
+
+		RepositoryFragment<?> additional = iterator.next();
+		assertThat(additional.getImplementationClass()).contains(MyFragment.class);
+	}
+
+	enum MyNeo4jRepositoryFragmentsContributor implements Neo4jRepositoryFragmentsContributor {
+
+		INSTANCE;
+
+		@Override
+		public RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+				Neo4jEntityInformation<?, ?> entityInformation, Neo4jOperations operations,
+				Neo4jMappingContext mappingContext) {
+			return RepositoryComposition.RepositoryFragments.just(new MyFragment());
+		}
+
+		@Override
+		public RepositoryComposition.RepositoryFragments describe(RepositoryMetadata metadata) {
+			return RepositoryComposition.RepositoryFragments.just(new MyFragment());
+		}
+	}
+
+	static class MyFragment {
+
+	}
+
+	interface QuerydslRepository
+			extends Repository<ThingWithAllAdditionalTypes, Long>, QuerydslPredicateExecutor<ThingWithAllAdditionalTypes> {}
+
+	interface CypherdslRepository
+			extends Repository<ThingWithAllAdditionalTypes, Long>, CypherdslConditionExecutor<ThingWithAllAdditionalTypes> {}
+
+	interface ComposedRepository extends Repository<ThingWithAllAdditionalTypes, Long>,
+			QuerydslPredicateExecutor<ThingWithAllAdditionalTypes>, CypherdslConditionExecutor<ThingWithAllAdditionalTypes> {}
+
+}

--- a/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryTest.java
@@ -44,7 +44,7 @@ class ReactiveNeo4jRepositoryFactoryTest {
 	@Nested
 	class IdentifierTypeCheck {
 
-		@Spy private ReactiveNeo4jRepositoryFactory neo4jRepositoryFactory = new ReactiveNeo4jRepositoryFactory(null, null);
+		@Spy private ReactiveNeo4jRepositoryFactory neo4jRepositoryFactory = new ReactiveNeo4jRepositoryFactory(null, null, null);
 		private Neo4jEntityInformation entityInformation;
 		private RepositoryInformation metadata;
 

--- a/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFragmentsContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFragmentsContributorUnitTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.repository.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.neo4j.core.ReactiveNeo4jOperations;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.integration.shared.conversion.ThingWithAllAdditionalTypes;
+import org.springframework.data.neo4j.repository.query.ReactiveCypherdslConditionExecutorImpl;
+import org.springframework.data.neo4j.repository.query.ReactiveQuerydslNeo4jPredicateExecutor;
+import org.springframework.data.neo4j.repository.query.SimpleReactiveQueryByExampleExecutor;
+import org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryFragment;
+
+/**
+ * Unit tests for {@link ReactiveNeo4jRepositoryFragmentsContributor}.
+ *
+ * @author Mark Paluch
+ */
+class ReactiveNeo4jRepositoryFragmentsContributorUnitTests {
+
+	Neo4jMappingContext mappingContext = new Neo4jMappingContext();
+	ReactiveNeo4jOperations operations = mock(ReactiveNeo4jOperations.class);
+
+	@Test
+	void builtInContributorShouldCreateFragments() {
+
+		RepositoryComposition.RepositoryFragments fragments = ReactiveNeo4jRepositoryFragmentsContributor.DEFAULT
+				.contribute(AbstractRepositoryMetadata.getMetadata(CypherdslRepository.class),
+						new DefaultNeo4jEntityInformation<>(mappingContext.getPersistentEntity(ThingWithAllAdditionalTypes.class)),
+						operations, mappingContext);
+
+		assertThat(fragments).hasSize(2);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleReactiveQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> cypherdsl = iterator.next();
+		assertThat(cypherdsl.getImplementationClass()).contains(ReactiveCypherdslConditionExecutorImpl.class);
+	}
+
+	@Test
+	void builtInContributorShouldDescribeFragments() {
+
+		RepositoryComposition.RepositoryFragments fragments = ReactiveNeo4jRepositoryFragmentsContributor.DEFAULT
+				.describe(AbstractRepositoryMetadata.getMetadata(ComposedRepository.class));
+
+		assertThat(fragments).hasSize(3);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleReactiveQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> querydsl = iterator.next();
+		assertThat(querydsl.getImplementationClass()).contains(ReactiveQuerydslNeo4jPredicateExecutor.class);
+
+		RepositoryFragment<?> cypherdsl = iterator.next();
+		assertThat(cypherdsl.getImplementationClass()).contains(ReactiveCypherdslConditionExecutorImpl.class);
+	}
+
+	@Test
+	void composedContributorShouldCreateFragments() {
+
+		ReactiveNeo4jRepositoryFragmentsContributor contributor = ReactiveNeo4jRepositoryFragmentsContributor.DEFAULT
+				.andThen(MyNeo4jRepositoryFragmentsContributor.INSTANCE);
+
+		RepositoryComposition.RepositoryFragments fragments = contributor.contribute(
+				AbstractRepositoryMetadata.getMetadata(QuerydslRepository.class),
+				new DefaultNeo4jEntityInformation<>(mappingContext.getPersistentEntity(ThingWithAllAdditionalTypes.class)),
+				operations, mappingContext);
+
+		assertThat(fragments).hasSize(3);
+
+		Iterator<RepositoryFragment<?>> iterator = fragments.iterator();
+
+		RepositoryFragment<?> queryByExample = iterator.next();
+		assertThat(queryByExample.getImplementationClass()).contains(SimpleReactiveQueryByExampleExecutor.class);
+
+		RepositoryFragment<?> querydsl = iterator.next();
+		assertThat(querydsl.getImplementationClass()).contains(ReactiveQuerydslNeo4jPredicateExecutor.class);
+
+		RepositoryFragment<?> additional = iterator.next();
+		assertThat(additional.getImplementationClass()).contains(MyFragment.class);
+	}
+
+	enum MyNeo4jRepositoryFragmentsContributor implements ReactiveNeo4jRepositoryFragmentsContributor {
+
+		INSTANCE;
+
+		@Override
+		public RepositoryComposition.RepositoryFragments contribute(RepositoryMetadata metadata,
+				Neo4jEntityInformation<?, ?> entityInformation, ReactiveNeo4jOperations operations,
+				Neo4jMappingContext mappingContext) {
+			return RepositoryComposition.RepositoryFragments.just(new MyFragment());
+		}
+
+		@Override
+		public RepositoryComposition.RepositoryFragments describe(RepositoryMetadata metadata) {
+			return RepositoryComposition.RepositoryFragments.just(new MyFragment());
+		}
+	}
+
+	static class MyFragment {
+
+	}
+
+	interface QuerydslRepository extends Repository<ThingWithAllAdditionalTypes, Long>,
+			ReactiveQuerydslPredicateExecutor<ThingWithAllAdditionalTypes> {}
+
+	interface CypherdslRepository extends Repository<ThingWithAllAdditionalTypes, Long>,
+			ReactiveCypherdslConditionExecutor<ThingWithAllAdditionalTypes> {}
+
+	interface ComposedRepository extends Repository<ThingWithAllAdditionalTypes, Long>,
+			ReactiveQuerydslPredicateExecutor<ThingWithAllAdditionalTypes>,
+			ReactiveCypherdslConditionExecutor<ThingWithAllAdditionalTypes> {}
+
+}


### PR DESCRIPTION
Repository fragments contributors can contribute repository fragments such as Querydsl or Cypherdsl fragments based on the repository interface declaration. Fragment contributors can be enabled for configuration to allow external contributions and provide metadata to describe fragments without actually creating instances for AOT description purposes.

See also https://github.com/spring-projects/spring-data-commons/pull/3282