### PR TITLE
backportdynamiclabels

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,21 @@
+# GitHub Actions for CodeQL Scanning
+
+name: "CodeQL Advanced"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+    - cron: '0 5 * * *'
+
+permissions: read-all
+
+jobs:
+  codeql-analysis-call:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: spring-io/github-actions/.github/workflows/codeql-analysis.yml@1

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,45 @@
+# GitHub Actions to automate GitHub issues for Spring Data Project Management
+
+name: Spring Data GitHub Issues
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  Inbox:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'spring-projects' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request == null && !contains(join(github.event.issue.labels.*.name, ', '), 'dependency-upgrade') && !contains(github.event.issue.title, 'Release ')
+    steps:
+      - name: Create or Update Issue Card
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/spring-projects/projects/25
+          github-token: ${{ secrets.GH_ISSUES_TOKEN_SPRING_DATA }}
+  Pull-Request:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'spring-projects' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request != null
+    steps:
+      - name: Create or Update Pull Request Card
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/spring-projects/projects/25
+          github-token: ${{ secrets.GH_ISSUES_TOKEN_SPRING_DATA }}
+  Feedback-Provided:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'spring-projects' && github.event_name == 'issue_comment' && github.event.action == 'created' && github.actor != 'spring-projects-issues' && github.event.pull_request == null && github.event.issue.state == 'open' && contains(toJSON(github.event.issue.labels), 'waiting-for-feedback')
+    steps:
+      - name: Update Project Card
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/spring-projects/projects/25
+          github-token: ${{ secrets.GH_ISSUES_TOKEN_SPRING_DATA }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>io.spring.develocity.conventions</groupId>
 		<artifactId>develocity-conventions-maven-extension</artifactId>
-		<version>0.0.19</version>
+		<version>0.0.22</version>
 	</extension>
 </extensions>

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -8,3 +8,7 @@
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.text=ALL-UNNAMED
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-#Thu Nov 07 09:47:20 CET 2024
-distributionUrl=https\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+#Thu Jul 17 14:00:50 CEST 2025
+distributionUrl=https\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 
 	triggers {
 		pollSCM 'H/10 * * * *'
-		upstream(upstreamProjects: "spring-data-commons/main", threshold: hudson.model.Result.SUCCESS)
+		upstream(upstreamProjects: "spring-data-commons/3.5.x", threshold: hudson.model.Result.SUCCESS)
 	}
 
 	options {

--- a/SECURITY.adoc
+++ b/SECURITY.adoc
@@ -1,9 +1,15 @@
-# Security Policy
+= Security Policy
 
-## Supported Versions
+== Reporting a Vulnerability
 
-Please see the https://spring.io/projects/spring-data-neo4j[Spring Data Neo4j] project page for supported versions.
+Please, https://github.com/spring-projects/security-advisories/security/advisories/new[open a draft security advisory] if you need to disclose and discuss a security issue in private with the Spring Data team.
+Note that we only accept reports against https://spring.io/projects/spring-data#support[supported versions].
 
-## Reporting a Vulnerability
+For more details, check out our https://spring.io/security-policy[security policy].
 
-Please don't raise security vulnerabilities here. Head over to https://pivotal.io/security to learn how to disclose them responsibly.
+== JAR signing
+
+Spring Data JARs released on Maven Central are signed.
+You'll find more information about the key here: https://spring.io/GPG-KEY-spring.txt
+
+Versions released prior to 2023 may be signed with a different key.

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -17,8 +17,8 @@ docker.redis.7.version=7.2.4
 docker.valkey.8.version=8.1.1
 
 # Docker environment settings
-docker.java.inside.basic=-v $HOME:/tmp/jenkins-home
-docker.java.inside.docker=-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v $HOME:/tmp/jenkins-home
+docker.java.inside.basic=-v $HOME:/tmp/jenkins-home --ulimit nofile=32000:32000
+docker.java.inside.docker=-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v $HOME:/tmp/jenkins-home --ulimit nofile=32000:32000
 
 # Credentials
 docker.registry=

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -1,15 +1,15 @@
 # Java versions
 java.main.tag=17.0.13_11-jdk-focal
-java.next.tag=23.0.1_11-jdk-noble
+java.next.tag=24.0.1_9-jdk-noble
 
 # Docker container images - standard
 docker.java.main.image=library/eclipse-temurin:${java.main.tag}
 docker.java.next.image=library/eclipse-temurin:${java.next.tag}
 
 # Supported versions of MongoDB
-docker.mongodb.6.0.version=6.0.10
-docker.mongodb.7.0.version=7.0.2
-docker.mongodb.8.0.version=8.0.0
+docker.mongodb.6.0.version=6.0.23
+docker.mongodb.7.0.version=7.0.20
+docker.mongodb.8.0.version=8.0.9
 
 # Supported versions of Redis
 docker.redis.6.version=6.2.13

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -1,5 +1,5 @@
 # Java versions
-java.main.tag=17.0.13_11-jdk-focal
+java.main.tag=17.0.15_6-jdk-focal
 java.next.tag=24.0.1_9-jdk-noble
 
 # Docker container images - standard

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -14,6 +14,7 @@ docker.mongodb.8.0.version=8.0.9
 # Supported versions of Redis
 docker.redis.6.version=6.2.13
 docker.redis.7.version=7.2.4
+docker.valkey.8.version=8.1.1
 
 # Docker environment settings
 docker.java.inside.basic=-v $HOME:/tmp/jenkins-home

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -7,8 +7,6 @@ docker.java.main.image=library/eclipse-temurin:${java.main.tag}
 docker.java.next.image=library/eclipse-temurin:${java.next.tag}
 
 # Supported versions of MongoDB
-docker.mongodb.4.4.version=4.4.25
-docker.mongodb.5.0.version=5.0.21
 docker.mongodb.6.0.version=6.0.10
 docker.mongodb.7.0.version=7.0.2
 docker.mongodb.8.0.version=8.0.0
@@ -16,9 +14,6 @@ docker.mongodb.8.0.version=8.0.0
 # Supported versions of Redis
 docker.redis.6.version=6.2.13
 docker.redis.7.version=7.2.4
-
-# Supported versions of Cassandra
-docker.cassandra.3.version=3.11.16
 
 # Docker environment settings
 docker.java.inside.basic=-v $HOME:/tmp/jenkins-home

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,7 +6,7 @@ mkdir -p /tmp/jenkins-home
 
 export JENKINS_USER=${JENKINS_USER_NAME}
 export SDN_FORCE_REUSE_OF_CONTAINERS=true
-export SDN_NEO4J_VERSION=5.26.2
+export SDN_NEO4J_VERSION=5.26.12
 
 MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home -Dscan=false" \
   ./mvnw -s settings.xml -P${PROFILE} clean dependency:list verify -Dsort -U -B -Dmaven.repo.local=/tmp/jenkins-home/.m2/spring-data-neo4j -Ddevelocity.storage.directory=/tmp/jenkins-home/.develocity-root

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,7 +6,7 @@ mkdir -p /tmp/jenkins-home
 
 export JENKINS_USER=${JENKINS_USER_NAME}
 export SDN_FORCE_REUSE_OF_CONTAINERS=true
-export SDN_NEO4J_VERSION=5.20
+export SDN_NEO4J_VERSION=5.26.2
 
 MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home -Dscan=false" \
   ./mvnw -s settings.xml -P${PROFILE} clean dependency:list verify -Dsort -U -B -Dmaven.repo.local=/tmp/jenkins-home/.m2/spring-data-neo4j -Ddevelocity.storage.directory=/tmp/jenkins-home/.develocity-root

--- a/etc/checkstyle/java-header.txt
+++ b/etc/checkstyle/java-header.txt
@@ -1,5 +1,5 @@
 ^\Q/*\E$
-^\Q * Copyright 2011-20\E\d\d\Q the original author or authors.\E$
+^\Q * Copyright 2011-present the original author or authors.\E$
 ^\Q *\E$
 ^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
 ^\Q * you may not use this file except in compliance with the License.\E$

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.7</version>
+	<version>7.5.8-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.4</version>
+	<version>7.5.5-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-M1</version>
+	<version>7.5.0-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.5.0-M2</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.5.0-M1</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.7-SNAPSHOT</version>
+	<version>7.5.7</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-RC1</version>
+	<version>7.5.0-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-M2</version>
+	<version>7.5.0-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.1</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
-		<neo4j.version>4.4.39</neo4j.version>
+		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.5</neo4j-java-driver.version>
-		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
+		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.27.0</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.1</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.1</neo4j-migrations.version>
 		<neo4j.version>4.4.39</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.7-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.6</springdata.commons>
+		<springdata.commons>3.5.7-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,8 +429,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<maven-install-plugin.version>3.1.4</maven-install-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.9</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.10</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.3-SNAPSHOT</version>
+	<version>7.5.3</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.5-SNAPSHOT</version>
+	<version>7.5.5</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.5</springdata.commons>
+		<springdata.commons>3.5.6-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,8 +429,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.6-SNAPSHOT</version>
+	<version>7.5.6</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.7-SNAPSHOT</version>
+		<version>3.5.7</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.7-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.7</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,20 +429,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.5.0-M1</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.0-M1</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,16 +436,6 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0</version>
+		<version>3.5.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0</springdata.commons>
+		<springdata.commons>3.5.1-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,8 +436,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.3</version>
+	<version>7.5.4-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  | Copyright 2011-2025 the original author or authors.
  |
@@ -13,13 +13,14 @@
  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  | See the License for the specific language governing permissions and
  | limitations under the License.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.3-SNAPSHOT</version>
+		<version>3.5.3</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -101,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.3-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.3</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -428,20 +429,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.5.0-M2</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.0-M2</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,16 +436,6 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.5-SNAPSHOT</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.5-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.5</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,20 +429,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0</version>
+	<version>7.5.1-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.1</version>
+	<version>7.5.2-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.1-SNAPSHOT</version>
+		<version>3.5.1</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -101,7 +101,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.1-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.1</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -428,20 +428,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.2</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.3</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.5.0-RC1</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.0-RC1</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,16 +436,6 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-M1</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-M1</springdata.commons>
+		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,6 +436,16 @@
 	</dependencies>
 
 	<repositories>
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.4-SNAPSHOT</version>
+	<version>7.5.4</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.5.0</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.0</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,20 +436,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,24 +77,16 @@
 		<cypher-dsl.version>2024.5.1</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
-		<flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
-		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+		<flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
+		<jacoco-maven-plugin.version>${jacoco}</jacoco-maven-plugin.version>
 		<jakarta.interceptor-api.version>2.0.1</jakarta.interceptor-api.version>
 		<jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
 		<java-module-name>spring.data.neo4j</java-module-name>
 		<java.version>17</java.version>
 		<jaxb.version>2.3.1</jaxb.version>
 		<junit-cc-testcontainer>2021.0.1</junit-cc-testcontainer>
-		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-		<maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
-		<maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
-		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-		<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+		<maven-install-plugin.version>3.1.4</maven-install-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
-		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.5</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
@@ -484,28 +476,8 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>${maven-deploy-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>${maven-enforcer-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>${maven-install-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>${maven-failsafe-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>${maven-jar-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -522,7 +494,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>${maven-checkstyle-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>verify</id>
@@ -660,7 +631,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>${maven-jar-plugin.version}</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
-		<cypher-dsl.version>2024.5.1</cypher-dsl.version>
+		<cypher-dsl.version>2025.2.2</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
@@ -91,7 +91,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.10</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
-		<neo4j.version>4.4.41</neo4j.version>
+		<neo4j.version>5.26.12</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-M2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-M2</springdata.commons>
+		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,6 +436,16 @@
 	</dependencies>
 
 	<repositories>
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.1</neo4j-java-driver.version>
-		<neo4j-migrations.version>2.15.1</neo4j-migrations.version>
+		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
 		<neo4j.version>4.4.39</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.5.4</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.4-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.4</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,20 +429,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<maven-install-plugin.version>3.1.4</maven-install-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.5</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.7</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
-		<cypher-dsl.version>2024.5.0</cypher-dsl.version>
+		<cypher-dsl.version>2024.5.1</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.1</version>
+		<version>3.5.2-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -101,7 +101,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.1</springdata.commons>
+		<springdata.commons>3.5.2-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -428,8 +428,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<maven-install-plugin.version>3.1.4</maven-install-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.8</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.9</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.7</version>
+		<version>3.5.8-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.7</springdata.commons>
+		<springdata.commons>3.5.8-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,8 +429,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.0-RC1</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -109,7 +109,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.0-RC1</springdata.commons>
+		<springdata.commons>3.5.0-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -436,6 +436,16 @@
 	</dependencies>
 
 	<repositories>
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
 		<repository>
 			<id>spring-milestone</id>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<maven-install-plugin.version>3.1.4</maven-install-plugin.version>
 		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.7</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.8</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright 2011-2025 the original author or authors.
+ | Copyright 2011-present the original author or authors.
  |
  | Licensed under the Apache License, Version 2.0 (the "License");
  | you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.1</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.2</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.5.0-RC1</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.5</version>
+	<version>7.5.6-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.1-SNAPSHOT</version>
+	<version>7.5.1</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.4</springdata.commons>
+		<springdata.commons>3.5.5-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,8 +429,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
-		<classgraph.version>4.8.149</classgraph.version>
 		<cypher-dsl.version>2024.4.0</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
@@ -143,11 +142,6 @@
 				<groupId>org.junit-pioneer</groupId>
 				<artifactId>junit-pioneer</artifactId>
 				<version>${junit-pioneer.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.github.classgraph</groupId>
-				<artifactId>classgraph</artifactId>
-				<version>${classgraph.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.r2dbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.2</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -101,7 +101,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.2</springdata.commons>
+		<springdata.commons>3.5.3-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -428,8 +428,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.0-SNAPSHOT</version>
+	<version>7.5.0</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.2-SNAPSHOT</version>
+	<version>7.5.2</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.3</version>
+		<version>3.5.4-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.3</springdata.commons>
+		<springdata.commons>3.5.4-SNAPSHOT</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,8 +429,20 @@
 	</dependencies>
 
 	<repositories>
-		
-		
+		<repository>
+			<id>spring-snapshot</id>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestone</id>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.2</version>
+	<version>7.5.3-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-neo4j</artifactId>
-	<version>7.5.6</version>
+	<version>7.5.7-SNAPSHOT</version>
 
 	<name>Spring Data Neo4j</name>
 	<description>Next generation Object-Graph-Mapping for Spring Data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.6-SNAPSHOT</version>
+		<version>3.5.6</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -102,7 +102,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.6-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.6</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -429,20 +429,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.4</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.5</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
-		<cypher-dsl.version>2024.4.0</cypher-dsl.version>
+		<cypher-dsl.version>2024.5.0</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.2</version>
 	</parent>
 
 	<groupId>org.springframework.data</groupId>
@@ -101,7 +101,7 @@
 
 		<skipUnitTests>${skipTests}</skipUnitTests>
 
-		<springdata.commons>3.5.2-SNAPSHOT</springdata.commons>
+		<springdata.commons>3.5.2</springdata.commons>
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 	</properties>
 
@@ -428,20 +428,8 @@
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
+		
+		
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<maven-source-plugin.version>3.2.0</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
-		<neo4j-java-driver.version>5.28.3</neo4j-java-driver.version>
+		<neo4j-java-driver.version>5.28.4</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.15.2</neo4j-migrations.version>
 		<neo4j.version>4.4.41</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>

--- a/src/main/antora/modules/ROOT/pages/appendix/conversions.adoc
+++ b/src/main/antora/modules/ROOT/pages/appendix/conversions.adoc
@@ -188,6 +188,10 @@ If you require the time zone, use a type that supports it (i.e. `ZoneDateTime`) 
 |Point with CRS 4326 and x/y corresponding to lat/long
 |
 
+|`org.springframework.data.domain.Vector`
+|persisted through `setNodeVectorProperty`
+|
+
 |Instances of `Enum`
 |String (The name value of the enum)
 |
@@ -209,6 +213,17 @@ If you require the time zone, use a type that supports it (i.e. `ZoneDateTime`) 
 |
 
 |===
+
+[[build-in.conversions.vector]]
+=== Vector type
+Spring Data has its own type for vector representation `org.springframework.data.domain.Vector`.
+While this can be used as a wrapper around a `float` or `double` array, Spring Data Neo4j supports only the `double` variant right now.
+From a user perspective, it is possible to only define the `Vector` interface on the property definition and use either `double` or `float`.
+Neo4j will store both `double` and `float` variants as a 64-bit Cypher `FLOAT` value, which is consistent with values persisted through Cypher and the dedicated `setNodeVectorProperty` function that Spring Data Neo4j uses to persist the property.
+
+NOTE: Spring Data Neo4j only allows one `Vector` property to be present in an entity definition.
+
+NOTE: Please be aware that a persisted `float` value differs from a read back value due to the nature of floating numbers.
 
 [[custom.conversions]]
 == Custom conversions

--- a/src/main/antora/modules/ROOT/pages/appendix/custom-queries.adoc
+++ b/src/main/antora/modules/ROOT/pages/appendix/custom-queries.adoc
@@ -353,8 +353,8 @@ Passing an instance of `Movie` to the repository method above, will generate the
 }
 ----
 
-A node is represented by a map. The map will always contain `__id__`  which is the mapped id property.
-Under `__labels__` all labels, static and dynamic, will be available.
+A node is represented by a map. The map will always contain `\\__id__`  which is the mapped id property.
+Under `\\__labels__` all labels, static and dynamic, will be available.
 All properties - and type of relationships - appear in those maps as they would appear in the graph when the entity would
 have been written by SDN.
 Values will have the correct Cypher type and won't need further conversion.

--- a/src/main/antora/modules/ROOT/pages/appendix/query-creation.adoc
+++ b/src/main/antora/modules/ROOT/pages/appendix/query-creation.adoc
@@ -83,7 +83,7 @@ This is needed for situations when inheritance is used and you query not for the
 Talking about relationships: If you have defined relationships in your entity, they will get added to the returned map as https://neo4j.com/docs/cypher-manual/4.0/syntax/lists/#cypher-pattern-comprehension[pattern comprehensions].
 The above return part will then look like:
 
-`RETURN n{.first_name, ..., Person_Has_Hobby: [(n)-[:Has]->(n_hobbies:Hobby)|n_hobbies{{neo4jInternalId}: id(n_hobbies), .name, __nodeLabels__: labels(n_hobbies)}]}`
+`RETURN n{.first_name, ..., Person_Has_Hobby: [(n)-[:Has]->(n_hobbies:Hobby)|n_hobbies{{neo4jInternalId}: id(n_hobbies), .name, {neo4jLabels}: labels(n_hobbies)}]}`
 
 The map projection and pattern comprehension used by SDN ensures that only the properties and relationships you have defined are getting queried.
 

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -3,24 +3,22 @@ prerelease: ${antora-component.prerelease}
 
 asciidoc:
   attributes:
-    copyright-year: ${current.year}
-    neo4jGroupId: ${project.groupId}
-    artifactId: ${project.artifactId}
     attribute-missing: 'warn'
     chomp: 'all'
-    version: ${project.version}
-    springversionshort: ${spring.short}
-    springversion: ${spring}
-    commons: ${springdata.commons.docs}
+    version: '${project.version}'
+    copyright-year: '${current.year}'
+    springversionshort: '${spring.short}'
+    springversion: '${spring}'
+    commons: '${springdata.commons.docs}'
     include-xml-namespaces: false
-    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference/{commons}
+    spring-data-commons-docs-url: '${documentation.baseurl}/spring-data/commons/reference/${springdata.commons.short}'
     spring-data-commons-javadoc-base: '{spring-data-commons-docs-url}/api/java'
-    springdocsurl: https://docs.spring.io/spring-framework/reference/{springversionshort}
+    springdocsurl: '${documentation.baseurl}/spring-framework/reference/{springversionshort}'
     spring-framework-docs: '{springdocsurl}'
-    springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api
+    springjavadocurl: '${documentation.spring-javadoc-url}'
     spring-framework-javadoc: '{springjavadocurl}'
-    springhateoasversion: ${spring-hateoas}
-    releasetrainversion: ${releasetrain}
+    springhateoasversion: '${spring-hateoas}'
+    releasetrainversion: '${releasetrain}'
     store: Neo4j
     groupIdStarter: org.springframework.boot
     artifactIdStarter: spring-boot-starter-data-neo4j

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -6,17 +6,18 @@ asciidoc:
     copyright-year: ${current.year}
     neo4jGroupId: ${project.groupId}
     artifactId: ${project.artifactId}
+    attribute-missing: 'warn'
+    chomp: 'all'
     version: ${project.version}
     springversionshort: ${spring.short}
     springversion: ${spring}
-    attribute-missing: 'warn'
     commons: ${springdata.commons.docs}
     include-xml-namespaces: false
-    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference
-    spring-data-commons-javadoc-base: https://docs.spring.io/spring-data/commons/docs/${springdata.commons}/api/
+    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference/{commons}
+    spring-data-commons-javadoc-base: '{spring-data-commons-docs-url}/api/java'
     springdocsurl: https://docs.spring.io/spring-framework/reference/{springversionshort}
-    springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api
     spring-framework-docs: '{springdocsurl}'
+    springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api
     spring-framework-javadoc: '{springjavadocurl}'
     springhateoasversion: ${spring-hateoas}
     releasetrainversion: ${releasetrain}

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -20,6 +20,8 @@ asciidoc:
     springhateoasversion: '${spring-hateoas}'
     releasetrainversion: '${releasetrain}'
     store: Neo4j
+    neo4jGroupId: ${project.groupId}
+    artifactId: ${project.artifactId}
     groupIdStarter: org.springframework.boot
     artifactIdStarter: spring-boot-starter-data-neo4j
     docs-neo4j-docker-version: 5

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -24,7 +24,7 @@ asciidoc:
     groupIdStarter: org.springframework.boot
     artifactIdStarter: spring-boot-starter-data-neo4j
     docs-neo4j-docker-version: 5
-    spring-boot-version: 3.2.0
+    spring-boot-version: 3.4.5
     docs-neo4j-4-version: 4.4.25
     docs-neo4j-3-version: 3.5.33
     java-driver-starter-href: https://github.com/neo4j/neo4j-java-driver-spring-boot-starter

--- a/src/main/java/org/springframework/data/neo4j/aot/Neo4jAotPredicates.java
+++ b/src/main/java/org/springframework/data/neo4j/aot/Neo4jAotPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/aot/Neo4jManagedTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/aot/Neo4jManagedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/aot/Neo4jManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/neo4j/aot/Neo4jManagedTypesBeanRegistrationAotProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/aot/Neo4jRuntimeHints.java
+++ b/src/main/java/org/springframework/data/neo4j/aot/Neo4jRuntimeHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractNeo4jConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
+++ b/src/main/java/org/springframework/data/neo4j/config/AbstractReactiveNeo4jConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Builtin.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Builtin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jAuditing.java
+++ b/src/main/java/org/springframework/data/neo4j/config/EnableNeo4jAuditing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/EnableReactiveNeo4jAuditing.java
+++ b/src/main/java/org/springframework/data/neo4j/config/EnableReactiveNeo4jAuditing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jAuditingRegistrar.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jAuditingRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiConfigurationSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jConfigurationSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/Neo4jEntityScanner.java
+++ b/src/main/java/org/springframework/data/neo4j/config/Neo4jEntityScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/config/ReactiveNeo4jAuditingRegistrar.java
+++ b/src/main/java/org/springframework/data/neo4j/config/ReactiveNeo4jAuditingRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DatabaseSelection.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DatabaseSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DatabaseSelectionProvider.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DatabaseSelectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultNeo4jClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DefaultReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DefaultReactiveNeo4jClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
@@ -52,11 +52,13 @@ final class DynamicLabels implements UnaryOperator<OngoingMatchAndUpdate> {
 	public OngoingMatchAndUpdate apply(OngoingMatchAndUpdate ongoingMatchAndUpdate) {
 
 		OngoingMatchAndUpdate decoratedMatchAndUpdate = ongoingMatchAndUpdate;
-		if (!oldLabels.isEmpty()) {
-			decoratedMatchAndUpdate = decoratedMatchAndUpdate.remove(rootNode, oldLabels.toArray(new String[0]));
+		if (!this.oldLabels.isEmpty()) {
+			decoratedMatchAndUpdate = decoratedMatchAndUpdate.remove(this.rootNode,
+					Cypher.allLabels(Cypher.anonParameter(this.oldLabels)));
 		}
-		if (!newLabels.isEmpty()) {
-			decoratedMatchAndUpdate = decoratedMatchAndUpdate.set(rootNode, newLabels.toArray(new String[0]));
+		if (!this.newLabels.isEmpty()) {
+			decoratedMatchAndUpdate = decoratedMatchAndUpdate.set(this.rootNode,
+					Cypher.allLabels(Cypher.anonParameter(this.newLabels)));
 		}
 		return decoratedMatchAndUpdate;
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/FluentFindOperation.java
+++ b/src/main/java/org/springframework/data/neo4j/core/FluentFindOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/FluentNeo4jOperations.java
+++ b/src/main/java/org/springframework/data/neo4j/core/FluentNeo4jOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/FluentOperationSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/FluentOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/FluentSaveOperation.java
+++ b/src/main/java/org/springframework/data/neo4j/core/FluentSaveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/KPropertyFilterSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/KPropertyFilterSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/NamedParameters.java
+++ b/src/main/java/org/springframework/data/neo4j/core/NamedParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jClient.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.core;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -43,6 +44,12 @@ import org.springframework.lang.Nullable;
  */
 @API(status = API.Status.STABLE, since = "6.0")
 public interface Neo4jClient {
+
+	/**
+	 * This is a public API introduced to turn the logging of the infamous warning back on.
+	 * {@code The query used a deprecated function: `id`.}
+	 */
+	AtomicBoolean SUPPRESS_ID_DEPRECATIONS = new AtomicBoolean(true);
 
 	LogAccessor cypherLog = new LogAccessor(LogFactory.getLog("org.springframework.data.neo4j.cypher"));
 	LogAccessor log = new LogAccessor(LogFactory.getLog(Neo4jClient.class));

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jOperations.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jPersistenceExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jPersistenceExceptionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jPropertyValueTransformers.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jPropertyValueTransformers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/Neo4jTemplate.java
@@ -1268,7 +1268,7 @@ public final class Neo4jTemplate implements
 						if (preparedQuery.resultsHaveBeenAggregated()) {
 							return all.stream().flatMap(nested -> ((Collection<T>) nested).stream()).distinct().collect(Collectors.toList());
 						}
-						return all.stream().collect(Collectors.toList());
+						return new ArrayList<>(all);
 					});
 		}
 
@@ -1328,8 +1328,8 @@ public final class Neo4jTemplate implements
 
 			Neo4jClient.MappingSpec<T> newMappingSpec = neo4jClient.query(cypherQuery)
 					.bindAll(finalParameters).fetchAs(preparedQuery.getResultType());
-			return Optional.of(preparedQuery.getOptionalMappingFunction()
-					.map(newMappingSpec::mappedBy).orElse(newMappingSpec));
+			return preparedQuery.getOptionalMappingFunction()
+					.map(newMappingSpec::mappedBy).or(() -> Optional.of(newMappingSpec));
 		}
 
 		private NodesAndRelationshipsByIdStatementProvider createNodesAndRelationshipsByIdStatementProvider(Neo4jPersistentEntity<?> entityMetaData,

--- a/src/main/java/org/springframework/data/neo4j/core/PreparedQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/core/PreparedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/PropertyFilterSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/PropertyFilterSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/PropertyPathWalkStep.java
+++ b/src/main/java/org/springframework/data/neo4j/core/PropertyPathWalkStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveDatabaseSelectionProvider.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveDatabaseSelectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentFindOperation.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentFindOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentNeo4jOperations.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentNeo4jOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentOperationSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentSaveOperation.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveFluentSaveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jOperations.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveNeo4jTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ReactiveUserSelectionProvider.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ReactiveUserSelectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/RelationshipHandler.java
+++ b/src/main/java/org/springframework/data/neo4j/core/RelationshipHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
+++ b/src/main/java/org/springframework/data/neo4j/core/ResultSummaries.java
@@ -50,7 +50,7 @@ final class ResultSummaries {
 	private static final LogAccessor cypherSecurityNotificationLog = new LogAccessor(LogFactory.getLog("org.springframework.data.neo4j.cypher.security"));
 	private static final LogAccessor cypherTopologyNotificationLog = new LogAccessor(LogFactory.getLog("org.springframework.data.neo4j.cypher.topology"));
 
-	private static final Pattern DEPRECATED_ID_PATTERN = Pattern.compile("(?im)The query used a deprecated function: `id`\\.");
+	private static final Pattern DEPRECATED_ID_PATTERN = Pattern.compile("(?im)The query used a deprecated function[\\.:] \\(?[`']id.+");
 
 	/**
 	 * Does some post-processing on the giving result summary, especially logging all notifications

--- a/src/main/java/org/springframework/data/neo4j/core/SingleValueMappingFunction.java
+++ b/src/main/java/org/springframework/data/neo4j/core/SingleValueMappingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/SingleValueMappingFunction.java
+++ b/src/main/java/org/springframework/data/neo4j/core/SingleValueMappingFunction.java
@@ -54,7 +54,11 @@ final class SingleValueMappingFunction<T> implements BiFunction<TypeSystem, Reco
 			throw new IllegalArgumentException("Records with more than one value cannot be converted without a mapper");
 		}
 
-		Value source = record.get(0);
+		return convertValue(record.get(0));
+	}
+
+	@Nullable
+	T convertValue(@Nullable Value source) {
 		if (targetClass == Void.class || targetClass == void.class) {
 			return null;
 		}

--- a/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/TemplateSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/UserSelection.java
+++ b/src/main/java/org/springframework/data/neo4j/core/UserSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/UserSelectionProvider.java
+++ b/src/main/java/org/springframework/data/neo4j/core/UserSelectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/AdditionalTypes.java
@@ -50,6 +50,7 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.convert.ConverterBuilder;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -104,12 +105,16 @@ final class AdditionalTypes {
 		hlp.add(ConverterBuilder.reading(Value.class, Node.class, Value::asNode));
 		hlp.add(ConverterBuilder.reading(Value.class, Relationship.class, Value::asRelationship));
 		hlp.add(ConverterBuilder.reading(Value.class, Map.class, Value::asMap).andWriting(AdditionalTypes::value));
-
+		hlp.add(ConverterBuilder.reading(Value.class, Vector.class, AdditionalTypes::asVector).andWriting(AdditionalTypes::value));
 		CONVERTERS = Collections.unmodifiableList(hlp);
 	}
 
 	static Value value(Map<?, ?> map) {
 		return Values.value(map);
+	}
+
+	static Value value(Vector vector) {
+		return Values.value(vector.toDoubleArray());
 	}
 
 	static TimeZone asTimeZone(Value value) {
@@ -460,6 +465,11 @@ final class AdditionalTypes {
 			array[i++] = v;
 		}
 		return array;
+	}
+
+	static Vector asVector(Value value) {
+		double[] array = asDoubleArray(value);
+		return Vector.of(array);
 	}
 
 	static Value value(short[] aShortArray) {

--- a/src/main/java/org/springframework/data/neo4j/core/convert/ConvertWith.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/ConvertWith.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/CypherTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/CypherTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/DefaultNeo4jPersistentPropertyConverterFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/DefaultNeo4jPersistentPropertyConverterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversionService.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversions.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jConversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyConverterFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyConverterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyToMapConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jPersistentPropertyToMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jSimpleTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/Neo4jSimpleTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/SpatialTypes.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/SpatialTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/TemporalAmountAdapter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/TemporalAmountAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/convert/TemporalAmountConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/convert/TemporalAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/AssociationHandlerSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/AssociationHandlerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
@@ -69,6 +69,11 @@ public final class Constants {
 	public static final String NAME_OF_KNOWN_RELATIONSHIPS_PARAM = "__knownRelationShipIds__";
 	public static final String NAME_OF_ALL_PROPERTIES = "__allProperties__";
 
+	/**
+	 * Optional property for relationship properties' simple class name to keep type info
+	 */
+	public static final String NAME_OF_RELATIONSHIP_TYPE = "__relationshipType__";
+
 	public static final String NAME_OF_SYNTHESIZED_ROOT_NODE = "__sn__";
 	public static final String NAME_OF_SYNTHESIZED_RELATED_NODES = "__srn__";
 	public static final String NAME_OF_SYNTHESIZED_RELATIONS = "__sr__";

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Constants.java
@@ -58,6 +58,8 @@ public final class Constants {
 	public static final String NAME_OF_ID = "__id__";
 	public static final String NAME_OF_VERSION_PARAM = "__version__";
 	public static final String NAME_OF_PROPERTIES_PARAM = "__properties__";
+	public static final String NAME_OF_VECTOR_PROPERTY = "__vectorProperty__";
+	public static final String NAME_OF_VECTOR_VALUE = "__vectorValue__";
 	/**
 	 * Indicates the parameter that contains the static labels which are required to correctly compute the difference
 	 * in the list of dynamic labels when saving a node.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CreateRelationshipStatementHolder.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CreateRelationshipStatementHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -21,7 +21,6 @@ import static org.neo4j.cypherdsl.core.Cypher.collect;
 import static org.neo4j.cypherdsl.core.Cypher.listBasedOn;
 import static org.neo4j.cypherdsl.core.Cypher.literalOf;
 import static org.neo4j.cypherdsl.core.Cypher.match;
-import static org.neo4j.cypherdsl.core.Cypher.node;
 import static org.neo4j.cypherdsl.core.Cypher.optionalMatch;
 import static org.neo4j.cypherdsl.core.Cypher.parameter;
 
@@ -93,6 +92,14 @@ public enum CypherGenerator {
 			throw new IllegalArgumentException("Unsupported CypherDSL type: " + named.getClass());
 		}
 	};
+
+	private static Node node(String primaryLabel, List<String> additionalLabels) {
+		var labels = Cypher.exactlyLabel(primaryLabel);
+		if (!additionalLabels.isEmpty()) {
+			labels = labels.conjunctionWith(Cypher.allLabels(Cypher.anonParameter(additionalLabels)));
+		}
+		return Cypher.node(labels);
+	}
 
 	/**
 	 * Set function to be used to query either elementId or id.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConversionService.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -38,7 +38,6 @@ import java.util.stream.StreamSupport;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Relationship;
@@ -449,7 +448,7 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			nodeRepresentation.labels().forEach(labels::add);
 		} else if (queryResult instanceof Relationship) {
 			Value value = queryResult.get(Constants.NAME_OF_RELATIONSHIP_TYPE);
-			if (value instanceof NullValue) {
+			if (value.isNull()) {
 				labels.addAll(nodeDescription.getStaticLabels());
 			} else {
 				labels.add(value.asString());

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jIsNewStrategy.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jIsNewStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -185,6 +185,14 @@ final class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo
 		return this.isRelationshipPropertiesEntity.get();
 	}
 
+	@Override
+	public boolean hasRelationshipPropertyPersistTypeInfoFlag() {
+		if (!isRelationshipPropertiesEntity()) {
+			return false;
+		}
+		return getRequiredAnnotation(RelationshipProperties.class).persistTypeInfo();
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see BasicPersistentEntity#getFallbackIsNewStrategy()

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultRelationshipDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultRelationshipDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DtoInstantiatingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/EntityFromDtoInstantiatingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/EntityFromDtoInstantiatingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/EntityInstanceWithSource.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/EntityInstanceWithSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/GraphPropertyDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/GraphPropertyDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/IdDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/IdDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/IdentitySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/IdentitySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/MapValueWrapper.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/MapValueWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/MappingSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jEntityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -57,6 +57,13 @@ public interface Neo4jPersistentEntity<T>
 	boolean isRelationshipPropertiesEntity();
 
 	/**
+	 * Determines if the entity is annotated with {@link org.springframework.data.neo4j.core.schema.RelationshipProperties}
+	 * and has the flag {@link org.springframework.data.neo4j.core.schema.RelationshipProperties#persistTypeInfo()} set to true.
+	 * @return true if this is a relationship properties class and the type info should be persisted, otherwise false.
+	 */
+	boolean hasRelationshipPropertyPersistTypeInfoFlag();
+
+	/**
 	 * @return True if the underlying domain classes uses {@code id()} to compute internally generated ids.
 	 */
 	default boolean isUsingDeprecatedInternalId() {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentEntity.java
@@ -75,4 +75,9 @@ public interface Neo4jPersistentEntity<T>
 		}
 		return isUsingInternalIds() && Neo4jPersistentEntity.DEPRECATED_GENERATED_ID_TYPES.contains(getRequiredIdProperty().getType());
 	}
+
+	boolean hasVectorProperty();
+
+	Neo4jPersistentProperty getVectorProperty();
+	Neo4jPersistentProperty getRequiredVectorProperty();
 }

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Neo4jPersistentProperty.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.core.mapping;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.neo4j.core.convert.Neo4jPersistentPropertyConverter;
 import org.springframework.data.neo4j.core.schema.CompositeProperty;
@@ -65,6 +66,10 @@ public interface Neo4jPersistentProperty extends PersistentProperty<Neo4jPersist
 	 */
 	default boolean isDynamicLabels() {
 		return this.isAnnotationPresent(DynamicLabels.class) && this.isCollectionLike();
+	}
+
+	default boolean isVectorProperty() {
+		return this.getType().isAssignableFrom(Vector.class);
 	}
 
 	@Nullable

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NestedRelationshipProcessingStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NoRootNodeMappingException.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NoRootNodeMappingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionAndLabels.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionAndLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NodeDescriptionStore.java
@@ -104,7 +104,8 @@ final class NodeDescriptionStore {
 
 	private NodeDescriptionAndLabels computeConcreteNodeDescription(NodeDescription<?> entityDescription, @Nullable List<String> labels) {
 
-		boolean isConcreteClassThatFulfillsEverything = !Modifier.isAbstract(entityDescription.getUnderlyingClass().getModifiers()) && entityDescription.getStaticLabels().containsAll(labels);
+		var isAbstractClassOrInterface = Modifier.isAbstract(entityDescription.getUnderlyingClass().getModifiers());
+		boolean isConcreteClassThatFulfillsEverything = !isAbstractClassOrInterface && entityDescription.getStaticLabels().containsAll(labels);
 
 		if (labels == null || labels.isEmpty() || isConcreteClassThatFulfillsEverything) {
 			return new NodeDescriptionAndLabels(entityDescription, Collections.emptyList());
@@ -119,9 +120,12 @@ final class NodeDescriptionStore {
 
 		if (!haystack.isEmpty()) {
 
-			NodeDescription<?> mostMatchingNodeDescription = null;
+			NodeDescription<?> mostMatchingNodeDescription = !isAbstractClassOrInterface ? entityDescription : null;
+			List<String> mostMatchingStaticLabels = !isAbstractClassOrInterface ? entityDescription.getStaticLabels() : null;
 			Map<NodeDescription<?>, Integer> unmatchedLabelsCache = new HashMap<>();
-			List<String> mostMatchingStaticLabels = null;
+			if (!isAbstractClassOrInterface) {
+				unmatchedLabelsCache.put(mostMatchingNodeDescription, labels.size() - mostMatchingStaticLabels.size());
+			}
 
 			for (NodeDescription<?> nd : haystack) {
 

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/NullSafeNeo4jPersistentPropertyConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/NullSafeNeo4jPersistentPropertyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PersistentPropertyCharacteristics.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PersistentPropertyCharacteristics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PersistentPropertyCharacteristicsProvider.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PersistentPropertyCharacteristicsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyFilter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyHandlerSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyHandlerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyTraverser.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/PropertyTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/RelationshipDescription.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/RelationshipDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/SpringDataCypherDsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/UnknownEntityException.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/UnknownEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/AfterConvertCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/AfterConvertCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/AuditingBeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/AuditingBeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/BeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/BeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/EventSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/EventSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/IdGeneratingBeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/IdGeneratingBeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/IdPopulator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/IdPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/PostLoadInvocation.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/PostLoadInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveAuditingBeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveAuditingBeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveBeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveBeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveEventSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveEventSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveIdGeneratingBeforeBindCallback.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveIdGeneratingBeforeBindCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/CompositeProperty.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/CompositeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/DynamicLabels.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/DynamicLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/GeneratedValue.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/GeneratedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/Id.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/IdGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/IdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/Node.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/PostLoad.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/PostLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/Property.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/Relationship.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/Relationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipId.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipProperties.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipProperties.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/RelationshipProperties.java
@@ -52,4 +52,12 @@ import org.apiguardian.api.API;
 @Inherited
 @API(status = API.Status.STABLE, since = "6.0")
 public @interface RelationshipProperties {
+	/**
+	 * Set to true will persist {@link org.springframework.data.neo4j.core.mapping.Constants#NAME_OF_RELATIONSHIP_TYPE} to {@link Class#getSimpleName()}
+	 * as a property in relationships. This property will be used to determine the type of the relationship
+	 * when mapping back to the domain model.
+	 *
+	 * @return whether to persist type information for the annotated class.
+	 */
+	boolean persistTypeInfo() default false;
 }

--- a/src/main/java/org/springframework/data/neo4j/core/schema/TargetNode.java
+++ b/src/main/java/org/springframework/data/neo4j/core/schema/TargetNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/BookmarkManagerReference.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/BookmarkManagerReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/DateLong.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/DateLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/DateString.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/DateString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/RetryExceptionPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/RetryExceptionPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/UUIDStringGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/UUIDStringGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/support/UserAgent.java
+++ b/src/main/java/org/springframework/data/neo4j/core/support/UserAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/AbstractBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/AbstractBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/DefaultBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarksUpdatedEvent.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarksUpdatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jSessionSynchronization.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jSessionSynchronization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionContext.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionHolder.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionUtils.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/NoopBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/NoopBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveDefaultBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jSessionSynchronization.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jSessionSynchronization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionHolder.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManager.java
+++ b/src/main/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/Neo4jRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/NoResultException.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/NoResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/ReactiveNeo4jRepository.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/ReactiveNeo4jRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/EnableReactiveNeo4jRepositories.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/EnableReactiveNeo4jRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoriesRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoriesRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/config/StartupLogger.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/config/StartupLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/AbstractReactiveNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/BoundingBox.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/BoundingBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslBasedQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslBasedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/CypherdslConditionExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ExistsQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ExistsQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FetchableFluentQueryByPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/FluentQuerySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jParameterAccessor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jParameterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryExecution.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryLookupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQuerySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryType.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jQueryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupport.java
@@ -18,10 +18,8 @@ package org.springframework.data.neo4j.repository.query;
 import java.io.Serial;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.locks.StampedLock;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -248,10 +246,7 @@ public final class Neo4jSpelSupport {
 				.getRequiredPersistentEntity(metadata.getJavaType());
 		evalContext.getEvaluationContext().setVariable(ENTITY_NAME, requiredPersistentEntity.getStaticLabels()
 				.stream()
-				.map(l -> {
-					Matcher matcher = LABEL_AND_TYPE_QUOTATION.matcher(l);
-					return String.format(Locale.ENGLISH, "`%s`", matcher.replaceAll("``"));
-				})
+				.map(l -> SchemaNames.sanitize(l, true).orElseThrow())
 				.collect(Collectors.joining(":")));
 
 		query = potentiallyQuoteExpressionsParameter(query);

--- a/src/main/java/org/springframework/data/neo4j/repository/query/OptionalUnwrappingConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/OptionalUnwrappingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PartTreeNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PartValidator.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PartValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/PropertyPathWrapper.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/PropertyPathWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/Query.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragments.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QueryFragmentsAndParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/QuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/QuerydslNeo4jPredicateExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslBasedQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslBasedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveCypherdslConditionExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByPredicate.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveFluentQueryByPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveNeo4jQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveNeo4jQueryLookupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveNeo4jQueryMethod.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveNeo4jQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactivePartTreeNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveQuerydslNeo4jPredicateExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleQueryByExampleExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/SimpleReactiveQueryByExampleExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/query/StringBasedNeo4jQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/CypherdslConditionExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/CypherdslConditionExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/CypherdslStatementExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/CypherdslStatementExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/DefaultNeo4jEntityInformation.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/DefaultNeo4jEntityInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/EntityAndGraphPropertyAccessingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/EntityAndGraphPropertyAccessingMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jEntityInformation.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jEntityInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jEvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jEvaluationContextExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryCdiBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryCdiBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslConditionExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslStatementExecutor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveCypherdslStatementExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactivePersistenceExceptionTranslationInterceptor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactivePersistenceExceptionTranslationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/ReactivePersistenceExceptionTranslationPostProcessor.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/ReactivePersistenceExceptionTranslationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/SimpleNeo4jRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/repository/support/SimpleReactiveNeo4jRepository.java
+++ b/src/main/java/org/springframework/data/neo4j/repository/support/SimpleReactiveNeo4jRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/AbstractPoint.java
+++ b/src/main/java/org/springframework/data/neo4j/types/AbstractPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/CartesianPoint2d.java
+++ b/src/main/java/org/springframework/data/neo4j/types/CartesianPoint2d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/CartesianPoint3d.java
+++ b/src/main/java/org/springframework/data/neo4j/types/CartesianPoint3d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/Coordinate.java
+++ b/src/main/java/org/springframework/data/neo4j/types/Coordinate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/GeographicPoint2d.java
+++ b/src/main/java/org/springframework/data/neo4j/types/GeographicPoint2d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/GeographicPoint3d.java
+++ b/src/main/java/org/springframework/data/neo4j/types/GeographicPoint3d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/Neo4jPoint.java
+++ b/src/main/java/org/springframework/data/neo4j/types/Neo4jPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/neo4j/types/PointBuilder.java
+++ b/src/main/java/org/springframework/data/neo4j/types/PointBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/Neo4jOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/Neo4jOperationsExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/PreparedQueryFactory.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/PreparedQueryFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jOperationsExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/springframework/data/neo4j/core/cypher/Parameters.kt
+++ b/src/main/kotlin/org/springframework/data/neo4j/core/cypher/Parameters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5 GA (2025.0.0)
+Spring Data Neo4j 7.5.1 (2025.0.1)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.6 (2025.0.6)
+Spring Data Neo4j 7.5.7 (2025.0.7)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.4 GA (2024.1.0)
+Spring Data Neo4j 7.5 M1 (2025.0.0)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.2 (2025.0.2)
+Spring Data Neo4j 7.5.3 (2025.0.3)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.3 (2025.0.3)
+Spring Data Neo4j 7.5.4 (2025.0.4)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5 M2 (2025.0.0)
+Spring Data Neo4j 7.5 RC1 (2025.0.0)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5 RC1 (2025.0.0)
+Spring Data Neo4j 7.5 GA (2025.0.0)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.4 (2025.0.4)
+Spring Data Neo4j 7.5.5 (2025.0.5)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.1 (2025.0.1)
+Spring Data Neo4j 7.5.2 (2025.0.2)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5 M1 (2025.0.0)
+Spring Data Neo4j 7.5 M2 (2025.0.0)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Neo4j 7.5.5 (2025.0.5)
+Spring Data Neo4j 7.5.6 (2025.0.6)
 Copyright 2011-2021 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 

--- a/src/test/java/org/springframework/data/neo4j/architecture/ArchitectureTest.java
+++ b/src/test/java/org/springframework/data/neo4j/architecture/ArchitectureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/config/Neo4jAuditingRegistrarTest.java
+++ b/src/test/java/org/springframework/data/neo4j/config/Neo4jAuditingRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/DatabaseSelectionProviderTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/DatabaseSelectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/NamedParametersTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/NamedParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/Neo4jClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/Neo4jPersistenceExceptionTranslatorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/Neo4jPersistenceExceptionTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ReactiveNeo4jClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/ResultSummariesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/SingleValueMappingFunctionTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/SingleValueMappingFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/TemplateSupportTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/TemplateSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/TransactionHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/convert/SpatialTypesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/convert/SpatialTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/convert/TemporalAmountAdapterTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/convert/TemporalAmountAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.FunctionInvocation;
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Dialect;
@@ -48,6 +50,12 @@ import org.springframework.data.neo4j.core.schema.Node;
  * @author Michael J. Simons
  */
 class CypherGeneratorTest {
+
+	@BeforeAll
+	static void fixTheAbusOfASingleton() {
+		CypherGenerator.INSTANCE
+			.setElementIdOrIdFunction(n -> FunctionInvocation.create(() -> "elementId", n.getRequiredSymbolicName()));
+	}
 
 	@Test
 	void shouldCreateRelationshipCreationQueryWithLabelIfPresent() {

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConversionServiceTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jConversionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jIsNewStrategyTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jIsNewStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntityTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentPropertyTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jPersistentPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/IdDescriptionTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/IdDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContextTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/Neo4jMappingContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyFilterTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyTraverserTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/PropertyTraverserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/callback/AuditingBeforeBindCallbackTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/callback/AuditingBeforeBindCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/callback/IdPopulatorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/callback/IdPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/callback/ImmutableSample.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/callback/ImmutableSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveAuditingBeforeBindCallbackTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/callback/ReactiveAuditingBeforeBindCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/callback/Sample.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/callback/Sample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/AbstractR.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/AbstractR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/B.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/C.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/P.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/P.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/R1.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/R1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/R2.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1446/R2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/A_S3.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/A_S3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/B_S3.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/B_S3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/C_S3.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/C_S3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/R_S3.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/R_S3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/RelatedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/datagraph1448/RelatedThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Properties.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Source.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Target.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/genericRelProperties/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/gh2574/Model.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/gh2574/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/support/RetryExceptionPredicateTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/support/RetryExceptionPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/support/UserAgentTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/support/UserAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/AssertableBookmarkManager.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/AssertableBookmarkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/BookmarkForTesting.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/BookmarkForTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/BookmarkManagerTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/BookmarkManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManagerTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jBookmarkManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionManagerTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionUtilsTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/Neo4jTransactionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManagerTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/transaction/ReactiveNeo4jTransactionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/Neo4jConfig.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/Neo4jConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/domain/MovieEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/domain/MovieEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/domain/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/domain/MovieRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/domain/PersonEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/domain/PersonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/domain/Roles.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/domain/Roles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/Config.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/CustomFragmentPostfix.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/CustomFragmentPostfix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/ReactiveConfig.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/ReactiveConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/conversion/MyCustomTypeConverter.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/conversion/MyCustomTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/CustomQueriesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/CustomQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
@@ -21,7 +21,7 @@ import static org.neo4j.cypherdsl.core.Cypher.listWith;
 import static org.neo4j.cypherdsl.core.Cypher.name;
 import static org.neo4j.cypherdsl.core.Cypher.node;
 import static org.neo4j.cypherdsl.core.Cypher.parameter;
-import static org.neo4j.cypherdsl.core.Cypher.shortestPath;
+import static org.neo4j.cypherdsl.core.Cypher.shortestK;
 
 // end::domain-results-impl[]
 import java.util.Collection;
@@ -82,7 +82,7 @@ class DomainResultsImpl implements DomainResults {
 
 		var p1 = node("Person").withProperties("name", parameter("person1"));
 		var p2 = node("Person").withProperties("name", parameter("person2"));
-		var shortestPath = shortestPath("p").definedBy(
+		var shortestPath = shortestK(1).named("p").definedBy(
 				p1.relationshipBetween(p2).unbounded()
 		);
 		var p = shortestPath.getRequiredSymbolicName();

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/ARepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/ARepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/AnAggregateRoot.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/AnAggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/DomainEventsApplication.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/DomainEventsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/DomainEventsTest.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/DomainEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/SomeEvent.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/domain_events/SomeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/ReactiveTemplateExampleTest.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/ReactiveTemplateExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/TemplateExampleTest.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/spring_boot/TemplateExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/bookmarks/DatabaseInitializer.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/bookmarks/DatabaseInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/bookmarks/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/bookmarks/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/bookmarks/imperative/NoopBookmarkmanagerIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/bookmarks/imperative/NoopBookmarkmanagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/bookmarks/reactive/ReactiveNoopBookmarkmanagerIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/bookmarks/reactive/ReactiveNoopBookmarkmanagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.test.Neo4jExtension;
 
+@Tag(Neo4jExtension.NEEDS_VERSION_SUPPORTING_ELEMENT_ID)
 abstract class AbstractCascadingTestBase {
 
 	@Autowired

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CVE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CVE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CVI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CVI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/CascadingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/ExternalId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/ExternalId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/PVI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/Parent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/ReactiveCascadingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/ReactiveCascadingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/Versioned.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/Versioned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jBasedService.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jBasedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/Neo4jCdiExtensionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/cdi/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cdi/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/CustomTypesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/CustomTypesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/ImperativeCompositePropertiesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/ImperativeCompositePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/Neo4jConversionsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/Neo4jConversionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
@@ -39,6 +39,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.neo4j.driver.Driver;
@@ -70,6 +71,7 @@ import org.springframework.data.neo4j.integration.shared.conversion.ThingWithCus
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import org.springframework.data.neo4j.test.BookmarkCapture;
+import org.springframework.data.neo4j.test.Neo4jExtension;
 import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -77,11 +79,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
+ * Tag due to the requirements on db.create.setNodeVectorProperty
+ *
  * @author Michael J. Simons
  * @author Dennis Crissman
  * @soundtrack Tool - Fear Inoculum
  */
 @Neo4jIntegrationTest
+@Tag(Neo4jExtension.NEEDS_VECTOR_INDEX)
 class TypeConversionIT extends Neo4jConversionsITBase {
 
 	private final CypherTypesRepository cypherTypesRepository;

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeValue.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/CompositeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/ThingWithCompositeId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/ThingWithCompositeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/ThingWithCompositeProperty.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/compose_as_ids/ThingWithCompositeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCompositePropertiesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCompositePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCustomTypesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveCustomTypesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveTypeConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_reactive/ReactiveTypeConversionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/AuditingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/AuditingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/AuditingWithoutDatesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/AuditingWithoutDatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CallbacksIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CallbacksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CausalClusterLoadTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CausalClusterLoadTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CausalClusterLoadTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CausalClusterLoadTestIT.java
@@ -145,7 +145,7 @@ class CausalClusterLoadTestIT {
 		public boolean isCypher5Compatible() {
 			try (Session session = driver().session()) {
 				String version = session
-						.run("CALL dbms.components() YIELD versions RETURN 'Neo4j/' + versions[0] as version")
+						.run("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN 'Neo4j/' + versions[0] as version")
 						.single()
 						.get("version").asString();
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ChainedAuditingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ChainedAuditingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CollectionsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CollectionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CustomBaseRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CustomBaseRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslConditionExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslStatementExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/CypherdslStatementExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicLabelsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/DynamicRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ExceptionTranslationIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ExceptionTranslationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/IdGeneratorsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/IdGeneratorsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableAssignedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableAssignedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableExternallyGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableExternallyGeneratedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ImmutableGeneratedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
@@ -52,6 +53,7 @@ import org.springframework.data.neo4j.test.BookmarkCapture;
 import org.springframework.data.neo4j.test.Neo4jExtension;
 import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.data.neo4j.test.ServerVersion;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -333,7 +335,12 @@ public class InheritanceMappingIT {
 		}
 	}
 
+	static boolean isGreaterThanOrEqualNeo4j5() {
+		return neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.v5_0_0);
+	}
+
 	@Test // GH-2788
+	@EnabledIf("isGreaterThanOrEqualNeo4j5")
 	void detectPropertiesAndRelationshipsOfImplementingEntities(@Autowired Neo4jTemplate template) {
 		String id;
 		try (Session session = driver.session(bookmarkCapture.createSessionConfig()); Transaction transaction = session.beginTransaction()) {

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jClientIT.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
-import org.neo4j.cypherdsl.core.executables.ExecutableResultStatement;
-import org.neo4j.cypherdsl.core.executables.ExecutableStatement;
+import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
@@ -75,12 +74,12 @@ class Neo4jClientIT {
 
 		Node namedAnswer = Cypher.node("TheAnswer", Cypher.mapOf("value",
 				Cypher.literalOf(23).multiply(Cypher.literalOf(2)).subtract(Cypher.literalOf(4)))).named("n");
-		ExecutableResultStatement statement = ExecutableStatement.makeExecutable(Cypher.create(namedAnswer)
+		Statement statement = Cypher.create(namedAnswer)
 				.returning(namedAnswer)
-				.build());
+				.build();
 
 		Long vanishedId = transactionTemplate.execute(transactionStatus -> {
-			List<Record> records = statement.fetchWith(client.getQueryRunner());
+			List<Record> records = client.getQueryRunner().run(statement.getCypher()).list();
 			assertThat(records).hasSize(1)
 					.first().extracting(r -> r.get("n").get("value").asLong()).isEqualTo(42L);
 

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTemplateIT.java
@@ -1006,7 +1006,9 @@ class Neo4jTemplateIT {
 		public PlatformTransactionManager transactionManager(Driver driver, DatabaseSelectionProvider databaseNameProvider) {
 
 			BookmarkCapture bookmarkCapture = bookmarkCapture();
-			return new Neo4jTransactionManager(driver, databaseNameProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			Neo4jTransactionManager transactionManager = new Neo4jTransactionManager(driver, databaseNameProvider, Neo4jBookmarkManager.create(bookmarkCapture));
+			transactionManager.setValidateExistingTransaction(true);
+			return transactionManager;
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTransactionManagerTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/Neo4jTransactionManagerTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/OptimisticLockingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/OptimisticLockingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ProjectionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ProjectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/QuerydslNeo4jPredicateExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/QuerydslNeo4jPredicateExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RelationshipsAsConstructorParametersIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RelationshipsAsConstructorParametersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryIT.java
@@ -266,6 +266,18 @@ class RepositoryIT {
 		}
 
 		@Test
+		void noDomainType(@Autowired PersonRepository repository) {
+			var strings = repository.noDomainType();
+			assertThat(strings).containsExactly("a", "b", "c");
+		}
+
+		@Test
+		void noDomainTypeWithListInQueryShouldWork(@Autowired PersonRepository repository) {
+			var strings = repository.noDomainTypeWithListInQuery();
+			assertThat(strings).containsExactly("a", "b", "c");
+		}
+
+		@Test
 		void findAll(@Autowired PersonRepository repository) {
 
 			List<PersonWithAllConstructor> people = repository.findAll();

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryWithADifferentDatabaseIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryWithADifferentDatabaseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryWithADifferentUserIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/RepositoryWithADifferentUserIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/ScrollingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/StringlyTypedDynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/StringlyTypedDynamicRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/TransactionManagerMixedDatabasesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/TransactionManagerMixedDatabasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/FlightRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/FlightRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonRepository.java
@@ -131,6 +131,12 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 			countQuery = "MATCH (n:PersonWithAllConstructor) WHERE n.name = $aName OR n.name = $anotherName RETURN count(n)")
 	Page<PersonWithAllConstructor> findPageByCustomQueryWithCount(@Param("aName") String aName, @Param("anotherName") String anotherName, Pageable pageable);
 
+	@Query("UNWIND ['a', 'b', 'c'] AS x RETURN x")
+	List<String> noDomainType();
+
+	@Query("RETURN ['a', 'b', 'c']")
+	List<String> noDomainTypeWithListInQuery();
+
 	Long countAllByNameOrName(String aName, String anotherName);
 
 	Optional<PersonWithAllConstructor> findOneByNameAndFirstNameAllIgnoreCase(String name, String firstName);

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonWithNoConstructorRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonWithNoConstructorRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonWithWitherRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/PersonWithWitherRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/ScrollingRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/ScrollingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/ThingRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/repositories/ThingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
@@ -1707,7 +1707,7 @@ class IssuesIT extends TestBase {
 
 	@Tag("GH-2973")
 	@Test
-	void testTypeMapping(@Autowired Gh2973Repository gh2973Repository) {
+	void abstractedRelationshipTypesShouldBeMappedCorrectly(@Autowired Gh2973Repository gh2973Repository) {
 		var node = new BaseNode();
 		var nodeFail = new BaseNode();
 		RelationshipA a1 = new RelationshipA();
@@ -1756,15 +1756,19 @@ class IssuesIT extends TestBase {
 		var loadedNode = gh2973Repository.findById(persistedNode.getId()).get();
 		List<BaseRelationship> relationshipsA = loadedNode.getRelationships().get("a");
 		List<BaseRelationship> relationshipsB = loadedNode.getRelationships().get("b");
-		assertThat(relationshipsA).hasExactlyElementsOfTypes(RelationshipA.class, RelationshipA.class, RelationshipB.class);
-		assertThat(relationshipsB).hasExactlyElementsOfTypes(RelationshipB.class, RelationshipA.class);
-
+		assertThat(relationshipsA).satisfiesExactlyInAnyOrder(
+				r1 -> assertThat(r1).isOfAnyClassIn(RelationshipA.class),
+				r2 -> assertThat(r2).isOfAnyClassIn(RelationshipA.class),
+				r3 -> assertThat(r3).isOfAnyClassIn(RelationshipB.class)
+		);
+		assertThat(relationshipsB).satisfiesExactlyInAnyOrder(
+				r1 -> assertThat(r1).isOfAnyClassIn(RelationshipA.class),
+				r2 -> assertThat(r2).isOfAnyClassIn(RelationshipB.class)
+		);
 		// without type info, the relationships are all same type and not the base class BaseRelationship
 		var loadedNodeFail = gh2973Repository.findById(persistedNodeFail.getId()).get();
 		List<BaseRelationship> relationshipsCFail = loadedNodeFail.getRelationships().get("c");
 		assertThat(relationshipsCFail.get(0)).isNotExactlyInstanceOf(BaseRelationship.class);
-		var type = relationshipsCFail.get(0).getClass();
-		assertThat(relationshipsCFail).hasExactlyElementsOfTypes(type, type);
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
@@ -196,6 +196,8 @@ import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipA;
 import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipB;
 import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipC;
 import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipD;
+import org.springframework.data.neo4j.integration.issues.gh3036.Vehicle;
+import org.springframework.data.neo4j.integration.issues.gh3036.VehicleRepository;
 import org.springframework.data.neo4j.integration.issues.qbe.A;
 import org.springframework.data.neo4j.integration.issues.qbe.ARepository;
 import org.springframework.data.neo4j.integration.issues.qbe.B;
@@ -1769,6 +1771,22 @@ class IssuesIT extends TestBase {
 		var loadedNodeFail = gh2973Repository.findById(persistedNodeFail.getId()).get();
 		List<BaseRelationship> relationshipsCFail = loadedNodeFail.getRelationships().get("c");
 		assertThat(relationshipsCFail.get(0)).isNotExactlyInstanceOf(BaseRelationship.class);
+	}
+
+	@Tag("GH-3036")
+	@Test
+	void asdf(@Autowired VehicleRepository repository) {
+		var vehicleWithoutDynamicLabels = new Vehicle();
+		var vehicleWithOneDynamicLabel = new Vehicle();
+		vehicleWithOneDynamicLabel.setLabels(Set.of("label1"));
+		var vehicleWithTwoDynamicLabels = new Vehicle();
+		vehicleWithTwoDynamicLabels.setLabels(Set.of("label1", "label2"));
+
+		repository.saveAll(List.of(vehicleWithoutDynamicLabels, vehicleWithOneDynamicLabel, vehicleWithTwoDynamicLabels));
+
+		var vehicles = repository.findAllVehicles();
+		assertThat(vehicles).hasOnlyElementsOfType(Vehicle.class);
+
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/IssuesIT.java
@@ -189,6 +189,13 @@ import org.springframework.data.neo4j.integration.issues.gh2918.ConditionNode;
 import org.springframework.data.neo4j.integration.issues.gh2918.ConditionRepository;
 import org.springframework.data.neo4j.integration.issues.gh2963.MyModel;
 import org.springframework.data.neo4j.integration.issues.gh2963.MyRepository;
+import org.springframework.data.neo4j.integration.issues.gh2973.BaseNode;
+import org.springframework.data.neo4j.integration.issues.gh2973.BaseRelationship;
+import org.springframework.data.neo4j.integration.issues.gh2973.Gh2973Repository;
+import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipA;
+import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipB;
+import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipC;
+import org.springframework.data.neo4j.integration.issues.gh2973.RelationshipD;
 import org.springframework.data.neo4j.integration.issues.qbe.A;
 import org.springframework.data.neo4j.integration.issues.qbe.ARepository;
 import org.springframework.data.neo4j.integration.issues.qbe.B;
@@ -1698,6 +1705,68 @@ class IssuesIT extends TestBase {
 		assertThat(rootModelFromDbCustom).map(MyModel::getMyNestedModel).isPresent();
 	}
 
+	@Tag("GH-2973")
+	@Test
+	void testTypeMapping(@Autowired Gh2973Repository gh2973Repository) {
+		var node = new BaseNode();
+		var nodeFail = new BaseNode();
+		RelationshipA a1 = new RelationshipA();
+		RelationshipA a2 = new RelationshipA();
+		RelationshipA a3 = new RelationshipA();
+		RelationshipB b1 = new RelationshipB();
+		RelationshipB b2 = new RelationshipB();
+		RelationshipC c1 = new RelationshipC();
+		RelationshipD d1 = new RelationshipD();
+
+		a1.setTargetNode(new BaseNode());
+		a1.setA("a1");
+		a2.setTargetNode(new BaseNode());
+		a2.setA("a2");
+		a3.setTargetNode(new BaseNode());
+		a3.setA("a3");
+
+		b1.setTargetNode(new BaseNode());
+		b1.setB("b1");
+		b2.setTargetNode(new BaseNode());
+		b2.setB("b2");
+
+		c1.setTargetNode(new BaseNode());
+		c1.setC("c1");
+
+		d1.setTargetNode(new BaseNode());
+		d1.setD("d1");
+
+		node.setRelationships(Map.of(
+				"a", List.of(
+						a1, a2, b2
+				),
+				"b", List.of(
+						b1, a3
+				)
+		));
+		nodeFail.setRelationships(Map.of(
+				"c", List.of(
+						c1, d1
+				)
+		));
+		var persistedNode = gh2973Repository.save(node);
+		var persistedNodeFail = gh2973Repository.save(nodeFail);
+
+		// with type info, the relationships are of the correct type
+		var loadedNode = gh2973Repository.findById(persistedNode.getId()).get();
+		List<BaseRelationship> relationshipsA = loadedNode.getRelationships().get("a");
+		List<BaseRelationship> relationshipsB = loadedNode.getRelationships().get("b");
+		assertThat(relationshipsA).hasExactlyElementsOfTypes(RelationshipA.class, RelationshipA.class, RelationshipB.class);
+		assertThat(relationshipsB).hasExactlyElementsOfTypes(RelationshipB.class, RelationshipA.class);
+
+		// without type info, the relationships are all same type and not the base class BaseRelationship
+		var loadedNodeFail = gh2973Repository.findById(persistedNodeFail.getId()).get();
+		List<BaseRelationship> relationshipsCFail = loadedNodeFail.getRelationships().get("c");
+		assertThat(relationshipsCFail.get(0)).isNotExactlyInstanceOf(BaseRelationship.class);
+		var type = relationshipsCFail.get(0).getClass();
+		assertThat(relationshipsCFail).hasExactlyElementsOfTypes(type, type);
+	}
+
 	@Configuration
 	@EnableTransactionManagement
 	@EnableNeo4jRepositories(namedQueriesLocation = "more-custom-queries.properties")
@@ -1855,4 +1924,6 @@ class IssuesIT extends TestBase {
 
 		return repository.save(n1);
 	}
+
+
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/ReactiveIssuesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/ReactiveIssuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/SimpleDisplayNameGeneratorWithTags.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/SimpleDisplayNameGeneratorWithTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/TestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/events/EventsPublisherIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/events/EventsPublisherIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/events/Neo4jObject.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/events/Neo4jObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/events/Neo4jObjectService.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/events/Neo4jObjectService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/DomainObject.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/DomainObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/DomainObjectRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/DomainObjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/GeneratedValueStrategy.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/GeneratedValueStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObject.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectCompositePropertyConverter.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectCompositePropertyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectPropertyConverter.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectPropertyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectPropertyConverterAsBean.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2168/UnrelatedObjectPropertyConverterAsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2210/SomeEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2210/SomeEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2210/SomeRelation.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2210/SomeRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2244/Step.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2244/Step.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RangeRelation.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RangeRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RangeRelationRO.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RangeRelationRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/ReactiveSkuRORepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/ReactiveSkuRORepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/ReactiveSkuRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/ReactiveSkuRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RelationType.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/RelationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/Sku.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/Sku.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRO.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRORepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRORepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2289/SkuRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Knows.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Knows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Language.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Language.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/PersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/PersonService.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2323/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/AbstractLevel2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/AbstractLevel2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/AnimalRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/AnimalRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/BaseEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/BaseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/ReactiveAnimalRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2326/ReactiveAnimalRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/Entity2328.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/Entity2328.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/Entity2328Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/Entity2328Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/ReactiveEntity2328Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2328/ReactiveEntity2328Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/Application.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ApplicationRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ApplicationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ReactiveApplicationRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ReactiveApplicationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ReactiveWorkflowRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/ReactiveWorkflowRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/Workflow.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/Workflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/WorkflowRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2347/WorkflowRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/BaseNodeEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/BaseNodeEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/Credential.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/Credential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/NodeEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/NodeEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/NodeWithDefinedCredentials.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2415/NodeWithDefinedCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2451/WidgetRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Animal.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Boy.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Boy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Cat.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Cat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Dog.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Dog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Girl.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/Girl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/PetOwner.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/PetOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/PetOwnerRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2459/PetOwnerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModel.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModelDTO.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModelDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModelRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/CityModelRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/JobRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/JobRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/PersonModel.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/PersonModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/PersonModelRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2474/PersonModelRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestConverter.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestData.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestObject.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestObjectRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2493/TestObjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/DomainModel.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/DomainModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/DomainModelRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/DomainModelRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/Edge.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/Edge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/Vertex.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/Vertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/VertexRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2498/VertexRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2500/Device.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2500/Device.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2500/Group.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2500/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/AccountingMeasurementMeta.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/AccountingMeasurementMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/BaseNodeFieldsProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/BaseNodeFieldsProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/BaseNodeRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/BaseNodeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/DataPoint.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/DataPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/Measurand.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/Measurand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/MeasurementMeta.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/MeasurementMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/MeasurementProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/MeasurementProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/Variable.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/Variable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/VariableProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2526/VariableProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/InitialEntities.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/InitialEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/SomeStringGenerator.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/SomeStringGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/SomethingInBetweenRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2530/SomethingInBetweenRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/EntitiesAndProjections.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/EntitiesAndProjections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/GH2533Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/GH2533Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/ReactiveGH2533Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2533/ReactiveGH2533Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2542/TestNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2542/TestNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2542/TestNodeRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2542/TestNodeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572BaseEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572BaseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Child.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Child.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Parent.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Parent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/GH2572Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/MyStrategy.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/MyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/ReactiveGH2572Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2572/ReactiveGH2572Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/College.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/College.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/CollegeRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/CollegeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/Student.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2576/Student.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/ColumnNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/ColumnNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableAndColumnRelation.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableAndColumnRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2579/TableRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2583/GH2583Node.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2583/GH2583Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2583/GH2583Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2583/GH2583Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2622/GH2622Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2622/GH2622Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2622/MePointingTowardsMe.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2622/MePointingTowardsMe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/Movie.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/MovieRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/ReactiveConnectionAcquisitionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2632/ReactiveConnectionAcquisitionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Company.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Company.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/CompanyPerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/CompanyPerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/CompanyRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/CompanyRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Developer.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Developer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Enterprise.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Enterprise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Individual.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Individual.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Inventor.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Inventor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/LanguageRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/LanguageRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/ProgrammingLanguage.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/ProgrammingLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Sales.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2639/Sales.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2640/PersistentPropertyCharacteristicsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2640/PersistentPropertyCharacteristicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelEntityRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelEntityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/FirstLevelProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/OrderedRelation.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/OrderedRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelEntityRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelEntityRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/SecondLevelProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelEntityRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelEntityRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2727/ThirdLevelProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractReactiveTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractReactiveTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/AbstractTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/CorrectConfigIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/CorrectConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/CorrectReactiveConfigIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/CorrectReactiveConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithAssignedId1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithAssignedId1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithAssignedId2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithAssignedId2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithGeneratedDeprecatedId1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithGeneratedDeprecatedId1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithGeneratedDeprecatedId2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/TestEntityWithGeneratedDeprecatedId2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/WrongConfigIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/WrongConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/WrongReactiveConfigIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2728/WrongReactiveConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2819/GH2819Model.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2819/GH2819Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2819/GH2819Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2819/GH2819Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2858/GH2858.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2858/GH2858.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2858/GH2858Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2858/GH2858Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Apple.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Apple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Fruit.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Fruit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/FruitRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/FruitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/MagicalFruit.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/MagicalFruit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Orange.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2886/Orange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugFromV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugFromV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugRelationshipV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugRelationshipV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugTargetBaseV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugTargetBaseV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugTargetV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/BugTargetV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/FromRepositoryV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/FromRepositoryV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ReactiveFromRepositoryV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ReactiveFromRepositoryV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ReactiveToRepositoryV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ReactiveToRepositoryV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ToRepositoryV1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2905/ToRepositoryV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugFrom.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTarget.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTargetBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTargetBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTargetContainer.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/BugTargetContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/FromRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/FromRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/IncomingBugRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/IncomingBugRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/OutgoingBugRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/OutgoingBugRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ReactiveFromRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ReactiveFromRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ReactiveToRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ReactiveToRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ToRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2906/ToRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/HasNameAndPlace.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/HasNameAndPlace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/HasNameAndPlaceRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/HasNameAndPlaceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeWithSelfRef.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeWithSelfRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeWithSelfRefRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/LocatedNodeWithSelfRefRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/Place.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/Place.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/ReactiveLocatedNodeRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2908/ReactiveLocatedNodeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/ConditionNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/ConditionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/ConditionRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/ConditionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/FailureNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/FailureNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/FailureRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2918/FailureRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2963/MyModel.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2963/MyModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2963/MyRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2963/MyRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseNode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+
+/**
+ * @author yangyaofei
+ */
+@Node
+public class BaseNode {
+	@Id
+	@GeneratedValue
+	private UUID id;
+	@Relationship(direction = Relationship.Direction.OUTGOING)
+	private Map<String, List<BaseRelationship>> relationships = new HashMap<>();
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public Map<String, List<BaseRelationship>> getRelationships() {
+		return relationships;
+	}
+
+	public void setRelationships(Map<String, List<BaseRelationship>> relationships) {
+		this.relationships = relationships;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/BaseRelationship.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.RelationshipId;
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+import org.springframework.data.neo4j.core.schema.TargetNode;
+
+/**
+ * @author yangyaofei
+ */
+@RelationshipProperties
+public abstract class BaseRelationship {
+	@RelationshipId
+	@GeneratedValue
+	private Long id;
+	@TargetNode
+	private BaseNode targetNode;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public BaseNode getTargetNode() {
+		return targetNode;
+	}
+
+	public void setTargetNode(BaseNode targetNode) {
+		this.targetNode = targetNode;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/Gh2973Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/Gh2973Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/Gh2973Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/Gh2973Repository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+import java.util.UUID;
+
+/**
+ * Test repository for GH-2973
+ *
+ * @author yangyaofei
+ */
+public interface Gh2973Repository extends Neo4jRepository<BaseNode, UUID> {
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipA.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipA.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipA.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @author yangyaofei
+ */
+@RelationshipProperties(persistTypeInfo = true)
+public class RelationshipA extends BaseRelationship {
+	String a;
+
+	public String getA() {
+		return a;
+	}
+
+	public void setA(String a) {
+		this.a = a;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipB.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipB.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipB.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @author yangyaofei
+ */
+@RelationshipProperties(persistTypeInfo = true)
+public class RelationshipB extends BaseRelationship {
+	String b;
+
+	public String getB() {
+		return b;
+	}
+
+	public void setB(String b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipC.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipC.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipC.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @author yangyaofei
+ */
+@RelationshipProperties
+public class RelationshipC extends BaseRelationship {
+	String c;
+
+	public String getC() {
+		return c;
+	}
+
+	public void setC(String c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipD.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipD.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh2973/RelationshipD.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh2973;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @author yangyaofei
+ */
+@RelationshipProperties
+public class RelationshipD extends BaseRelationship {
+	String d;
+
+	public String getD() {
+		return d;
+	}
+
+	public void setD(String d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Car.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Car.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Car.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Car.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh3036;
+
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * Detailed implementation candidate
+ */
+@Node(primaryLabel = "Car")
+public class Car extends Vehicle {
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Sedan.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Sedan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Sedan.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Sedan.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh3036;
+
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * Detailed implementation candidate
+ */
+@Node(primaryLabel = "Sedan")
+public class Sedan extends Car {
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Vehicle.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Vehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Vehicle.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/Vehicle.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh3036;
+
+import java.util.Set;
+
+import org.springframework.data.neo4j.core.schema.DynamicLabels;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+
+/**
+ * Parent class
+ */
+@Node(primaryLabel = "Vehicle")
+public class Vehicle {
+    @Id
+	@GeneratedValue
+    public String id;
+
+    @Property(name = "name")
+    public String name;
+
+    @DynamicLabels
+    public Set<String> labels = Set.of();
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Set<String> getLabels() {
+		return labels;
+	}
+
+	public void setLabels(Set<String> labels) {
+		this.labels = labels;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/VehicleRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/VehicleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/VehicleRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/gh3036/VehicleRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.issues.gh3036;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+
+/**
+ * Repository for testing GH-3036
+ */
+public interface VehicleRepository extends Neo4jRepository<Vehicle, String> {
+    @Query("MATCH (vehicle:Vehicle) RETURN vehicle")
+	List<Vehicle> findAllVehicles();
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/NestedProjectionsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/NestedProjectionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/CentralNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/CentralNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/SourceNodeA.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/SourceNodeA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/SourceNodeB.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/model/SourceNodeB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/projection/SourceNodeAProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/projection/SourceNodeAProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/CustomRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/CustomRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/CustomRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/CustomRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/SourceNodeARepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/projections/repository/SourceNodeARepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/AbstractElementIdTestBase.java
@@ -80,6 +80,7 @@ abstract class AbstractElementIdTestBase {
 		assertThat(formattedMessages)
 				.noneMatch(s -> s.contains("Neo.ClientNotification.Statement.FeatureDeprecationWarning") ||
 						s.contains("The query used a deprecated function. ('id' is no longer supported)") ||
+						s.contains("The query used a deprecated function: `id`.") ||
 						s.matches("(?s).*toString\\(id\\(.*")); // No deprecations are logged when deprecated function call is nested. Anzeige ist raus.
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ImperativeElementIdIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ImperativeElementIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId3.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId4.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/NodeWithGeneratedId4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ReactiveElementIdIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/ReactiveElementIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/RelWithProps.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/RelWithProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/Thing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/pure_element_id/Thing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/A.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/ARepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/ARepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/B.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/issues/qbe/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/kotlin/KotlinIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/kotlin/KotlinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/A.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/B.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/LightweightMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/LightweightMappingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/MyDTO.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/MyDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/SomeDomainObject.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/SomeDomainObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/SomeDomainRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/SomeDomainRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/lite/User.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/lite/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/misc/ConcreteImplementationTwo.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/misc/ConcreteImplementationTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/misc/IdLoggingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/misc/IdLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/misc/IdLoggingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/misc/IdLoggingIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2011-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.neo4j.integration.misc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.core.Neo4jClient;
+import org.springframework.data.neo4j.integration.bookmarks.DatabaseInitializer;
+import org.springframework.data.neo4j.test.LogbackCapture;
+import org.springframework.data.neo4j.test.LogbackCapturingExtension;
+import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
+import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.data.neo4j.test.ServerVersion;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+@Neo4jIntegrationTest
+@ExtendWith(LogbackCapturingExtension.class)
+class IdLoggingIT {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	@Configuration
+	@EnableTransactionManagement
+	@ComponentScan
+	static class Config extends Neo4jImperativeTestConfiguration {
+
+		@Bean
+		DatabaseInitializer databaseInitializer(Driver driver) {
+			return new DatabaseInitializer(driver);
+		}
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		public boolean isCypher5Compatible() {
+			return neo4jConnectionSupport.isCypher5SyntaxCompatible();
+		}
+	}
+
+	static boolean isGreaterThanOrEqualNeo4j5() {
+		return neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.v5_0_0);
+	}
+
+	@EnabledIf("isGreaterThanOrEqualNeo4j5")
+	@Test
+	void idWarningShouldBeSuppressed(LogbackCapture logbackCapture, @Autowired Neo4jClient neo4jClient) {
+
+		// Was not able to combine the autowiring of capture and the client here
+		for (Boolean enabled : new Boolean[] {true, false, null}) {
+
+			Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger("org.springframework.data.neo4j.cypher.deprecation");
+			Level originalLevel = logger.getLevel();
+			logger.setLevel(Level.DEBUG);
+
+			Boolean oldValue = null;
+			if (enabled != null) {
+				oldValue = Neo4jClient.SUPPRESS_ID_DEPRECATIONS.getAndSet(enabled);
+			}
+
+			try {
+				assertThatCode(() -> neo4jClient.query(
+						"CREATE (n:XXXIdTest) RETURN id(n)").fetch().all()).doesNotThrowAnyException();
+				Predicate<String> stringPredicate = msg -> msg.contains(
+						"Neo.ClientNotification.Statement.FeatureDeprecationWarning");
+
+				if (enabled == null || enabled) {
+					assertThat(logbackCapture.getFormattedMessages()).noneMatch(stringPredicate);
+				} else {
+					assertThat(logbackCapture.getFormattedMessages()).anyMatch(stringPredicate);
+				}
+			} finally {
+				logbackCapture.clear();
+				logger.setLevel(originalLevel);
+				if (oldValue != null) {
+					Neo4jClient.SUPPRESS_ID_DEPRECATIONS.set(oldValue);
+				}
+			}
+		}
+	}
+
+	@EnabledIf("isGreaterThanOrEqualNeo4j5")
+	@Test
+	void otherDeprecationsWarningsShouldNotBeSuppressed(LogbackCapture logbackCapture, @Autowired Neo4jClient neo4jClient) {
+
+		Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger("org.springframework.data.neo4j.cypher.deprecation");
+		Level originalLevel = logger.getLevel();
+		logger.setLevel(Level.DEBUG);
+
+		try {
+			assertThatCode(() -> neo4jClient.query(
+					"MATCH (n) CALL {WITH n RETURN count(n) AS cnt} RETURN *").fetch().all()).doesNotThrowAnyException();
+			assertThat(logbackCapture.getFormattedMessages())
+					.anyMatch(msg -> msg.contains("Neo.ClientNotification.Statement.FeatureDeprecationWarning"))
+					.anyMatch(msg -> msg.contains("CALL subquery without a variable scope clause is now deprecated. Use CALL (n) { ... }"));
+		} finally {
+			logger.setLevel(originalLevel);
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/imperative/AdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/imperative/AdvancedMappingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/imperative/AdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/imperative/AdvancedMappingIT.java
@@ -298,8 +298,10 @@ class AdvancedMappingIT {
 	void mappingOfAPathWithOddNumberOfElementsShouldWorkFromStartToEnd(@Autowired Neo4jTemplate template) {
 
 		Map<String, Movie> movies = template
-				.findAll(
-						"MATCH p=shortestPath((:Person {name: 'Mary Alice'})-[*]-(:Person {name: 'Emil Eifrem'})) RETURN p",
+				.findAll("""
+					MATCH p=shortestPath((:Person {name: 'Mary Alice'})-[*]-(:Person {name: 'Emil Eifrem'}))
+					WHERE any(t IN [ x in nodes(p) | x.title] WHERE t = 'The Matrix Reloaded')
+					RETURN p""",
 						Collections.emptyMap(), Movie.class)
 				.stream().collect(Collectors.toMap(Movie::getTitle, Function.identity()));
 		assertThat(movies).hasSize(3);
@@ -317,8 +319,11 @@ class AdvancedMappingIT {
 	void mappingOfAPathWithEventNumberOfElementsShouldWorkFromStartToEnd(@Autowired Neo4jTemplate template) {
 
 		Map<String, Movie> movies = template
-				.findAll(
-						"MATCH p=shortestPath((:Movie {title: 'The Matrix Revolutions'})-[*]-(:Person {name: 'Emil Eifrem'})) RETURN p",
+				.findAll("""
+					MATCH p=shortestPath((:Movie {title: 'The Matrix Revolutions'})-[*]-(:Person {name: 'Emil Eifrem'}))
+					WHERE any(t IN [ x in nodes(p) | x.title] WHERE t = 'The Matrix Reloaded')
+					RETURN p
+					""",
 						Collections.emptyMap(), Movie.class)
 				.stream().collect(Collectors.toMap(Movie::getTitle, Function.identity()));
 		assertThat(movies).hasSize(3);

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/reactive/ReactiveAdvancedMappingIT.java
@@ -258,7 +258,10 @@ class ReactiveAdvancedMappingIT {
 	void mappingOfAPathWithOddNumberOfElementsShouldWorkFromStartToEnd(@Autowired ReactiveNeo4jTemplate template) {
 
 		StepVerifier.create(template
-				.findAll("MATCH p=shortestPath((:Person {name: 'Mary Alice'})-[*]-(:Person {name: 'Emil Eifrem'})) RETURN p", Collections.emptyMap(), Movie.class))
+				.findAll("""
+					MATCH p=shortestPath((:Person {name: 'Mary Alice'})-[*]-(:Person {name: 'Emil Eifrem'}))
+					WHERE any(t IN [ x in nodes(p) | x.title] WHERE t = 'The Matrix Reloaded')
+					RETURN p""", Collections.emptyMap(), Movie.class))
 				.recordWith(ArrayList::new)
 				.expectNextCount(3)
 				.consumeRecordedWith(result -> {
@@ -279,7 +282,10 @@ class ReactiveAdvancedMappingIT {
 	void mappingOfAPathWithEventNumberOfElementsShouldWorkFromStartToEnd(@Autowired ReactiveNeo4jTemplate template) {
 
 		StepVerifier.create(template
-				.findAll("MATCH p=shortestPath((:Movie {title: 'The Matrix Revolutions'})-[*]-(:Person {name: 'Emil Eifrem'})) RETURN p", Collections.emptyMap(), Movie.class))
+				.findAll("""
+					MATCH p=shortestPath((:Movie {title: 'The Matrix Revolutions'})-[*]-(:Person {name: 'Emil Eifrem'}))
+					WHERE any(t IN [ x in nodes(p) | x.title] WHERE t = 'The Matrix Reloaded')
+					RETURN p""", Collections.emptyMap(), Movie.class))
 				.recordWith(ArrayList::new)
 				.expectNextCount(3)
 				.consumeRecordedWith(result -> {

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Actor.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/CypherUtils.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/CypherUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Movie.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Organisation.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Organisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Partner.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Partner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/movies/shared/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/MultipleContextsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/MultipleContextsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/SharedConfig.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/SharedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Config.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Entity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain1/Domain1Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Config.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Entity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Repository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/multiple_ctx_imperative/domain2/Domain2Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/properties/DomainClasses.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/properties/DomainClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/properties/PropertyIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/properties/PropertyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/properties/ReactivePropertyIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/properties/ReactivePropertyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/CustomReactiveBaseRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/CustomReactiveBaseRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingWithoutDatesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveAuditingWithoutDatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCallbacksIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCallbacksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCausalClusterLoadTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCausalClusterLoadTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCausalClusterLoadTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCausalClusterLoadTestIT.java
@@ -152,7 +152,7 @@ class ReactiveCausalClusterLoadTestIT {
 		public boolean isCypher5Compatible() {
 			try (Session session = driver().session()) {
 				String version = session
-						.run("CALL dbms.components() YIELD versions RETURN 'Neo4j/' + versions[0] as version")
+						.run("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN 'Neo4j/' + versions[0] as version")
 						.single()
 						.get("version").asString();
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslConditionExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveCypherdslStatementExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -15,24 +15,6 @@
  */
 package org.springframework.data.neo4j.integration.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.neo4j.driver.TransactionContext;
-import org.junit.jupiter.api.RepeatedTest;
-import org.neo4j.driver.reactive.ReactiveSession;
-import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
-import org.springframework.data.neo4j.integration.shared.common.CounterMetric;
-import org.springframework.data.neo4j.integration.shared.common.GaugeMetric;
-import org.springframework.data.neo4j.integration.shared.common.HistogramMetric;
-import org.springframework.data.neo4j.integration.shared.common.Metric;
-import org.springframework.data.neo4j.integration.shared.common.SummaryMetric;
-import org.springframework.data.neo4j.test.Neo4jReactiveTestConfiguration;
-
-import reactor.adapter.JdkFlowAdapter;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,23 +27,35 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.TransactionContext;
+import org.neo4j.driver.reactive.ReactiveSession;
+import reactor.adapter.JdkFlowAdapter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.neo4j.core.ReactiveDatabaseSelectionProvider;
 import org.springframework.data.neo4j.core.ReactiveNeo4jTemplate;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager;
+import org.springframework.data.neo4j.integration.shared.common.CounterMetric;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.DynamicLabelsWithMultipleNodeLabels;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.DynamicLabelsWithNodeLabel;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.ExtendedBaseClass1;
@@ -73,8 +67,13 @@ import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDyna
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.SimpleDynamicLabelsWithVersion;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.SuperNode;
 import org.springframework.data.neo4j.integration.shared.common.EntityWithDynamicLabelsAndIdThatNeedsToBeConverted;
+import org.springframework.data.neo4j.integration.shared.common.GaugeMetric;
+import org.springframework.data.neo4j.integration.shared.common.HistogramMetric;
+import org.springframework.data.neo4j.integration.shared.common.Metric;
+import org.springframework.data.neo4j.integration.shared.common.SummaryMetric;
 import org.springframework.data.neo4j.test.BookmarkCapture;
 import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jReactiveTestConfiguration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -82,29 +81,141 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Michael J. Simons
  */
 @Tag(Neo4jExtension.NEEDS_REACTIVE_SUPPORT)
 @ExtendWith(Neo4jExtension.class)
-public class ReactiveDynamicLabelsIT {
+final class ReactiveDynamicLabelsIT {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
 
+	private ReactiveDynamicLabelsIT() {
+	}
+
+	public static class DialectConfig extends SpringTestBase.Config {
+
+		@Bean
+		@Primary
+		public org.neo4j.cypherdsl.core.renderer.Configuration getConfiguration() {
+			if (neo4jConnectionSupport.isCypher5SyntaxCompatible()) {
+				return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build();
+			}
+
+			return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build();
+		}
+
+	}
+
+	@ExtendWith(SpringExtension.class)
+	@ContextConfiguration(classes = DialectConfig.class)
+	@DirtiesContext
+	abstract static class SpringTestBase {
+
+		@Autowired
+		protected Driver driver;
+
+		@Autowired
+		protected TransactionalOperator transactionalOperator;
+
+		@Autowired
+		protected BookmarkCapture bookmarkCapture;
+
+		protected Long existingEntityId;
+
+		abstract Long createTestEntity(TransactionContext t);
+
+		@BeforeEach
+		void setupData() {
+			try (Session session = this.driver.session();) {
+				session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
+				this.existingEntityId = session.executeWrite(this::createTestEntity);
+				this.bookmarkCapture.seedWith(session.lastBookmarks());
+			}
+		}
+
+		@SuppressWarnings("deprecation")
+		protected final Flux<String> getLabels(Long id) {
+			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(Cypher.parameter("id")), id);
+		}
+
+		protected final Flux<String> getLabels(Condition idCondition, Object id) {
+
+			Node n = Cypher.anyNode("n");
+			String cypher = Renderer.getDefaultRenderer()
+				.render(Cypher.match(n)
+					.where(idCondition)
+					.and(n.property("moreLabels").isNull())
+					.unwind(n.labels())
+					.as("label")
+					.returning("label")
+					.build());
+			return Flux.usingWhen(Mono.fromSupplier(
+					() -> this.driver.session(ReactiveSession.class, this.bookmarkCapture.createSessionConfig())),
+					s -> JdkFlowAdapter.flowPublisherToFlux(s.run(cypher, Collections.singletonMap("id", id)))
+						.flatMap(r -> JdkFlowAdapter.flowPublisherToFlux(r.records())),
+					rs -> JdkFlowAdapter.flowPublisherToFlux(rs.close()))
+				.map(r -> r.get("label").asString());
+		}
+
+		@Configuration
+		@EnableTransactionManagement
+		static class Config extends Neo4jReactiveTestConfiguration {
+
+			@Bean
+			@Override
+			public Driver driver() {
+				return neo4jConnectionSupport.getDriver();
+			}
+
+			@Bean
+			BookmarkCapture bookmarkCapture() {
+				return new BookmarkCapture();
+			}
+
+			@Override
+			public ReactiveTransactionManager reactiveTransactionManager(Driver driver,
+					ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
+
+				BookmarkCapture bookmarkCapture = bookmarkCapture();
+				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider,
+						Neo4jBookmarkManager.createReactive(bookmarkCapture));
+			}
+
+			@Bean
+			TransactionalOperator transactionalOperator(ReactiveTransactionManager transactionManager) {
+				return TransactionalOperator.create(transactionManager);
+			}
+
+			@Override
+			public boolean isCypher5Compatible() {
+				return neo4jConnectionSupport.isCypher5SyntaxCompatible();
+			}
+
+		}
+
+	}
 
 	@Nested
 	class DynamicLabelsAndOrderOfClassesBeingLoaded extends SpringTestBase {
 
 		@Override
 		Long createTestEntity(TransactionContext t) {
-			return t.run("CREATE (m:Metric:Counter:A:B:C:D {timestamp: datetime()}) RETURN id(m)").single().get(0).asLong();
+			return t.run("CREATE (m:Metric:Counter:A:B:C:D {timestamp: datetime()}) RETURN id(m)")
+				.single()
+				.get(0)
+				.asLong();
 
 		}
 
 		@RepeatedTest(100) // GH-2619
-		void ownLabelsShouldNotEndUpWithDynamicLabels(@Autowired Neo4jMappingContext mappingContext, @Autowired ReactiveNeo4jTemplate template) {
+		void ownLabelsShouldNotEndUpWithDynamicLabels(@Autowired Neo4jMappingContext mappingContext,
+				@Autowired ReactiveNeo4jTemplate template) {
 
-			List<Class<? extends Metric>> metrics = Arrays.asList(GaugeMetric.class, SummaryMetric.class, HistogramMetric.class, CounterMetric.class);
+			List<Class<? extends Metric>> metrics = Arrays.asList(GaugeMetric.class, SummaryMetric.class,
+					HistogramMetric.class, CounterMetric.class);
 			Collections.shuffle(metrics);
 			for (Class<?> type : metrics) {
 				assertThat(mappingContext.getPersistentEntity(type)).isNotNull();
@@ -112,15 +223,18 @@ public class ReactiveDynamicLabelsIT {
 
 			Map<String, Object> args = new HashMap<>();
 			args.put("agentIdLabel", "B");
-			template.findAll("MATCH (m:Metric) WHERE $agentIdLabel in labels(m) RETURN m ORDER BY m.timestamp DESC", args, Metric.class)
-					.as(StepVerifier::create)
-					.assertNext(cm -> {
-						assertThat(cm).isInstanceOf(CounterMetric.class);
-						assertThat(cm.getId()).isEqualTo(existingEntityId);
-						assertThat(cm.getDynamicLabels()).containsExactlyInAnyOrder("A", "B", "C", "D");
-					})
-					.verifyComplete();
+			template
+				.findAll("MATCH (m:Metric) WHERE $agentIdLabel in labels(m) RETURN m ORDER BY m.timestamp DESC", args,
+						Metric.class)
+				.as(StepVerifier::create)
+				.assertNext(cm -> {
+					assertThat(cm).isInstanceOf(CounterMetric.class);
+					assertThat(cm.getId()).isEqualTo(this.existingEntityId);
+					assertThat(cm.getDynamicLabels()).containsExactlyInAnyOrder("A", "B", "C", "D");
+				})
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -129,28 +243,36 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId").single();
+				.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar").verifyComplete();
+			template.findById(this.existingEntityId, SimpleDynamicLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabels.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, SimpleDynamicLabels.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabels").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -162,10 +284,14 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "SimpleDynamicLabels").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -179,11 +305,17 @@ public class ReactiveDynamicLabelsIT {
 			SuperNode superNode = new SuperNode();
 			superNode.relatedTo = entity;
 
-			template.save(superNode).map(SuperNode::getRelatedTo).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels)
-					.sort().as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabels").verifyComplete();
+			template.save(superNode)
+				.map(SuperNode::getRelatedTo)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -191,30 +323,37 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabels:InheritedSimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
-					.single();
+			Record r = transaction.run(
+					"CREATE (e:SimpleDynamicLabels:InheritedSimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, InheritedSimpleDynamicLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar").verifyComplete();
+			template.findById(this.existingEntityId, InheritedSimpleDynamicLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, InheritedSimpleDynamicLabels.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, InheritedSimpleDynamicLabels.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -226,11 +365,16 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -239,9 +383,9 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction.run("""
-				CREATE (e:SimpleDynamicLabelsWithBusinessId:Foo:Bar:Baz:Foobar {id: 'E1'})
-				RETURN id(e) as existingEntityId
-				""").single();
+					CREATE (e:SimpleDynamicLabelsWithBusinessId:Foo:Bar:Baz:Foobar {id: 'E1'})
+					RETURN id(e) as existingEntityId
+					""").single();
 			return r.get("existingEntityId").asLong();
 		}
 
@@ -252,9 +396,13 @@ public class ReactiveDynamicLabelsIT {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessId").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessId")
+				.verifyComplete();
 		}
 
 		@Test
@@ -267,11 +415,16 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabelsWithBusinessId::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessId").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabelsWithBusinessId::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessId")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -280,22 +433,26 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction.run(
-					"CREATE (e:SimpleDynamicLabelsWithVersion:Foo:Bar:Baz:Foobar {myVersion: 0}) RETURN id(e) as existingEntityId").single();
+					"CREATE (e:SimpleDynamicLabelsWithVersion:Foo:Bar:Baz:Foobar {myVersion: 0}) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabelsWithVersion.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, SimpleDynamicLabelsWithVersion.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
-					.as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort()
-					.as(StepVerifier::create).expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithVersion")
-					.verifyComplete();
+			})
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithVersion")
+				.verifyComplete();
 		}
 
 		@Test
@@ -307,12 +464,17 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
-					.map(SimpleDynamicLabelsWithVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "SimpleDynamicLabelsWithVersion").verifyComplete();
+			template.save(entity)
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
+				.map(SimpleDynamicLabelsWithVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithVersion")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -320,7 +482,9 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:SimpleDynamicLabelsWithBusinessIdAndVersion:Foo:Bar:Baz:Foobar {id: 'E2', myVersion: 0}) RETURN id(e) as existingEntityId").single();
+			Record r = transaction.run(
+					"CREATE (e:SimpleDynamicLabelsWithBusinessIdAndVersion:Foo:Bar:Baz:Foobar {id: 'E2', myVersion: 0}) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
@@ -331,12 +495,15 @@ public class ReactiveDynamicLabelsIT {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
-					.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessIdAndVersion").verifyComplete();
+			})
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
+				.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessIdAndVersion")
+				.verifyComplete();
 		}
 
 		@Test
@@ -349,13 +516,17 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
-					.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessIdAndVersion")
-					.verifyComplete();
+			template.save(entity)
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
+				.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessIdAndVersion")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -364,18 +535,21 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabelsCtor:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
-					.single();
+				.run("CREATE (e:SimpleDynamicLabelsCtor:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabelsCtor.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar");
+			template.findById(this.existingEntityId, SimpleDynamicLabelsCtor.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar");
 		}
+
 	}
 
 	@Nested
@@ -383,48 +557,55 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId").single();
+			Record r = transaction
+				.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsOnClassWithSingleNodeLabel(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, DynamicLabelsWithNodeLabel.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Foo", "Foobar", "SimpleDynamicLabels")
-					.verifyComplete();
+			template.findById(this.existingEntityId, DynamicLabelsWithNodeLabel.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Foo", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsOnClassWithMultipleNodeLabel(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, DynamicLabelsWithMultipleNodeLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Baz", "Foobar", "SimpleDynamicLabels")
-					.verifyComplete();
+			template.findById(this.existingEntityId, DynamicLabelsWithMultipleNodeLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Baz", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test // GH-2296
 		void shouldConvertIds(@Autowired ReactiveNeo4jTemplate template) {
 
 			String label = "value_1";
-			Predicate<EntityWithDynamicLabelsAndIdThatNeedsToBeConverted> expectatations = savedInstance ->
-					label.equals(savedInstance.getValue()) && savedInstance.getExtraLabels().contains(label);
+			Predicate<EntityWithDynamicLabelsAndIdThatNeedsToBeConverted> expectatations = savedInstance -> label
+				.equals(savedInstance.getValue()) && savedInstance.getExtraLabels().contains(label);
 
 			AtomicReference<UUID> generatedUUID = new AtomicReference<>();
 			template.deleteAll(EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.class)
-					.then(template.save(new EntityWithDynamicLabelsAndIdThatNeedsToBeConverted(label)))
-					.doOnNext(s -> generatedUUID.set(s.getId()))
-					.as(StepVerifier::create)
-					.expectNextMatches(expectatations)
-					.verifyComplete();
+				.then(template.save(new EntityWithDynamicLabelsAndIdThatNeedsToBeConverted(label)))
+				.doOnNext(s -> generatedUUID.set(s.getId()))
+				.as(StepVerifier::create)
+				.expectNextMatches(expectatations)
+				.verifyComplete();
 
 			template.findById(generatedUUID.get(), EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.class)
-					.as(StepVerifier::create)
-					.expectNextMatches(expectatations)
-					.verifyComplete();
+				.as(StepVerifier::create)
+				.expectNextMatches(expectatations)
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -432,91 +613,23 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:DynamicLabelsBaseClass:ExtendedBaseClass1:D1:D2:D3) RETURN id(e) as existingEntityId").single();
+			Record r = transaction
+				.run("CREATE (e:DynamicLabelsBaseClass:ExtendedBaseClass1:D1:D2:D3) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsInInheritance(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, ExtendedBaseClass1.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("D1", "D2", "D3")
-					.verifyComplete();
-		}
-	}
-
-	@ExtendWith(SpringExtension.class)
-	@ContextConfiguration(classes = SpringTestBase.Config.class)
-	@DirtiesContext
-	abstract static class SpringTestBase {
-
-		@Autowired protected Driver driver;
-
-		@Autowired protected TransactionalOperator transactionalOperator;
-
-		@Autowired protected BookmarkCapture bookmarkCapture;
-
-		protected Long existingEntityId;
-
-		abstract Long createTestEntity(TransactionContext t);
-
-		@BeforeEach
-		void setupData() {
-			try (Session session = driver.session();) {
-				session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
-				existingEntityId = session.executeWrite(this::createTestEntity);
-				bookmarkCapture.seedWith(session.lastBookmarks());
-			}
+			template.findById(this.existingEntityId, ExtendedBaseClass1.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("D1", "D2", "D3")
+				.verifyComplete();
 		}
 
-		@SuppressWarnings("deprecation")
-		protected final Flux<String> getLabels(Long id) {
-			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(Cypher.parameter("id")), id);
-		}
-
-		protected final Flux<String> getLabels(Condition idCondition, Object id) {
-
-			Node n = Cypher.anyNode("n");
-			String cypher = Renderer.getDefaultRenderer().render(Cypher.match(n).where(idCondition)
-					.and(n.property("moreLabels").isNull()).unwind(n.labels()).as("label").returning("label").build());
-			return Flux
-					.usingWhen(Mono.fromSupplier(() -> driver.session(ReactiveSession.class, bookmarkCapture.createSessionConfig())),
-							s -> JdkFlowAdapter.flowPublisherToFlux(s.run(cypher, Collections.singletonMap("id", id))).flatMap(r -> JdkFlowAdapter.flowPublisherToFlux(r.records())), rs -> JdkFlowAdapter.flowPublisherToFlux(rs.close()))
-					.map(r -> r.get("label").asString());
-		}
-
-		@Configuration
-		@EnableTransactionManagement
-		static class Config extends Neo4jReactiveTestConfiguration {
-
-			@Bean
-			public Driver driver() {
-				return neo4jConnectionSupport.getDriver();
-			}
-
-			@Bean
-			public BookmarkCapture bookmarkCapture() {
-				return new BookmarkCapture();
-			}
-
-			@Override
-			public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
-
-				BookmarkCapture bookmarkCapture = bookmarkCapture();
-				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
-			}
-
-			@Bean
-			public TransactionalOperator transactionalOperator(ReactiveTransactionManager transactionManager) {
-				return TransactionalOperator.create(transactionManager);
-			}
-
-			@Override
-			public boolean isCypher5Compatible() {
-				return neo4jConnectionSupport.isCypher5SyntaxCompatible();
-			}
-		}
 	}
 
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
@@ -70,7 +70,9 @@ class ReactiveExceptionTranslationTest {
 			ex.getMessage().matches(
 					"Node\\(\\d+\\) already exists with label `SimplePerson` and property `name` = '[\\w\\s]+'; Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'.*") ||
 			ex.getMessage().matches(
-					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Both node \\d+ and node -?\\d+ share the property value \\( String\\(\"Tom\"\\) \\); Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'")
+					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Both node \\d+ and node -?\\d+ share the property value \\( String\\(\"Tom\"\\) \\); Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'") ||
+			ex.getMessage().matches(
+					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Node\\(\\d+\\) already exists with label `Label\\[\\d+]` and property `PropertyKey\\[\\d+]` = 'Tom'; Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'")
 	);
 	// @formatter:on
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveExceptionTranslationTest.java
@@ -72,7 +72,9 @@ class ReactiveExceptionTranslationTest {
 			ex.getMessage().matches(
 					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Both node \\d+ and node -?\\d+ share the property value \\( String\\(\"Tom\"\\) \\); Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'") ||
 			ex.getMessage().matches(
-					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Node\\(\\d+\\) already exists with label `Label\\[\\d+]` and property `PropertyKey\\[\\d+]` = 'Tom'; Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'")
+					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Node\\(\\d+\\) already exists with label `Label\\[\\d+]` and property `PropertyKey\\[\\d+]` = 'Tom'; Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'") ||
+			ex.getMessage().matches(
+					"New data does not satisfy Constraint\\( id=\\d+, name='simple_person__unique_name', type='NODE PROPERTY UNIQUENESS', schema=\\(:SimplePerson \\{name}\\), ownedIndex=\\d+ \\): Node\\(\\d+\\) already exists with label `Label\\[\\d+]` and property `PropertyKey\\[\\d+]` = 'Tom'; Error code 'Neo\\.ClientError\\.Schema\\.ConstraintValidationFailed'")
 	);
 	// @formatter:on
 

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveIdGeneratorsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveIdGeneratorsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableAssignedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableAssignedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableExternallyGeneratedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveImmutableGeneratedIdsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
@@ -15,17 +15,10 @@
  */
 package org.springframework.data.neo4j.integration.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,20 +26,16 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
-import org.neo4j.cypherdsl.core.Statement;
-import org.neo4j.cypherdsl.core.executables.ExecutableResultStatement;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Query;
-import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.SimpleQueryRunner;
 import org.neo4j.driver.Transaction;
-import org.neo4j.driver.async.AsyncQueryRunner;
-import org.neo4j.driver.reactivestreams.ReactiveQueryRunner;
 import org.neo4j.driver.reactivestreams.ReactiveResult;
 import org.neo4j.driver.reactivestreams.ReactiveSession;
-import org.neo4j.driver.summary.ResultSummary;
-import org.reactivestreams.Publisher;
+import reactor.blockhound.BlockHound;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,10 +53,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
-import reactor.blockhound.BlockHound;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Michael J. Simons
@@ -153,12 +139,13 @@ class ReactiveNeo4jClientIT {
 
 		Node namedAnswer = Cypher.node("TheAnswer", Cypher.mapOf("value",
 				Cypher.literalOf(23).multiply(Cypher.literalOf(2)).subtract(Cypher.literalOf(4)))).named("n");
-		NewReactiveExecutableResultStatement statement = new NewReactiveExecutableResultStatement(namedAnswer);
+		var cypher = Cypher.create(namedAnswer).returning(namedAnswer).build().getCypher();
 
 		AtomicLong vanishedId = new AtomicLong();
 		transactionalOperator.execute(transaction -> {
-					Flux<Long> inner = client.getQueryRunner()
-							.flatMapMany(statement::fetchWith)
+					var inner = client.getQueryRunner()
+							.flatMap(qr -> Mono.from(qr.run(cypher)))
+							.flatMapMany(r -> Flux.from(r.records()))
 							.doOnNext(r -> vanishedId.set(TestIdentitySupport.getInternalId(r.get("n").asNode())))
 							.map(record -> record.get("n").get("value").asLong());
 
@@ -212,71 +199,6 @@ class ReactiveNeo4jClientIT {
 		@Override
 		public boolean isCypher5Compatible() {
 			return neo4jConnectionSupport.isCypher5SyntaxCompatible();
-		}
-	}
-
-	private static class NewReactiveExecutableResultStatement implements ExecutableResultStatement {
-
-		private final Statement delegate;
-
-		NewReactiveExecutableResultStatement(Node namedAnswer) {
-			delegate = Cypher.create(namedAnswer)
-					.returning(namedAnswer)
-					.build();
-		}
-
-		/**
-		 * This method should move into a future Cypher-DSL version.
-		 * @param reactiveQueryRunner The runner to run the statement with
-		 * @return a publisher of records
-		 */
-		public Publisher<Record> fetchWith(ReactiveQueryRunner reactiveQueryRunner) {
-			return Mono.fromCallable(this::createQuery).flatMapMany(reactiveQueryRunner::run)
-					.flatMap(ReactiveResult::records);
-		}
-
-		@Override
-		public <T> List<T> fetchWith(SimpleQueryRunner queryRunner, Function<Record, T> function) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override public <T> CompletableFuture<List<T>> fetchWith(AsyncQueryRunner asyncQueryRunner,
-				Function<Record, T> function) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ResultSummary streamWith(SimpleQueryRunner queryRunner, Consumer<Stream<Record>> consumer) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ResultSummary executeWith(SimpleQueryRunner queryRunner) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public CompletableFuture<ResultSummary> executeWith(AsyncQueryRunner queryRunner) {
-			throw new UnsupportedOperationException();
-		}
-
-		Query createQuery() {
-			return new Query(this.delegate.getCypher(), this.delegate.getCatalog().getParameters());
-		}
-
-		@Override
-		public Map<String, Object> getParameters() {
-			return this.delegate.getCatalog().getParameters();
-		}
-
-		@Override
-		public Collection<String> getParameterNames() {
-			return this.delegate.getCatalog().getParameterNames();
-		}
-
-		@Override
-		public String getCypher() {
-			return this.delegate.getCypher();
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTemplateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTransactionManagerTestIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jTransactionManagerTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveOptimisticLockingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveOptimisticLockingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveProjectionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveProjectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveQuerydslNeo4jPredicateExecutorIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveQuerydslNeo4jPredicateExecutorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryIT.java
@@ -251,6 +251,18 @@ class ReactiveRepositoryIT {
 		}
 
 		@Test
+		void noDomainType(@Autowired ReactivePersonRepository repository) {
+			var strings = repository.noDomainTypeAsFlux();
+			StepVerifier.create(strings).expectNext("a", "b", "c").verifyComplete();
+		}
+
+		@Test
+		void noDomainTypeWithListInQueryShouldWork(@Autowired ReactivePersonRepository repository) {
+			var strings = repository.noDomainTypeWithListInQuery();
+			StepVerifier.create(strings).expectNext("a", "b", "c").verifyComplete();
+		}
+
+		@Test
 		void findAllByIdsPublisher(@Autowired ReactivePersonRepository repository) {
 
 			List<PersonWithAllConstructor> personList = Arrays.asList(person1, person2);

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryWithADifferentDatabaseIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryWithADifferentDatabaseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryWithADifferentUserIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveRepositoryWithADifferentUserIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveScrollingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveStringlyTypeDynamicRelationshipsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveStringlyTypeDynamicRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveTransactionManagerMixedDatabasesTest.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveTransactionManagerMixedDatabasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveFlightRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveFlightRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactivePersonRepository.java
@@ -48,6 +48,12 @@ public interface ReactivePersonRepository extends ReactiveNeo4jRepository<Person
 	@Query("MATCH (n:PersonWithAllConstructor{name:'Test'}) return n")
 	Mono<PersonWithAllConstructor> getOnePersonViaQuery();
 
+	@Query("UNWIND ['a', 'b', 'c'] AS x RETURN x")
+	Flux<String> noDomainTypeAsFlux();
+
+	@Query("RETURN ['a', 'b', 'c']")
+	Flux<String> noDomainTypeWithListInQuery();
+
 	Mono<PersonWithAllConstructor> findOneByNameAndFirstName(String name, String firstName);
 
 	Mono<PersonWithAllConstructor> findOneByNameAndFirstNameAllIgnoreCase(String name, String firstName);

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveScrollingRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveScrollingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveThingRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/repositories/ReactiveThingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AbstractNamedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AbstractNamedThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AbstractPet.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AbstractPet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Airport.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Airport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AllArgsCtorNoBuilder.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AllArgsCtorNoBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltHobby.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltHobby.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltLikedByPersonRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltLikedByPersonRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltPerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AltPerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AlwaysTheSameIdGenerator.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AlwaysTheSameIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AnotherThingWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AnotherThingWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AuditableThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AuditableThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/AuditingITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/AuditingITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalEnd.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalExternallyGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalSameEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalSameEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalStart.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/BidirectionalStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Book.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/CallbacksITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/CallbacksITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Cat.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Cat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Club.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Club.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ClubRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ClubRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/CounterMetric.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/CounterMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DeepRelationships.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DeepRelationships.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DepartmentEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DepartmentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Dog.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Dog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DoritoEatingPerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DoritoEatingPerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DtoPersonProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DtoPersonProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DtoPersonProjectionContainingAdditionalFields.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DtoPersonProjectionContainingAdditionalFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/DynamicRelationshipsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/DynamicRelationshipsITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Editor.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Editor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntitiesWithDynamicLabels.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntitiesWithDynamicLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithConvertedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithConvertedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithPrimitiveConstructorArguments.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithPrimitiveConstructorArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithRelationshipPropertiesPath.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/EntityWithRelationshipPropertiesPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ExtendedParentNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ExtendedParentNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Flight.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Flight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Friend.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Friend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/FriendshipRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/FriendshipRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/GH2621Domain.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/GH2621Domain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/GaugeMetric.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/GaugeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/HistogramMetric.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/HistogramMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Hobby.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Hobby.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/HobbyRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/HobbyRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/IdGeneratorsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/IdGeneratorsITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableAuditableThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableAuditableThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableAuditableThingWithGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableAuditableThingWithGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithAssignedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithAssignedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithExternallyGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithExternallyGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithExternallyGeneratedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithExternallyGeneratedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithGeneratedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePersonWithGeneratedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePet.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutablePet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithAssignedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithAssignedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithExternallyGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithExternallyGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithExternallyGeneratedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithExternallyGeneratedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithGeneratedIdRelationshipProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableSecondPersonWithGeneratedIdRelationshipProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableVersionedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ImmutableVersionedThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Inheritance.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Inheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/LikesHobbyRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/LikesHobbyRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Metric.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Multiple1O1Relationships.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Multiple1O1Relationships.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/MultipleLabels.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/MultipleLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/MultipleRelationshipsThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/MultipleRelationshipsThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/MutableChild.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/MutableChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/MutableParent.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/MutableParent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesOnly.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesOnlyDto.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesOnlyDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesWithSpELCity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/NamesWithSpELCity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/OffsetTemporalEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/OffsetTemporalEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/OneToOneSource.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/OneToOneSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/OneToOneTarget.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/OneToOneTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ParentNode.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ParentNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Person.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Person.java
@@ -42,7 +42,7 @@ public class Person {
 	 */
 	@Node
 	public static class Address {
-		@Id
+		@Id @GeneratedValue
 		private Long id;
 		private String zipCode;
 		private String city;

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonDepartmentQueryResult.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonDepartmentQueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonProjection.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonSummary.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithAllConstructor.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithAllConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithNoConstructor.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithNoConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationshipWithProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationshipWithProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationshipWithProperties2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelationshipWithProperties2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelatives.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithRelatives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithStringlyTypedRelatives.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithStringlyTypedRelatives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithWither.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/PersonWithWither.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Pet.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Pet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/Port.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/Port.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTest1O1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTest1O1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestLevel1.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestLevel1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestLevel2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestLevel2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestRoot.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ProjectionTestRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/RelationshipsAsConstructorParametersEntities.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/RelationshipsAsConstructorParametersEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/RelationshipsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/RelationshipsITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SameIdProperty.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SameIdProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ScrollingEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ScrollingEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimilarThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimilarThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipA.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipB.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipC.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimpleEntityWithRelationshipC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimplePerson.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SimplePerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/SummaryMetric.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/SummaryMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/TestSequenceGenerator.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/TestSequenceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllCypherTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllCypherTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllCypherTypes2.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllCypherTypes2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllSpatialTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAllSpatialTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithFixedGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithFixedGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithGeneratedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithIdGeneratedByBean.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithIdGeneratedByBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithSequence.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithUUIDID.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/ThingWithUUIDID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThingWithAssignedId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/VersionedThingWithAssignedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/common/WorksInClubRelationship.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/common/WorksInClubRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/CompositePropertiesITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/CompositePropertiesITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ListPropertyConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ListPropertyConversionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/Neo4jConversionsITBase.java
@@ -18,6 +18,7 @@ package org.springframework.data.neo4j.integration.shared.conversion;
 import org.junit.jupiter.api.BeforeAll;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.geo.Point;
 import org.springframework.data.neo4j.integration.shared.conversion.ThingWithAllAdditionalTypes.SomeEnum;
 import org.springframework.data.neo4j.test.BookmarkCapture;
@@ -126,6 +127,7 @@ public abstract class Neo4jConversionsITBase {
 		hlp.put("aZoneId", ZoneId.of("America/New_York"));
 		hlp.put("aZeroPeriod", Period.of(0, 0, 0));
 		hlp.put("aZeroDuration", Duration.ZERO);
+		hlp.put("aVector", Vector.of(0.1d, 0.2d));
 		ADDITIONAL_TYPES = Collections.unmodifiableMap(hlp);
 	}
 
@@ -278,7 +280,8 @@ public abstract class Neo4jConversionsITBase {
 						n.anEnum = 'TheUsualMisfit', n.anArrayOfEnums = ['ValueA', 'ValueB'],
 						n.aCollectionOfEnums = ['ValueC', 'TheUsualMisfit'],
 						n.aTimeZone = 'America/Los_Angeles',\s
-						n.aZoneId = 'America/New_York', n.aZeroPeriod = duration('PT0S'), n.aZeroDuration = duration('PT0S')
+						n.aZoneId = 'America/New_York', n.aZeroPeriod = duration('PT0S'), n.aZeroDuration = duration('PT0S'),
+						n.aVector = [0.1, 0.2]
 					RETURN id(n) AS id
 					""", parameters).single().get("id").asLong();
 

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/PersonWithCustomId.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/PersonWithCustomId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/RelationshipWithCompositeProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/RelationshipWithCompositeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -595,7 +596,7 @@ public class ThingWithAllAdditionalTypes {
 	}
 
 	public ThingWithAllAdditionalTypes withId(Long id) {
-		return this.id == id ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
+		return Objects.equals(this.id, id) ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
 	}
 
 	enum SomeEnum {
@@ -887,7 +888,7 @@ public class ThingWithAllAdditionalTypes {
 			return this;
 		}
 
-		public ThingWithAllAdditionalTypesBuilder aVector(Vector vector) {
+		public ThingWithAllAdditionalTypesBuilder aVector(Vector aVector) {
 			this.aVector = aVector;
 			return this;
 		}

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithAllAdditionalTypes.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import org.springframework.data.domain.Vector;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
@@ -43,7 +44,7 @@ import org.springframework.data.neo4j.core.schema.Node;
 @Node("AdditionalTypes")
 public class ThingWithAllAdditionalTypes {
 
-	private ThingWithAllAdditionalTypes(Long id, boolean[] booleanArray, byte aByte, char aChar, char[] charArray, Date aDate, BigDecimal aBigDecimal, BigInteger aBigInteger, double[] doubleArray, float aFloat, float[] floatArray, int anInt, int[] intArray, Locale aLocale, long[] longArray, short aShort, short[] shortArray, Period aPeriod, Duration aDuration, String[] stringArray, List<String> listOfStrings, Set<String> setOfStrings, Instant anInstant, UUID aUUID, URL aURL, URI aURI, SomeEnum anEnum, SomeEnum[] anArrayOfEnums, List<Double> listOfDoubles, List<SomeEnum> aCollectionOfEnums, TimeZone aTimeZone, ZoneId aZoneId, Period aZeroPeriod, Duration aZeroDuration) {
+	private ThingWithAllAdditionalTypes(Long id, boolean[] booleanArray, byte aByte, char aChar, char[] charArray, Date aDate, BigDecimal aBigDecimal, BigInteger aBigInteger, double[] doubleArray, float aFloat, float[] floatArray, int anInt, int[] intArray, Locale aLocale, long[] longArray, short aShort, short[] shortArray, Period aPeriod, Duration aDuration, String[] stringArray, List<String> listOfStrings, Set<String> setOfStrings, Instant anInstant, UUID aUUID, URL aURL, URI aURI, SomeEnum anEnum, SomeEnum[] anArrayOfEnums, List<Double> listOfDoubles, List<SomeEnum> aCollectionOfEnums, TimeZone aTimeZone, ZoneId aZoneId, Period aZeroPeriod, Duration aZeroDuration, Vector aVector) {
 		this.id = id;
 		this.booleanArray = booleanArray;
 		this.aByte = aByte;
@@ -78,6 +79,7 @@ public class ThingWithAllAdditionalTypes {
 		this.aZoneId = aZoneId;
 		this.aZeroPeriod = aZeroPeriod;
 		this.aZeroDuration = aZeroDuration;
+		this.aVector = aVector;
 	}
 
 	public static ThingWithAllAdditionalTypesBuilder builder() {
@@ -220,6 +222,10 @@ public class ThingWithAllAdditionalTypes {
 		return this.aZeroDuration;
 	}
 
+	public Vector getAVector() {
+		return this.aVector;
+	}
+
 	public void setBooleanArray(boolean[] booleanArray) {
 		this.booleanArray = booleanArray;
 	}
@@ -350,6 +356,10 @@ public class ThingWithAllAdditionalTypes {
 
 	public void setAZeroDuration(Duration aZeroDuration) {
 		this.aZeroDuration = aZeroDuration;
+	}
+
+	public void setAVector(Vector aVector) {
+		this.aVector = aVector;
 	}
 
 	public boolean equals(final Object o) {
@@ -505,6 +515,12 @@ public class ThingWithAllAdditionalTypes {
 		if (this$aZeroDuration == null ? other$aZeroDuration != null : !this$aZeroDuration.equals(other$aZeroDuration)) {
 			return false;
 		}
+
+		final Object this$aVector = this.getAVector();
+		final Object other$aVector = other.getAVector();
+		if (this$aVector == null ? other$aVector != null : !this$aVector.equals(other$aVector)) {
+			return false;
+		}
 		return true;
 	}
 
@@ -569,6 +585,8 @@ public class ThingWithAllAdditionalTypes {
 		result = result * PRIME + ($aZeroPeriod == null ? 43 : $aZeroPeriod.hashCode());
 		final Object $aZeroDuration = this.getAZeroDuration();
 		result = result * PRIME + ($aZeroDuration == null ? 43 : $aZeroDuration.hashCode());
+		final Object $aVector = this.getAVector();
+		result = result * PRIME + ($aVector == null ? 43 : $aVector.hashCode());
 		return result;
 	}
 
@@ -577,7 +595,7 @@ public class ThingWithAllAdditionalTypes {
 	}
 
 	public ThingWithAllAdditionalTypes withId(Long id) {
-		return this.id == id ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration);
+		return this.id == id ? this : new ThingWithAllAdditionalTypes(id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
 	}
 
 	enum SomeEnum {
@@ -654,6 +672,8 @@ public class ThingWithAllAdditionalTypes {
 
 	private Duration aZeroDuration;
 
+	private Vector aVector;
+
 	/**
 	 * the builder
 	 */
@@ -692,6 +712,7 @@ public class ThingWithAllAdditionalTypes {
 		private ZoneId aZoneId;
 		private Period aZeroPeriod;
 		private Duration aZeroDuration;
+		private Vector aVector;
 
 		ThingWithAllAdditionalTypesBuilder() {
 		}
@@ -866,12 +887,17 @@ public class ThingWithAllAdditionalTypes {
 			return this;
 		}
 
+		public ThingWithAllAdditionalTypesBuilder aVector(Vector vector) {
+			this.aVector = aVector;
+			return this;
+		}
+
 		public ThingWithAllAdditionalTypes build() {
-			return new ThingWithAllAdditionalTypes(this.id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration);
+			return new ThingWithAllAdditionalTypes(this.id, this.booleanArray, this.aByte, this.aChar, this.charArray, this.aDate, this.aBigDecimal, this.aBigInteger, this.doubleArray, this.aFloat, this.floatArray, this.anInt, this.intArray, this.aLocale, this.longArray, this.aShort, this.shortArray, this.aPeriod, this.aDuration, this.stringArray, this.listOfStrings, this.setOfStrings, this.anInstant, this.aUUID, this.aURL, this.aURI, this.anEnum, this.anArrayOfEnums, this.listOfDoubles, this.aCollectionOfEnums, this.aTimeZone, this.aZoneId, this.aZeroPeriod, this.aZeroDuration, this.aVector);
 		}
 
 		public String toString() {
-			return "ThingWithAllAdditionalTypes.ThingWithAllAdditionalTypesBuilder(id=" + this.id + ", booleanArray=" + java.util.Arrays.toString(this.booleanArray) + ", aByte=" + this.aByte + ", aChar=" + this.aChar + ", charArray=" + java.util.Arrays.toString(this.charArray) + ", aDate=" + this.aDate + ", aBigDecimal=" + this.aBigDecimal + ", aBigInteger=" + this.aBigInteger + ", doubleArray=" + java.util.Arrays.toString(this.doubleArray) + ", aFloat=" + this.aFloat + ", floatArray=" + java.util.Arrays.toString(this.floatArray) + ", anInt=" + this.anInt + ", intArray=" + java.util.Arrays.toString(this.intArray) + ", aLocale=" + this.aLocale + ", longArray=" + java.util.Arrays.toString(this.longArray) + ", aShort=" + this.aShort + ", shortArray=" + java.util.Arrays.toString(this.shortArray) + ", aPeriod=" + this.aPeriod + ", aDuration=" + this.aDuration + ", stringArray=" + java.util.Arrays.deepToString(this.stringArray) + ", listOfStrings=" + this.listOfStrings + ", setOfStrings=" + this.setOfStrings + ", anInstant=" + this.anInstant + ", aUUID=" + this.aUUID + ", aURL=" + this.aURL + ", aURI=" + this.aURI + ", anEnum=" + this.anEnum + ", anArrayOfEnums=" + java.util.Arrays.deepToString(this.anArrayOfEnums) + ", listOfDoubles=" + this.listOfDoubles + ", aCollectionOfEnums=" + this.aCollectionOfEnums + ", aTimeZone=" + this.aTimeZone + ", aZoneId=" + this.aZoneId + ", aZeroPeriod=" + this.aZeroPeriod + ", aZeroDuration=" + this.aZeroDuration + ")";
+			return "ThingWithAllAdditionalTypes.ThingWithAllAdditionalTypesBuilder(id=" + this.id + ", booleanArray=" + java.util.Arrays.toString(this.booleanArray) + ", aByte=" + this.aByte + ", aChar=" + this.aChar + ", charArray=" + java.util.Arrays.toString(this.charArray) + ", aDate=" + this.aDate + ", aBigDecimal=" + this.aBigDecimal + ", aBigInteger=" + this.aBigInteger + ", doubleArray=" + java.util.Arrays.toString(this.doubleArray) + ", aFloat=" + this.aFloat + ", floatArray=" + java.util.Arrays.toString(this.floatArray) + ", anInt=" + this.anInt + ", intArray=" + java.util.Arrays.toString(this.intArray) + ", aLocale=" + this.aLocale + ", longArray=" + java.util.Arrays.toString(this.longArray) + ", aShort=" + this.aShort + ", shortArray=" + java.util.Arrays.toString(this.shortArray) + ", aPeriod=" + this.aPeriod + ", aDuration=" + this.aDuration + ", stringArray=" + java.util.Arrays.deepToString(this.stringArray) + ", listOfStrings=" + this.listOfStrings + ", setOfStrings=" + this.setOfStrings + ", anInstant=" + this.anInstant + ", aUUID=" + this.aUUID + ", aURL=" + this.aURL + ", aURI=" + this.aURI + ", anEnum=" + this.anEnum + ", anArrayOfEnums=" + java.util.Arrays.deepToString(this.anArrayOfEnums) + ", listOfDoubles=" + this.listOfDoubles + ", aCollectionOfEnums=" + this.aCollectionOfEnums + ", aTimeZone=" + this.aTimeZone + ", aZoneId=" + this.aZoneId + ", aZeroPeriod=" + this.aZeroPeriod + ", aZeroDuration=" + this.aZeroDuration + ", aVector=" + this.aVector + ")";
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithCompositeProperties.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithCompositeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithCustomTypes.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/shared/conversion/ThingWithCustomTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/OptimisticLockingOfSelfReferencesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/OptimisticLockingOfSelfReferencesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/ReactiveOptimisticLockingOfSelfReferencesIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/ReactiveOptimisticLockingOfSelfReferencesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/Relatable.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/Relatable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/TestBase.java
@@ -34,7 +34,6 @@ import org.neo4j.cypherdsl.core.Cypher;
 
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.ResultStatement;
-import org.neo4j.cypherdsl.core.executables.ExecutableStatement;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
@@ -140,7 +139,7 @@ abstract class TestBase {
 				statement = Cypher.create(nodeTemplate).returning(nodeTemplate.internalId()).build();
 			}
 
-			long id = ExecutableStatement.makeExecutable(statement).fetchWith(tx).get(0).get(0).asLong();
+			long id = tx.run(statement.getCypher(), statement.getCatalog().getParameters()).single().get(0).asLong();
 
 			tx.commit();
 			return id;
@@ -182,7 +181,7 @@ abstract class TestBase {
 						.build();
 			}
 
-			Record record = ExecutableStatement.makeExecutable(statement).fetchWith(tx).get(0);
+			Record record = tx.run(statement.getCypher(), statement.getCatalog().getParameters()).single();
 			long id1 = record.get(0).asLong();
 			long id2 = record.get(1).asLong();
 
@@ -270,7 +269,7 @@ abstract class TestBase {
 
 	private void assertImpl(Long expectedVersion, ResultStatement resultStatement) {
 		try (Session session = driver.session(bookmarkCapture.createSessionConfig())) {
-			List<Record> result = ExecutableStatement.makeExecutable(resultStatement).fetchWith(session);
+			List<Record> result = session.run(resultStatement.getCypher(), resultStatement.getCatalog().getParameters()).list();
 			assertThat(result).hasSize(1)
 					.first().satisfies(record -> {
 						long version = record.get(0).asLong();

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdListBased.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdListBased.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdWithEquals.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdWithEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdWithoutEquals.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedExternalIdWithoutEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdListBased.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdListBased.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdWithEquals.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdWithEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdWithoutEquals.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/versioned_self_references/VersionedInternalIdWithoutEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/config/AnEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/config/AnEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositoriesTests.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/config/EnableNeo4jRepositoriesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/config/EnableReactiveNeo4jRepositoriesTests.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/config/EnableReactiveNeo4jRepositoriesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/config/StartupLoggerTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/config/StartupLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/BoundingBoxTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/BoundingBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtilsTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/CypherAdapterUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/ExtendedTestEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/ExtendedTestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriterTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/Neo4jNestedMapEntityWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupportTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/Neo4jSpelSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/ReactiveRepositoryQueryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/ReactiveRepositoryQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/RepositoryQueryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/RepositoryQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/query/TestEntity.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/query/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactorySupportTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactorySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/Neo4jRepositoryFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryTest.java
+++ b/src/test/java/org/springframework/data/neo4j/repository/support/ReactiveNeo4jRepositoryFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/support/ProxyImageNameSubstitutor.java
+++ b/src/test/java/org/springframework/data/neo4j/support/ProxyImageNameSubstitutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/BookmarkCapture.java
+++ b/src/test/java/org/springframework/data/neo4j/test/BookmarkCapture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/CausalClusterIntegrationTest.java
+++ b/src/test/java/org/springframework/data/neo4j/test/CausalClusterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/DriverMocks.java
+++ b/src/test/java/org/springframework/data/neo4j/test/DriverMocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/LogbackCapture.java
+++ b/src/test/java/org/springframework/data/neo4j/test/LogbackCapture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/LogbackCapture.java
+++ b/src/test/java/org/springframework/data/neo4j/test/LogbackCapture.java
@@ -61,7 +61,7 @@ public final class LogbackCapture implements ExtensionContext.Store.CloseableRes
 		this.listAppender.start();
 	}
 
-	void clear() {
+	public void clear() {
 		this.resetLogLevel();
 		this.listAppender.list.clear();
 	}

--- a/src/test/java/org/springframework/data/neo4j/test/LogbackCapturingExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/LogbackCapturingExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -258,11 +258,17 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 				synchronized (this) {
 					serverVersion = this.cachedServerVersion;
 					if (serverVersion == null) {
+						String versionString = "";
 						try (Session session = this.getDriver().session()) {
 							Record result = session.run("CALL dbms.components() YIELD versions RETURN 'Neo4j/' + versions[0] as version").single();
-							this.cachedServerVersion = ServerVersion.version(result.get("version").asString());
+							versionString = result.get("version").asString();
+							this.cachedServerVersion = ServerVersion.version(versionString);
 						} catch (Exception e) {
-							throw new RuntimeException("Could not determine server version", e);
+							if (versionString.matches("Neo4j/20\\d{2}.+")) {
+								this.cachedServerVersion = ServerVersion.vInDev;
+							} else {
+								throw new RuntimeException("Could not determine server version", e);
+							}
 						}
 						serverVersion = this.cachedServerVersion;
 					}

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -67,6 +67,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 
 	public final static String NEEDS_REACTIVE_SUPPORT = "reactive-test";
 	public final static String NEEDS_VERSION_SUPPORTING_ELEMENT_ID = "elementid-test";
+	public static final String NEEDS_VECTOR_INDEX = "vectorindex-test";
 	public final static String COMMUNITY_EDITION_ONLY = "community-edition";
 	public final static String COMMERCIAL_EDITION_ONLY = "commercial-edition";
 	/**
@@ -160,6 +161,13 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		if (tags.contains(COMMERCIAL_EDITION_ONLY)) {
 			assumeThat(neo4jConnectionSupport.isCommercialEdition())
 					.describedAs("This test should be run on the commercial edition only").isTrue();
+		}
+
+		if (tags.contains(NEEDS_VECTOR_INDEX)) {
+			assumeThat(
+					neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.version("Neo4j/5.13.0")))
+					.describedAs("This tests needs a Neo4j version supporting Vector indexes")
+					.isTrue();
 		}
 
 		tags.stream().filter(s -> s.startsWith(REQUIRES)).map(ServerVersion::version).forEach(v -> {

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -212,6 +212,10 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		 */
 		public Driver getDriver() {
 
+			if (uri.getScheme().startsWith("neo4j")) {
+				return createDriverInstance();
+			}
+
 			Driver driver = this.driverInstance;
 			if (!isUsable(driver)) {
 				synchronized (this) {

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -83,6 +83,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 	private static final String KEY_DRIVER_INSTANCE = "neo4j.driver";
 
 	private static final String SYS_PROPERTY_NEO4J_URL = "SDN_NEO4J_URL";
+	private static final String SYS_PROPERTY_NEO4J_USERNAME = "SDN_NEO4J_USERNAME";
 	private static final String SYS_PROPERTY_NEO4J_PASSWORD = "SDN_NEO4J_PASSWORD";
 	private static final String SYS_PROPERTY_NEO4J_ACCEPT_COMMERCIAL_EDITION = "SDN_NEO4J_ACCEPT_COMMERCIAL_EDITION";
 	private static final String SYS_PROPERTY_NEO4J_REPOSITORY = "SDN_NEO4J_REPOSITORY";
@@ -107,6 +108,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		}
 
 		String neo4jUrl = Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_URL)).orElse("");
+		String neo4jUser = Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_USERNAME)).orElse("neo4j").trim();
 		String neo4jPassword = Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_PASSWORD)).orElse("").trim();
 
 		ExtensionContext.Store contextStore = context.getStore(NAMESPACE);
@@ -115,7 +117,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		if (neo4jConnectionSupport == null) {
 			if (!(neo4jUrl.isEmpty() || neo4jPassword.isEmpty())) {
 				log.info(LogMessage.format("Using Neo4j instance at %s.", neo4jUrl));
-				neo4jConnectionSupport = new Neo4jConnectionSupport(neo4jUrl, AuthTokens.basic("neo4j", neo4jPassword));
+				neo4jConnectionSupport = new Neo4jConnectionSupport(neo4jUrl, AuthTokens.basic(neo4jUser, neo4jPassword));
 			} else {
 				log.info("Using Neo4j test container.");
 				ContainerAdapter adapter = contextStore.getOrComputeIfAbsent(KEY_NEO4J_INSTANCE,

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -266,7 +266,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 					if (serverVersion == null) {
 						String versionString = "";
 						try (Session session = this.getDriver().session()) {
-							Record result = session.run("CALL dbms.components() YIELD versions RETURN 'Neo4j/' + versions[0] as version").single();
+							Record result = session.run("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN 'Neo4j/' + versions[0] as version").single();
 							versionString = result.get("version").asString();
 							this.cachedServerVersion = ServerVersion.version(versionString);
 						} catch (Exception e) {
@@ -288,7 +288,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 			String edition;
 			SessionConfig sessionConfig = SessionConfig.builder().withDefaultAccessMode(AccessMode.READ).build();
 			try (Session session = getDriver().session(sessionConfig)) {
-				edition = session.run("call dbms.components() yield edition").single().get("edition").asString();
+				edition = session.run("CALL dbms.components() YIELD name, edition WHERE name = 'Neo4j Kernel' RETURN edition").single().get("edition").asString();
 			}
 			return edition.toLowerCase(Locale.ENGLISH);
 		}

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jImperativeTestConfiguration.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jImperativeTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jIntegrationTest.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jReactiveTestConfiguration.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jReactiveTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
@@ -27,9 +27,9 @@ public interface Neo4jTestConfiguration {
 
 	default Configuration getConfiguration() {
 		if (isCypher5Compatible()) {
-			return Configuration.newConfig().withDialect(Dialect.NEO4J_5).build();
+			return Configuration.newConfig().withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build();
 		}
 
-		return Configuration.defaultConfig();
+		return Configuration.newConfig().withDialect(Dialect.NEO4J_4).build();
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/test/ServerVersion.java
+++ b/src/test/java/org/springframework/data/neo4j/test/ServerVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/ServerVersionTest.java
+++ b/src/test/java/org/springframework/data/neo4j/test/ServerVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/test/TestIdentitySupport.java
+++ b/src/test/java/org/springframework/data/neo4j/test/TestIdentitySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/types/GeographicPoint2dTest.java
+++ b/src/test/java/org/springframework/data/neo4j/types/GeographicPoint2dTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/neo4j/types/GeographicPoint3dTest.java
+++ b/src/test/java/org/springframework/data/neo4j/types/GeographicPoint3dTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jClientExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jOperationsExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/Neo4jOperationsExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/PreparedQueryExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/PreparedQueryExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jClientExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jOperationsExtensionsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/ReactiveNeo4jOperationsExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/core/cypher/ParametersTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/core/cypher/ParametersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/ImmutableRelationshipsIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -243,5 +245,16 @@ class KotlinInheritanceIT @Autowired constructor(
 		open fun transactionTemplate(transactionManager: PlatformTransactionManager): TransactionTemplate {
 			return TransactionTemplate(transactionManager)
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -135,5 +137,16 @@ internal class KotlinProjectionIT {
 		override fun driver(): Driver {
 			return neo4jConnectionSupport.driver
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
@@ -20,11 +20,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.neo4j.driver.Values
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.Neo4jClient
 import org.springframework.data.neo4j.core.cypher.asParam
@@ -108,6 +110,17 @@ class Neo4jClientKotlinInteropIT @Autowired constructor(
         @Bean
         override fun driver(): Driver {
             return neo4jConnectionSupport.driver
+        }
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
         }
     }
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsIT.kt
@@ -18,10 +18,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager
@@ -37,7 +39,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 @Neo4jIntegrationTest
-class Neo4jListContainsTest {
+class Neo4jListContainsIT {
 
 	companion object {
 		@JvmStatic
@@ -93,6 +95,17 @@ class Neo4jListContainsTest {
 		override fun transactionManager(driver: Driver, databaseNameProvider: DatabaseSelectionProvider): PlatformTransactionManager {
 			val bookmarkCapture = bookmarkCapture()
 			return Neo4jTransactionManager(driver, databaseNameProvider, Neo4jBookmarkManager.create(bookmarkCapture))
+		}
+
+		@Bean
+		@Primary
+		open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+			if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+				return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+					.withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+			}
+
+			return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
 		}
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsTest.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.k
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -30,6 +32,7 @@ import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager
+import org.springframework.data.neo4j.integration.imperative.Neo4jListContainsIT
 import org.springframework.data.neo4j.repository.Neo4jRepository
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories
 import org.springframework.data.neo4j.test.BookmarkCapture
@@ -111,5 +114,16 @@ internal class KotlinIssuesIT {
 		open fun transactionTemplate(transactionManager: PlatformTransactionManager): TransactionTemplate {
 			return TransactionTemplate(transactionManager)
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientKotlinInteropIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientKotlinInteropIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/ImmutableRelationships.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/ImmutableRelationships.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinInheritance.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinInheritance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinPerson.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinPerson.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinRepository.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/KotlinRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/TestNode.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/TestNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/TestPersonEntity.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/shared/common/TestPersonEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2011-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+api.version=1.44


### PR DESCRIPTION
- **GH-2973: Persist type information on relationship properties (#2974)**
- **Remove driver's NullValue usage.**
- **Fix test case that assumed strict ordering.**
- **fix(test): Expected database message changed.**
- **refactor: Use `SchemaNames` to escape and sanitze labels used in SpEL.**
- **refactor(test): Stabilize a couple of tests (especially the ones using _a_ shortest path).**
- **feature: Allow Cypher `LIST<ANY>` to be used directly as repository methods returning collections.**
- **Fix formatting in documentation.**
- **build(deps): Upgrade Neo4j Java driver to 5.28.1.**
- **build(deps): Upgrade Neo4j Migrations to 2.15.2.**
- **build(deps): Upgrade Neo4j to 4.4.41.**
- **build(deps): Remove superflous classgraph dependency.**
- **Update CI Properties.**
- **Prepare 7.5 M1 (2025.0.0).**
- **Release version 7.5 M1 (2025.0.0).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **feat: Suppress logging of deprecation warning for `id()` by default.**
- **fix: Bump CI version of Neo4j to trigger a specific deprecation warning.**
- **Upgrade Cypher-DSL to 2024.5.0.**
- **Upgrade Neo4j Java Driver to 5.28.2.**
- **Upgrade Neo4j Java Driver to 5.28.3.**
- **build: Add support for configuring the Neo4j username in tests, too.**
- **build: Always create fresh driver for `neo4j` protocol.**
- **Prepare 7.5 M2 (2025.0.0).**
- **Release version 7.5 M2 (2025.0.0).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **fix: use readonly transaction template where possible, #2953**
- **refactor: Remove usage of Cypher-DSL driver integrations.**
- **build(deps): Upgrade Cypher-DSL to 2024.5.1.**
- **build(deps): Upgrade Neo4j Java driver to 5.28.4.**
- **Prepare 7.5 RC1 (2025.0.0).**
- **Release version 7.5 RC1 (2025.0.0).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Upgrade Neo4j Java driver to 5.28.5.**
- **fix: update spring-boot-version to 3.3.0 to fix gzip extraction error (#3008)**
- **GH-3003 - Add vector type support.**
- **Update CI Properties.**
- **Update CI Properties.**
- **Update CI Properties.**
- **Update CI Properties.**
- **Prepare 7.5 GA (2025.0.0).**
- **Release version 7.5 GA (2025.0.0).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Adjust the deprecation pattern for filtering.**
- **build: Fix version sniffing during tests for newer versions of Neo4j.**
- **fix: Use parameter to assign vector field.**
- **build: Remove self-managed, dated plugin versions.**
- **Prepare 7.5.1 (2025.0.1).**
- **Release version 7.5.1 (2025.0.1).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Upgrade Neo4j Java driver to 5.28.7**
- **Update neo4j-java-driver to 5.28.8**
- **Upgrade Neo4j driver to 5.28.9**
- **Upgrade to Maven Wrapper 3.9.11.**
- **Prepare 7.5.2 (2025.0.2).**
- **Release version 7.5.2 (2025.0.2).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Polishing.**
- **Prepare 7.5.3 (2025.0.3).**
- **Release version 7.5.3 (2025.0.3).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Refine version properties for documentation build.**
- **GH-3036 - Use correct type for mapping.**
- **Refine version properties for documentation build.**
- **Prepare 7.5.4 (2025.0.4).**
- **Release version 7.5.4 (2025.0.4).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Update GitHub Actions.**
- **Prepare 7.5.5 (2025.0.5).**
- **Release version 7.5.5 (2025.0.5).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Upgrade Neo4j driver to 5.28.10**
- **Update Update security documentation.**
- **Prepare 7.5.6 (2025.0.6).**
- **Release version 7.5.6 (2025.0.6).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Add `docker-java.properties`.**
- **Update CI Properties.**
- **Prepare 7.5.7 (2025.0.7).**
- **Release version 7.5.7 (2025.0.7).**
- **Prepare next development iteration.**
- **After release cleanups.**
- **Extend license header copyright years to present.**
- **fix: Extend license header copyright proper by adapting the checkstyle config, too.**
- **feat: Use label expressions for dynamic labels when available.**
