### PR TITLE
feat: Use label expressions for dynamic labels when available.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,7 +6,7 @@ mkdir -p /tmp/jenkins-home
 
 export JENKINS_USER=${JENKINS_USER_NAME}
 export SDN_FORCE_REUSE_OF_CONTAINERS=true
-export SDN_NEO4J_VERSION=5.26.2
+export SDN_NEO4J_VERSION=5.26.12
 
 MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home -Dscan=false" \
   ./mvnw -s settings.xml -P${PROFILE} clean dependency:list verify -Dsort -U -B -Dmaven.repo.local=/tmp/jenkins-home/.m2/spring-data-neo4j -Ddevelocity.storage.directory=/tmp/jenkins-home/.develocity-root

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<blockhound.version>1.0.8.RELEASE</blockhound.version>
 		<checkstyle.skip>${skipTests}</checkstyle.skip>
 		<checkstyle.version>8.40</checkstyle.version>
-		<cypher-dsl.version>2024.5.1</cypher-dsl.version>
+		<cypher-dsl.version>2025.2.2</cypher-dsl.version>
 		<dist.id>spring-data-neo4j</dist.id>
 		<dist.key>SDNEO4J</dist.key>
 		<flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
@@ -91,7 +91,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<neo4j-java-driver.version>5.28.10</neo4j-java-driver.version>
 		<neo4j-migrations.version>2.17.3</neo4j-migrations.version>
-		<neo4j.version>4.4.41</neo4j.version>
+		<neo4j.version>5.26.12</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
+++ b/src/main/java/org/springframework/data/neo4j/core/DynamicLabels.java
@@ -52,11 +52,13 @@ final class DynamicLabels implements UnaryOperator<OngoingMatchAndUpdate> {
 	public OngoingMatchAndUpdate apply(OngoingMatchAndUpdate ongoingMatchAndUpdate) {
 
 		OngoingMatchAndUpdate decoratedMatchAndUpdate = ongoingMatchAndUpdate;
-		if (!oldLabels.isEmpty()) {
-			decoratedMatchAndUpdate = decoratedMatchAndUpdate.remove(rootNode, oldLabels.toArray(new String[0]));
+		if (!this.oldLabels.isEmpty()) {
+			decoratedMatchAndUpdate = decoratedMatchAndUpdate.remove(this.rootNode,
+					Cypher.allLabels(Cypher.anonParameter(this.oldLabels)));
 		}
-		if (!newLabels.isEmpty()) {
-			decoratedMatchAndUpdate = decoratedMatchAndUpdate.set(rootNode, newLabels.toArray(new String[0]));
+		if (!this.newLabels.isEmpty()) {
+			decoratedMatchAndUpdate = decoratedMatchAndUpdate.set(this.rootNode,
+					Cypher.allLabels(Cypher.anonParameter(this.newLabels)));
 		}
 		return decoratedMatchAndUpdate;
 	}

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/CypherGenerator.java
@@ -21,7 +21,6 @@ import static org.neo4j.cypherdsl.core.Cypher.collect;
 import static org.neo4j.cypherdsl.core.Cypher.listBasedOn;
 import static org.neo4j.cypherdsl.core.Cypher.literalOf;
 import static org.neo4j.cypherdsl.core.Cypher.match;
-import static org.neo4j.cypherdsl.core.Cypher.node;
 import static org.neo4j.cypherdsl.core.Cypher.optionalMatch;
 import static org.neo4j.cypherdsl.core.Cypher.parameter;
 
@@ -93,6 +92,14 @@ public enum CypherGenerator {
 			throw new IllegalArgumentException("Unsupported CypherDSL type: " + named.getClass());
 		}
 	};
+
+	private static Node node(String primaryLabel, List<String> additionalLabels) {
+		var labels = Cypher.exactlyLabel(primaryLabel);
+		if (!additionalLabels.isEmpty()) {
+			labels = labels.conjunctionWith(Cypher.allLabels(Cypher.anonParameter(additionalLabels)));
+		}
+		return Cypher.node(labels);
+	}
 
 	/**
 	 * Set function to be used to query either elementId or id.

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/CypherGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.FunctionInvocation;
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Dialect;
@@ -48,6 +50,12 @@ import org.springframework.data.neo4j.core.schema.Node;
  * @author Michael J. Simons
  */
 class CypherGeneratorTest {
+
+	@BeforeAll
+	static void fixTheAbusOfASingleton() {
+		CypherGenerator.INSTANCE
+			.setElementIdOrIdFunction(n -> FunctionInvocation.create(() -> "elementId", n.getRequiredSymbolicName()));
+	}
 
 	@Test
 	void shouldCreateRelationshipCreationQueryWithLabelIfPresent() {

--- a/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
+++ b/src/test/java/org/springframework/data/neo4j/documentation/repositories/custom_queries/MovieRepository.java
@@ -21,7 +21,7 @@ import static org.neo4j.cypherdsl.core.Cypher.listWith;
 import static org.neo4j.cypherdsl.core.Cypher.name;
 import static org.neo4j.cypherdsl.core.Cypher.node;
 import static org.neo4j.cypherdsl.core.Cypher.parameter;
-import static org.neo4j.cypherdsl.core.Cypher.shortestPath;
+import static org.neo4j.cypherdsl.core.Cypher.shortestK;
 
 // end::domain-results-impl[]
 import java.util.Collection;
@@ -82,7 +82,7 @@ class DomainResultsImpl implements DomainResults {
 
 		var p1 = node("Person").withProperties("name", parameter("person1"));
 		var p2 = node("Person").withProperties("name", parameter("person2"));
-		var shortestPath = shortestPath("p").definedBy(
+		var shortestPath = shortestK(1).named("p").definedBy(
 				p1.relationshipBetween(p2).unbounded()
 		);
 		var p = shortestPath.getRequiredSymbolicName();

--- a/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/cascading/AbstractCascadingTestBase.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.types.TypeSystem;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.neo4j.test.Neo4jExtension;
 
+@Tag(Neo4jExtension.NEEDS_VERSION_SUPPORTING_ELEMENT_ID)
 abstract class AbstractCascadingTestBase {
 
 	@Autowired

--- a/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/conversion_imperative/TypeConversionIT.java
@@ -39,6 +39,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.neo4j.driver.Driver;
@@ -70,6 +71,7 @@ import org.springframework.data.neo4j.integration.shared.conversion.ThingWithCus
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import org.springframework.data.neo4j.test.BookmarkCapture;
+import org.springframework.data.neo4j.test.Neo4jExtension;
 import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -77,11 +79,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
+ * Tag due to the requirements on db.create.setNodeVectorProperty
+ *
  * @author Michael J. Simons
  * @author Dennis Crissman
  * @soundtrack Tool - Fear Inoculum
  */
 @Neo4jIntegrationTest
+@Tag(Neo4jExtension.NEEDS_VECTOR_INDEX)
 class TypeConversionIT extends Neo4jConversionsITBase {
 
 	private final CypherTypesRepository cypherTypesRepository;

--- a/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/imperative/InheritanceMappingIT.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
@@ -52,6 +53,7 @@ import org.springframework.data.neo4j.test.BookmarkCapture;
 import org.springframework.data.neo4j.test.Neo4jExtension;
 import org.springframework.data.neo4j.test.Neo4jImperativeTestConfiguration;
 import org.springframework.data.neo4j.test.Neo4jIntegrationTest;
+import org.springframework.data.neo4j.test.ServerVersion;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -333,7 +335,12 @@ public class InheritanceMappingIT {
 		}
 	}
 
+	static boolean isGreaterThanOrEqualNeo4j5() {
+		return neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.v5_0_0);
+	}
+
 	@Test // GH-2788
+	@EnabledIf("isGreaterThanOrEqualNeo4j5")
 	void detectPropertiesAndRelationshipsOfImplementingEntities(@Autowired Neo4jTemplate template) {
 		String id;
 		try (Session session = driver.session(bookmarkCapture.createSessionConfig()); Transaction transaction = session.beginTransaction()) {

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -15,24 +15,6 @@
  */
 package org.springframework.data.neo4j.integration.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.neo4j.driver.TransactionContext;
-import org.junit.jupiter.api.RepeatedTest;
-import org.neo4j.driver.reactive.ReactiveSession;
-import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
-import org.springframework.data.neo4j.integration.shared.common.CounterMetric;
-import org.springframework.data.neo4j.integration.shared.common.GaugeMetric;
-import org.springframework.data.neo4j.integration.shared.common.HistogramMetric;
-import org.springframework.data.neo4j.integration.shared.common.Metric;
-import org.springframework.data.neo4j.integration.shared.common.SummaryMetric;
-import org.springframework.data.neo4j.test.Neo4jReactiveTestConfiguration;
-
-import reactor.adapter.JdkFlowAdapter;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,23 +27,35 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.TransactionContext;
+import org.neo4j.driver.reactive.ReactiveSession;
+import reactor.adapter.JdkFlowAdapter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.neo4j.core.ReactiveDatabaseSelectionProvider;
 import org.springframework.data.neo4j.core.ReactiveNeo4jTemplate;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager;
 import org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager;
+import org.springframework.data.neo4j.integration.shared.common.CounterMetric;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.DynamicLabelsWithMultipleNodeLabels;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.DynamicLabelsWithNodeLabel;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.ExtendedBaseClass1;
@@ -73,8 +67,13 @@ import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDyna
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.SimpleDynamicLabelsWithVersion;
 import org.springframework.data.neo4j.integration.shared.common.EntitiesWithDynamicLabels.SuperNode;
 import org.springframework.data.neo4j.integration.shared.common.EntityWithDynamicLabelsAndIdThatNeedsToBeConverted;
+import org.springframework.data.neo4j.integration.shared.common.GaugeMetric;
+import org.springframework.data.neo4j.integration.shared.common.HistogramMetric;
+import org.springframework.data.neo4j.integration.shared.common.Metric;
+import org.springframework.data.neo4j.integration.shared.common.SummaryMetric;
 import org.springframework.data.neo4j.test.BookmarkCapture;
 import org.springframework.data.neo4j.test.Neo4jExtension;
+import org.springframework.data.neo4j.test.Neo4jReactiveTestConfiguration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -82,29 +81,141 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Michael J. Simons
  */
 @Tag(Neo4jExtension.NEEDS_REACTIVE_SUPPORT)
 @ExtendWith(Neo4jExtension.class)
-public class ReactiveDynamicLabelsIT {
+final class ReactiveDynamicLabelsIT {
 
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
 
+	private ReactiveDynamicLabelsIT() {
+	}
+
+	public static class DialectConfig extends SpringTestBase.Config {
+
+		@Bean
+		@Primary
+		public org.neo4j.cypherdsl.core.renderer.Configuration getConfiguration() {
+			if (neo4jConnectionSupport.isCypher5SyntaxCompatible()) {
+				return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build();
+			}
+
+			return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build();
+		}
+
+	}
+
+	@ExtendWith(SpringExtension.class)
+	@ContextConfiguration(classes = DialectConfig.class)
+	@DirtiesContext
+	abstract static class SpringTestBase {
+
+		@Autowired
+		protected Driver driver;
+
+		@Autowired
+		protected TransactionalOperator transactionalOperator;
+
+		@Autowired
+		protected BookmarkCapture bookmarkCapture;
+
+		protected Long existingEntityId;
+
+		abstract Long createTestEntity(TransactionContext t);
+
+		@BeforeEach
+		void setupData() {
+			try (Session session = this.driver.session();) {
+				session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
+				this.existingEntityId = session.executeWrite(this::createTestEntity);
+				this.bookmarkCapture.seedWith(session.lastBookmarks());
+			}
+		}
+
+		@SuppressWarnings("deprecation")
+		protected final Flux<String> getLabels(Long id) {
+			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(Cypher.parameter("id")), id);
+		}
+
+		protected final Flux<String> getLabels(Condition idCondition, Object id) {
+
+			Node n = Cypher.anyNode("n");
+			String cypher = Renderer.getDefaultRenderer()
+				.render(Cypher.match(n)
+					.where(idCondition)
+					.and(n.property("moreLabels").isNull())
+					.unwind(n.labels())
+					.as("label")
+					.returning("label")
+					.build());
+			return Flux.usingWhen(Mono.fromSupplier(
+					() -> this.driver.session(ReactiveSession.class, this.bookmarkCapture.createSessionConfig())),
+					s -> JdkFlowAdapter.flowPublisherToFlux(s.run(cypher, Collections.singletonMap("id", id)))
+						.flatMap(r -> JdkFlowAdapter.flowPublisherToFlux(r.records())),
+					rs -> JdkFlowAdapter.flowPublisherToFlux(rs.close()))
+				.map(r -> r.get("label").asString());
+		}
+
+		@Configuration
+		@EnableTransactionManagement
+		static class Config extends Neo4jReactiveTestConfiguration {
+
+			@Bean
+			@Override
+			public Driver driver() {
+				return neo4jConnectionSupport.getDriver();
+			}
+
+			@Bean
+			BookmarkCapture bookmarkCapture() {
+				return new BookmarkCapture();
+			}
+
+			@Override
+			public ReactiveTransactionManager reactiveTransactionManager(Driver driver,
+					ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
+
+				BookmarkCapture bookmarkCapture = bookmarkCapture();
+				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider,
+						Neo4jBookmarkManager.createReactive(bookmarkCapture));
+			}
+
+			@Bean
+			TransactionalOperator transactionalOperator(ReactiveTransactionManager transactionManager) {
+				return TransactionalOperator.create(transactionManager);
+			}
+
+			@Override
+			public boolean isCypher5Compatible() {
+				return neo4jConnectionSupport.isCypher5SyntaxCompatible();
+			}
+
+		}
+
+	}
 
 	@Nested
 	class DynamicLabelsAndOrderOfClassesBeingLoaded extends SpringTestBase {
 
 		@Override
 		Long createTestEntity(TransactionContext t) {
-			return t.run("CREATE (m:Metric:Counter:A:B:C:D {timestamp: datetime()}) RETURN id(m)").single().get(0).asLong();
+			return t.run("CREATE (m:Metric:Counter:A:B:C:D {timestamp: datetime()}) RETURN id(m)")
+				.single()
+				.get(0)
+				.asLong();
 
 		}
 
 		@RepeatedTest(100) // GH-2619
-		void ownLabelsShouldNotEndUpWithDynamicLabels(@Autowired Neo4jMappingContext mappingContext, @Autowired ReactiveNeo4jTemplate template) {
+		void ownLabelsShouldNotEndUpWithDynamicLabels(@Autowired Neo4jMappingContext mappingContext,
+				@Autowired ReactiveNeo4jTemplate template) {
 
-			List<Class<? extends Metric>> metrics = Arrays.asList(GaugeMetric.class, SummaryMetric.class, HistogramMetric.class, CounterMetric.class);
+			List<Class<? extends Metric>> metrics = Arrays.asList(GaugeMetric.class, SummaryMetric.class,
+					HistogramMetric.class, CounterMetric.class);
 			Collections.shuffle(metrics);
 			for (Class<?> type : metrics) {
 				assertThat(mappingContext.getPersistentEntity(type)).isNotNull();
@@ -112,15 +223,18 @@ public class ReactiveDynamicLabelsIT {
 
 			Map<String, Object> args = new HashMap<>();
 			args.put("agentIdLabel", "B");
-			template.findAll("MATCH (m:Metric) WHERE $agentIdLabel in labels(m) RETURN m ORDER BY m.timestamp DESC", args, Metric.class)
-					.as(StepVerifier::create)
-					.assertNext(cm -> {
-						assertThat(cm).isInstanceOf(CounterMetric.class);
-						assertThat(cm.getId()).isEqualTo(existingEntityId);
-						assertThat(cm.getDynamicLabels()).containsExactlyInAnyOrder("A", "B", "C", "D");
-					})
-					.verifyComplete();
+			template
+				.findAll("MATCH (m:Metric) WHERE $agentIdLabel in labels(m) RETURN m ORDER BY m.timestamp DESC", args,
+						Metric.class)
+				.as(StepVerifier::create)
+				.assertNext(cm -> {
+					assertThat(cm).isInstanceOf(CounterMetric.class);
+					assertThat(cm.getId()).isEqualTo(this.existingEntityId);
+					assertThat(cm.getDynamicLabels()).containsExactlyInAnyOrder("A", "B", "C", "D");
+				})
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -129,28 +243,36 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId").single();
+				.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar").verifyComplete();
+			template.findById(this.existingEntityId, SimpleDynamicLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabels.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, SimpleDynamicLabels.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabels").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -162,10 +284,14 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "SimpleDynamicLabels").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -179,11 +305,17 @@ public class ReactiveDynamicLabelsIT {
 			SuperNode superNode = new SuperNode();
 			superNode.relatedTo = entity;
 
-			template.save(superNode).map(SuperNode::getRelatedTo).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels)
-					.sort().as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabels").verifyComplete();
+			template.save(superNode)
+				.map(SuperNode::getRelatedTo)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -191,30 +323,37 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabels:InheritedSimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
-					.single();
+			Record r = transaction.run(
+					"CREATE (e:SimpleDynamicLabels:InheritedSimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, InheritedSimpleDynamicLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar").verifyComplete();
+			template.findById(this.existingEntityId, InheritedSimpleDynamicLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, InheritedSimpleDynamicLabels.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, InheritedSimpleDynamicLabels.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
@@ -226,11 +365,16 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabels::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabels::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "InheritedSimpleDynamicLabels", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -239,9 +383,9 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction.run("""
-				CREATE (e:SimpleDynamicLabelsWithBusinessId:Foo:Bar:Baz:Foobar {id: 'E1'})
-				RETURN id(e) as existingEntityId
-				""").single();
+					CREATE (e:SimpleDynamicLabelsWithBusinessId:Foo:Bar:Baz:Foobar {id: 'E1'})
+					RETURN id(e) as existingEntityId
+					""").single();
 			return r.get("existingEntityId").asLong();
 		}
 
@@ -252,9 +396,13 @@ public class ReactiveDynamicLabelsIT {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessId").verifyComplete();
+			})
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessId")
+				.verifyComplete();
 		}
 
 		@Test
@@ -267,11 +415,16 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).map(SimpleDynamicLabelsWithBusinessId::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessId").verifyComplete();
+			template.save(entity)
+				.map(SimpleDynamicLabelsWithBusinessId::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessId")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -280,22 +433,26 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction.run(
-					"CREATE (e:SimpleDynamicLabelsWithVersion:Foo:Bar:Baz:Foobar {myVersion: 0}) RETURN id(e) as existingEntityId").single();
+					"CREATE (e:SimpleDynamicLabelsWithVersion:Foo:Bar:Baz:Foobar {myVersion: 0}) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldUpdateDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabelsWithVersion.class).flatMap(entity -> {
+			template.findById(this.existingEntityId, SimpleDynamicLabelsWithVersion.class).flatMap(entity -> {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
-					.as(transactionalOperator::transactional)
-					.thenMany(getLabels(existingEntityId)).sort()
-					.as(StepVerifier::create).expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithVersion")
-					.verifyComplete();
+			})
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
+				.as(this.transactionalOperator::transactional)
+				.thenMany(getLabels(this.existingEntityId))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithVersion")
+				.verifyComplete();
 		}
 
 		@Test
@@ -307,12 +464,17 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
-					.map(SimpleDynamicLabelsWithVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(this::getLabels).sort().as(StepVerifier::create)
-					.expectNext("A", "B", "C", "SimpleDynamicLabelsWithVersion").verifyComplete();
+			template.save(entity)
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
+				.map(SimpleDynamicLabelsWithVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(this::getLabels)
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithVersion")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -320,7 +482,9 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:SimpleDynamicLabelsWithBusinessIdAndVersion:Foo:Bar:Baz:Foobar {id: 'E2', myVersion: 0}) RETURN id(e) as existingEntityId").single();
+			Record r = transaction.run(
+					"CREATE (e:SimpleDynamicLabelsWithBusinessIdAndVersion:Foo:Bar:Baz:Foobar {id: 'E2', myVersion: 0}) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
@@ -331,12 +495,15 @@ public class ReactiveDynamicLabelsIT {
 				entity.moreLabels.remove("Foo");
 				entity.moreLabels.add("Fizz");
 				return template.save(entity);
-			}).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
-					.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessIdAndVersion").verifyComplete();
+			})
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(1))
+				.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Fizz", "Foobar", "SimpleDynamicLabelsWithBusinessIdAndVersion")
+				.verifyComplete();
 		}
 
 		@Test
@@ -349,13 +516,17 @@ public class ReactiveDynamicLabelsIT {
 			entity.moreLabels.add("B");
 			entity.moreLabels.add("C");
 
-			template.save(entity).doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
-					.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
-					.as(transactionalOperator::transactional)
-					.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id)).sort()
-					.as(StepVerifier::create).expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessIdAndVersion")
-					.verifyComplete();
+			template.save(entity)
+				.doOnNext(e -> assertThat(e.myVersion).isNotNull().isEqualTo(0))
+				.map(SimpleDynamicLabelsWithBusinessIdAndVersion::getId)
+				.as(this.transactionalOperator::transactional)
+				.flatMapMany(id -> getLabels(Cypher.anyNode("n").property("id").isEqualTo(Cypher.parameter("id")), id))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("A", "B", "C", "SimpleDynamicLabelsWithBusinessIdAndVersion")
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -364,18 +535,21 @@ public class ReactiveDynamicLabelsIT {
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
 			Record r = transaction
-					.run("CREATE (e:SimpleDynamicLabelsCtor:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
-					.single();
+				.run("CREATE (e:SimpleDynamicLabelsCtor:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabels(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, SimpleDynamicLabelsCtor.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Baz", "Foo", "Foobar");
+			template.findById(this.existingEntityId, SimpleDynamicLabelsCtor.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Baz", "Foo", "Foobar");
 		}
+
 	}
 
 	@Nested
@@ -383,48 +557,55 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId").single();
+			Record r = transaction
+				.run("CREATE (e:SimpleDynamicLabels:Foo:Bar:Baz:Foobar) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsOnClassWithSingleNodeLabel(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, DynamicLabelsWithNodeLabel.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Bar", "Foo", "Foobar", "SimpleDynamicLabels")
-					.verifyComplete();
+			template.findById(this.existingEntityId, DynamicLabelsWithNodeLabel.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Bar", "Foo", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsOnClassWithMultipleNodeLabel(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, DynamicLabelsWithMultipleNodeLabels.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("Baz", "Foobar", "SimpleDynamicLabels")
-					.verifyComplete();
+			template.findById(this.existingEntityId, DynamicLabelsWithMultipleNodeLabels.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("Baz", "Foobar", "SimpleDynamicLabels")
+				.verifyComplete();
 		}
 
 		@Test // GH-2296
 		void shouldConvertIds(@Autowired ReactiveNeo4jTemplate template) {
 
 			String label = "value_1";
-			Predicate<EntityWithDynamicLabelsAndIdThatNeedsToBeConverted> expectatations = savedInstance ->
-					label.equals(savedInstance.getValue()) && savedInstance.getExtraLabels().contains(label);
+			Predicate<EntityWithDynamicLabelsAndIdThatNeedsToBeConverted> expectatations = savedInstance -> label
+				.equals(savedInstance.getValue()) && savedInstance.getExtraLabels().contains(label);
 
 			AtomicReference<UUID> generatedUUID = new AtomicReference<>();
 			template.deleteAll(EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.class)
-					.then(template.save(new EntityWithDynamicLabelsAndIdThatNeedsToBeConverted(label)))
-					.doOnNext(s -> generatedUUID.set(s.getId()))
-					.as(StepVerifier::create)
-					.expectNextMatches(expectatations)
-					.verifyComplete();
+				.then(template.save(new EntityWithDynamicLabelsAndIdThatNeedsToBeConverted(label)))
+				.doOnNext(s -> generatedUUID.set(s.getId()))
+				.as(StepVerifier::create)
+				.expectNextMatches(expectatations)
+				.verifyComplete();
 
 			template.findById(generatedUUID.get(), EntityWithDynamicLabelsAndIdThatNeedsToBeConverted.class)
-					.as(StepVerifier::create)
-					.expectNextMatches(expectatations)
-					.verifyComplete();
+				.as(StepVerifier::create)
+				.expectNextMatches(expectatations)
+				.verifyComplete();
 		}
+
 	}
 
 	@Nested
@@ -432,91 +613,23 @@ public class ReactiveDynamicLabelsIT {
 
 		@Override
 		Long createTestEntity(TransactionContext transaction) {
-			Record r = transaction.run("CREATE (e:DynamicLabelsBaseClass:ExtendedBaseClass1:D1:D2:D3) RETURN id(e) as existingEntityId").single();
+			Record r = transaction
+				.run("CREATE (e:DynamicLabelsBaseClass:ExtendedBaseClass1:D1:D2:D3) RETURN id(e) as existingEntityId")
+				.single();
 			return r.get("existingEntityId").asLong();
 		}
 
 		@Test
 		void shouldReadDynamicLabelsInInheritance(@Autowired ReactiveNeo4jTemplate template) {
 
-			template.findById(existingEntityId, ExtendedBaseClass1.class)
-					.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels)).sort().as(StepVerifier::create)
-					.expectNext("D1", "D2", "D3")
-					.verifyComplete();
-		}
-	}
-
-	@ExtendWith(SpringExtension.class)
-	@ContextConfiguration(classes = SpringTestBase.Config.class)
-	@DirtiesContext
-	abstract static class SpringTestBase {
-
-		@Autowired protected Driver driver;
-
-		@Autowired protected TransactionalOperator transactionalOperator;
-
-		@Autowired protected BookmarkCapture bookmarkCapture;
-
-		protected Long existingEntityId;
-
-		abstract Long createTestEntity(TransactionContext t);
-
-		@BeforeEach
-		void setupData() {
-			try (Session session = driver.session();) {
-				session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
-				existingEntityId = session.executeWrite(this::createTestEntity);
-				bookmarkCapture.seedWith(session.lastBookmarks());
-			}
+			template.findById(this.existingEntityId, ExtendedBaseClass1.class)
+				.flatMapMany(entity -> Flux.fromIterable(entity.moreLabels))
+				.sort()
+				.as(StepVerifier::create)
+				.expectNext("D1", "D2", "D3")
+				.verifyComplete();
 		}
 
-		@SuppressWarnings("deprecation")
-		protected final Flux<String> getLabels(Long id) {
-			return getLabels(Cypher.anyNode().named("n").internalId().isEqualTo(Cypher.parameter("id")), id);
-		}
-
-		protected final Flux<String> getLabels(Condition idCondition, Object id) {
-
-			Node n = Cypher.anyNode("n");
-			String cypher = Renderer.getDefaultRenderer().render(Cypher.match(n).where(idCondition)
-					.and(n.property("moreLabels").isNull()).unwind(n.labels()).as("label").returning("label").build());
-			return Flux
-					.usingWhen(Mono.fromSupplier(() -> driver.session(ReactiveSession.class, bookmarkCapture.createSessionConfig())),
-							s -> JdkFlowAdapter.flowPublisherToFlux(s.run(cypher, Collections.singletonMap("id", id))).flatMap(r -> JdkFlowAdapter.flowPublisherToFlux(r.records())), rs -> JdkFlowAdapter.flowPublisherToFlux(rs.close()))
-					.map(r -> r.get("label").asString());
-		}
-
-		@Configuration
-		@EnableTransactionManagement
-		static class Config extends Neo4jReactiveTestConfiguration {
-
-			@Bean
-			public Driver driver() {
-				return neo4jConnectionSupport.getDriver();
-			}
-
-			@Bean
-			public BookmarkCapture bookmarkCapture() {
-				return new BookmarkCapture();
-			}
-
-			@Override
-			public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
-
-				BookmarkCapture bookmarkCapture = bookmarkCapture();
-				return new ReactiveNeo4jTransactionManager(driver, databaseSelectionProvider, Neo4jBookmarkManager.createReactive(bookmarkCapture));
-			}
-
-			@Bean
-			public TransactionalOperator transactionalOperator(ReactiveTransactionManager transactionManager) {
-				return TransactionalOperator.create(transactionManager);
-			}
-
-			@Override
-			public boolean isCypher5Compatible() {
-				return neo4jConnectionSupport.isCypher5SyntaxCompatible();
-			}
-		}
 	}
 
 }

--- a/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
+++ b/src/test/java/org/springframework/data/neo4j/integration/reactive/ReactiveNeo4jClientIT.java
@@ -15,17 +15,10 @@
  */
 package org.springframework.data.neo4j.integration.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,20 +26,16 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
-import org.neo4j.cypherdsl.core.Statement;
-import org.neo4j.cypherdsl.core.executables.ExecutableResultStatement;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Query;
-import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.SimpleQueryRunner;
 import org.neo4j.driver.Transaction;
-import org.neo4j.driver.async.AsyncQueryRunner;
-import org.neo4j.driver.reactivestreams.ReactiveQueryRunner;
 import org.neo4j.driver.reactivestreams.ReactiveResult;
 import org.neo4j.driver.reactivestreams.ReactiveSession;
-import org.neo4j.driver.summary.ResultSummary;
-import org.reactivestreams.Publisher;
+import reactor.blockhound.BlockHound;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,10 +53,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
-import reactor.blockhound.BlockHound;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Michael J. Simons
@@ -153,12 +139,13 @@ class ReactiveNeo4jClientIT {
 
 		Node namedAnswer = Cypher.node("TheAnswer", Cypher.mapOf("value",
 				Cypher.literalOf(23).multiply(Cypher.literalOf(2)).subtract(Cypher.literalOf(4)))).named("n");
-		NewReactiveExecutableResultStatement statement = new NewReactiveExecutableResultStatement(namedAnswer);
+		var cypher = Cypher.create(namedAnswer).returning(namedAnswer).build().getCypher();
 
 		AtomicLong vanishedId = new AtomicLong();
 		transactionalOperator.execute(transaction -> {
-					Flux<Long> inner = client.getQueryRunner()
-							.flatMapMany(statement::fetchWith)
+					var inner = client.getQueryRunner()
+							.flatMap(qr -> Mono.from(qr.run(cypher)))
+							.flatMapMany(r -> Flux.from(r.records()))
 							.doOnNext(r -> vanishedId.set(TestIdentitySupport.getInternalId(r.get("n").asNode())))
 							.map(record -> record.get("n").get("value").asLong());
 
@@ -212,71 +199,6 @@ class ReactiveNeo4jClientIT {
 		@Override
 		public boolean isCypher5Compatible() {
 			return neo4jConnectionSupport.isCypher5SyntaxCompatible();
-		}
-	}
-
-	private static class NewReactiveExecutableResultStatement implements ExecutableResultStatement {
-
-		private final Statement delegate;
-
-		NewReactiveExecutableResultStatement(Node namedAnswer) {
-			delegate = Cypher.create(namedAnswer)
-					.returning(namedAnswer)
-					.build();
-		}
-
-		/**
-		 * This method should move into a future Cypher-DSL version.
-		 * @param reactiveQueryRunner The runner to run the statement with
-		 * @return a publisher of records
-		 */
-		public Publisher<Record> fetchWith(ReactiveQueryRunner reactiveQueryRunner) {
-			return Mono.fromCallable(this::createQuery).flatMapMany(reactiveQueryRunner::run)
-					.flatMap(ReactiveResult::records);
-		}
-
-		@Override
-		public <T> List<T> fetchWith(SimpleQueryRunner queryRunner, Function<Record, T> function) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override public <T> CompletableFuture<List<T>> fetchWith(AsyncQueryRunner asyncQueryRunner,
-				Function<Record, T> function) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ResultSummary streamWith(SimpleQueryRunner queryRunner, Consumer<Stream<Record>> consumer) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ResultSummary executeWith(SimpleQueryRunner queryRunner) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public CompletableFuture<ResultSummary> executeWith(AsyncQueryRunner queryRunner) {
-			throw new UnsupportedOperationException();
-		}
-
-		Query createQuery() {
-			return new Query(this.delegate.getCypher(), this.delegate.getCatalog().getParameters());
-		}
-
-		@Override
-		public Map<String, Object> getParameters() {
-			return this.delegate.getCatalog().getParameters();
-		}
-
-		@Override
-		public Collection<String> getParameterNames() {
-			return this.delegate.getCatalog().getParameterNames();
-		}
-
-		@Override
-		public String getCypher() {
-			return this.delegate.getCypher();
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jExtension.java
@@ -67,6 +67,7 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 
 	public final static String NEEDS_REACTIVE_SUPPORT = "reactive-test";
 	public final static String NEEDS_VERSION_SUPPORTING_ELEMENT_ID = "elementid-test";
+	public static final String NEEDS_VECTOR_INDEX = "vectorindex-test";
 	public final static String COMMUNITY_EDITION_ONLY = "community-edition";
 	public final static String COMMERCIAL_EDITION_ONLY = "commercial-edition";
 	/**
@@ -160,6 +161,13 @@ public class Neo4jExtension implements BeforeAllCallback, BeforeEachCallback {
 		if (tags.contains(COMMERCIAL_EDITION_ONLY)) {
 			assumeThat(neo4jConnectionSupport.isCommercialEdition())
 					.describedAs("This test should be run on the commercial edition only").isTrue();
+		}
+
+		if (tags.contains(NEEDS_VECTOR_INDEX)) {
+			assumeThat(
+					neo4jConnectionSupport.getServerVersion().greaterThanOrEqual(ServerVersion.version("Neo4j/5.13.0")))
+					.describedAs("This tests needs a Neo4j version supporting Vector indexes")
+					.isTrue();
 		}
 
 		tags.stream().filter(s -> s.startsWith(REQUIRES)).map(ServerVersion::version).forEach(v -> {

--- a/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
+++ b/src/test/java/org/springframework/data/neo4j/test/Neo4jTestConfiguration.java
@@ -27,9 +27,9 @@ public interface Neo4jTestConfiguration {
 
 	default Configuration getConfiguration() {
 		if (isCypher5Compatible()) {
-			return Configuration.newConfig().withDialect(Dialect.NEO4J_5).build();
+			return Configuration.newConfig().withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build();
 		}
 
-		return Configuration.defaultConfig();
+		return Configuration.newConfig().withDialect(Dialect.NEO4J_4).build();
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinInheritanceIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -243,5 +245,16 @@ class KotlinInheritanceIT @Autowired constructor(
 		open fun transactionTemplate(transactionManager: PlatformTransactionManager): TransactionTemplate {
 			return TransactionTemplate(transactionManager)
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/KotlinProjectionIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -135,5 +137,16 @@ internal class KotlinProjectionIT {
 		override fun driver(): Driver {
 			return neo4jConnectionSupport.driver
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jClientKotlinInteropIT.kt
@@ -20,11 +20,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.neo4j.driver.Values
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.Neo4jClient
 import org.springframework.data.neo4j.core.cypher.asParam
@@ -108,6 +110,17 @@ class Neo4jClientKotlinInteropIT @Autowired constructor(
         @Bean
         override fun driver(): Driver {
             return neo4jConnectionSupport.driver
+        }
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
         }
     }
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/imperative/Neo4jListContainsIT.kt
@@ -18,10 +18,12 @@ package org.springframework.data.neo4j.integration.imperative
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager
@@ -37,7 +39,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 @Neo4jIntegrationTest
-class Neo4jListContainsTest {
+class Neo4jListContainsIT {
 
 	companion object {
 		@JvmStatic
@@ -93,6 +95,17 @@ class Neo4jListContainsTest {
 		override fun transactionManager(driver: Driver, databaseNameProvider: DatabaseSelectionProvider): PlatformTransactionManager {
 			val bookmarkCapture = bookmarkCapture()
 			return Neo4jTransactionManager(driver, databaseNameProvider, Neo4jBookmarkManager.create(bookmarkCapture))
+		}
+
+		@Bean
+		@Primary
+		open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+			if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+				return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+					.withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+			}
+
+			return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
 		}
 	}
 }

--- a/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
+++ b/src/test/kotlin/org/springframework/data/neo4j/integration/k/KotlinIssuesIT.kt
@@ -19,10 +19,12 @@ package org.springframework.data.neo4j.integration.k
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.neo4j.config.AbstractNeo4jConfig
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider
 import org.springframework.data.neo4j.core.Neo4jTemplate
@@ -30,6 +32,7 @@ import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
 import org.springframework.data.neo4j.core.transaction.Neo4jBookmarkManager
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager
+import org.springframework.data.neo4j.integration.imperative.Neo4jListContainsIT
 import org.springframework.data.neo4j.repository.Neo4jRepository
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories
 import org.springframework.data.neo4j.test.BookmarkCapture
@@ -111,5 +114,16 @@ internal class KotlinIssuesIT {
 		open fun transactionTemplate(transactionManager: PlatformTransactionManager): TransactionTemplate {
 			return TransactionTemplate(transactionManager)
 		}
+
+        @Bean
+        @Primary
+        open fun getConfiguration(): org.neo4j.cypherdsl.core.renderer.Configuration? {
+            if (neo4jConnectionSupport.isCypher5SyntaxCompatible) {
+                return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig()
+                    .withDialect(Dialect.NEO4J_5_DEFAULT_CYPHER).build()
+            }
+
+            return org.neo4j.cypherdsl.core.renderer.Configuration.newConfig().withDialect(Dialect.NEO4J_4).build()
+        }
 	}
 }


### PR DESCRIPTION
This is a backport of ade01cb, with the tests only using the database default cypher 5 or 25 variant (due to the fact that 7.5.x is not on JUnit 6).

This might be a breaking change for very few users with the benefit of having this performance enhancement discussed in https://github.com/spring-projects/spring-data-neo4j/issues/3043 also available in SDN 7.5.x without going through the whole Spring Boot / Framework update dance: Cypher DSL is now bumped to the latest which is missing the driver integration.

Steps to fix this can be seen here:

https://github.com/spring-projects/spring-data-neo4j/commit/fba0b8b0e9e1a1277202f13490e1831f2d260fdd

And if you are running against Neo4j 4.4.x, you know *must*  configure an older dialect:

```
@Bean
Configuration cypherDslConfiguration() {
	return Configuration.newConfig()
                .withDialect(Dialect.NEO4J_4).build();
}
```

as Cypher DSL 2025 uses 5 by default.
