### PR TITLE
Preserve property declaration order when writing entities

### DIFF
--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -335,7 +336,9 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 			return;
 		}
 
-		Map<String, Object> properties = new HashMap<>();
+		// LinkedHashMap to preserve the declaration order of properties when writing
+		// them to the database. See https://github.com/spring-projects/spring-data-neo4j/issues/2866
+		Map<String, Object> properties = new LinkedHashMap<>();
 
 		if (nodeDescription.hasRelationshipPropertyPersistTypeInfoFlag()) {
 			// add type info when write to the database

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverter.java
@@ -337,7 +337,8 @@ final class DefaultNeo4jEntityConverter implements Neo4jEntityConverter {
 		}
 
 		// LinkedHashMap to preserve the declaration order of properties when writing
-		// them to the database. See https://github.com/spring-projects/spring-data-neo4j/issues/2866
+		// them to the database. See
+		// https://github.com/spring-projects/spring-data-neo4j/issues/2866
 		Map<String, Object> properties = new LinkedHashMap<>();
 
 		if (nodeDescription.hasRelationshipPropertyPersistTypeInfoFlag()) {

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
@@ -16,6 +16,7 @@
 package org.springframework.data.neo4j.core.mapping;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -118,7 +119,10 @@ public interface Schema {
 
 		Neo4jEntityConverter entityConverter = getEntityConverter();
 		return t -> {
-			Map<String, Object> parameters = new HashMap<>();
+			// LinkedHashMap to preserve the order of bound parameters (in particular
+			// the properties map produced by Neo4jEntityConverter#write). See
+			// https://github.com/spring-projects/spring-data-neo4j/issues/2866
+			Map<String, Object> parameters = new LinkedHashMap<>();
 			entityConverter.write(t, parameters);
 			return parameters;
 		};

--- a/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
+++ b/src/main/java/org/springframework/data/neo4j/core/mapping/Schema.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.neo4j.core.mapping;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTests.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTests.java
@@ -37,7 +37,6 @@ import org.springframework.data.neo4j.core.mapping.callback.EventSupport;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
-import org.springframework.data.neo4j.core.schema.Property;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,8 +53,11 @@ class DefaultNeo4jEntityConverterTests {
 		DefaultNeo4jConversionService conversionService = new DefaultNeo4jConversionService(new Neo4jConversions());
 		Neo4jMappingContext context = new Neo4jMappingContext();
 		context.addPersistentEntity(TypeInformation.of(EntityWithDefaultValues.class));
+		context.addPersistentEntity(TypeInformation.of(OrderedPropertiesEntity.class));
 		nodeDescriptionStore.put("User",
 				(DefaultNeo4jPersistentEntity<?>) context.getNodeDescription(EntityWithDefaultValues.class));
+		nodeDescriptionStore.put("OrderedPropertiesEntity",
+				(DefaultNeo4jPersistentEntity<?>) context.getNodeDescription(OrderedPropertiesEntity.class));
 		EventSupport eventSupport = EventSupport.useExistingCallbacks(context, EntityCallbacks.create());
 		TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 		this.entityConverter = new DefaultNeo4jEntityConverter(entityInstantiators, nodeDescriptionStore,
@@ -88,6 +90,26 @@ class DefaultNeo4jEntityConverterTests {
 		assertThat(readNode.defaultValue).isEqualTo("valueFromDatabase2");
 	}
 
+	@Test // GH-2866
+	void writeShouldPreservePropertyDeclarationOrder() {
+
+		Map<String, Object> parameters = new HashMap<>();
+		OrderedPropertiesEntity instance = new OrderedPropertiesEntity();
+		instance.nodeId = "n";
+		instance.description = "d";
+		instance.stuff = "s";
+		instance.reference = "r";
+		instance.title = "t";
+		this.entityConverter.write(instance, parameters);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> properties = (Map<String, Object>) parameters.get("__properties__");
+		List<String> writtenPropertyOrder = new ArrayList<>(properties.keySet());
+		// 'id' is filtered out by the converter (internal id property); the remaining
+		// keys must follow the declaration order of the source class.
+		assertThat(writtenPropertyOrder).containsExactly("nodeId", "description", "stuff", "reference", "title");
+	}
+
 	@Node
 	static class EntityWithDefaultValues {
 
@@ -99,37 +121,6 @@ class DefaultNeo4jEntityConverterTests {
 		@GeneratedValue
 		Long id;
 
-	}
-
-	@Test // GH-2866
-	void writeShouldPreservePropertyDeclarationOrder() {
-
-		Neo4jMappingContext context = new Neo4jMappingContext();
-		context.addPersistentEntity(TypeInformation.of(OrderedPropertiesEntity.class));
-		NodeDescriptionStore store = new NodeDescriptionStore();
-		store.put("OrderedPropertiesEntity",
-				(DefaultNeo4jPersistentEntity<?>) context.getNodeDescription(OrderedPropertiesEntity.class));
-		DefaultNeo4jEntityConverter localConverter = new DefaultNeo4jEntityConverter(
-				new EntityInstantiators(), store,
-				new DefaultNeo4jConversionService(new Neo4jConversions()),
-				EventSupport.useExistingCallbacks(context, EntityCallbacks.create()),
-				InternalTypeSystem.TYPE_SYSTEM);
-
-		Map<String, Object> parameters = new HashMap<>();
-		OrderedPropertiesEntity instance = new OrderedPropertiesEntity();
-		instance.nodeId = "n";
-		instance.description = "d";
-		instance.stuff = "s";
-		instance.reference = "r";
-		instance.title = "t";
-		localConverter.write(instance, parameters);
-
-		@SuppressWarnings("unchecked")
-		Map<String, Object> properties = (Map<String, Object>) parameters.get("props");
-		List<String> writtenPropertyOrder = new ArrayList<>(properties.keySet());
-		// 'id' is filtered out by the converter (internal id property); the remaining
-		// keys must follow the declaration order of the source class.
-		assertThat(writtenPropertyOrder).containsExactly("nodeId", "description", "stuff", "reference", "title");
 	}
 
 	@Node
@@ -148,6 +139,7 @@ class DefaultNeo4jEntityConverterTests {
 		@Id
 		@GeneratedValue
 		Long id;
+
 	}
 
 }

--- a/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTests.java
+++ b/src/test/java/org/springframework/data/neo4j/core/mapping/DefaultNeo4jEntityConverterTests.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.neo4j.core.mapping;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ import org.springframework.data.neo4j.core.mapping.callback.EventSupport;
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -96,6 +99,55 @@ class DefaultNeo4jEntityConverterTests {
 		@GeneratedValue
 		Long id;
 
+	}
+
+	@Test // GH-2866
+	void writeShouldPreservePropertyDeclarationOrder() {
+
+		Neo4jMappingContext context = new Neo4jMappingContext();
+		context.addPersistentEntity(TypeInformation.of(OrderedPropertiesEntity.class));
+		NodeDescriptionStore store = new NodeDescriptionStore();
+		store.put("OrderedPropertiesEntity",
+				(DefaultNeo4jPersistentEntity<?>) context.getNodeDescription(OrderedPropertiesEntity.class));
+		DefaultNeo4jEntityConverter localConverter = new DefaultNeo4jEntityConverter(
+				new EntityInstantiators(), store,
+				new DefaultNeo4jConversionService(new Neo4jConversions()),
+				EventSupport.useExistingCallbacks(context, EntityCallbacks.create()),
+				InternalTypeSystem.TYPE_SYSTEM);
+
+		Map<String, Object> parameters = new HashMap<>();
+		OrderedPropertiesEntity instance = new OrderedPropertiesEntity();
+		instance.nodeId = "n";
+		instance.description = "d";
+		instance.stuff = "s";
+		instance.reference = "r";
+		instance.title = "t";
+		localConverter.write(instance, parameters);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> properties = (Map<String, Object>) parameters.get("props");
+		List<String> writtenPropertyOrder = new ArrayList<>(properties.keySet());
+		// 'id' is filtered out by the converter (internal id property); the remaining
+		// keys must follow the declaration order of the source class.
+		assertThat(writtenPropertyOrder).containsExactly("nodeId", "description", "stuff", "reference", "title");
+	}
+
+	@Node
+	static class OrderedPropertiesEntity {
+
+		String nodeId;
+
+		String description;
+
+		String stuff;
+
+		String reference;
+
+		String title;
+
+		@Id
+		@GeneratedValue
+		Long id;
 	}
 
 }


### PR DESCRIPTION
### Description

The maps used by `Neo4jEntityConverter#write` and
`Schema#getRequiredBinderFunctionFor` to collect properties and bound
parameters were `HashMap` instances, which do not preserve insertion
order. As a result, the order in which properties were serialized to
the Cypher parameter map (and therefore stored on the node) was
non-deterministic and appeared random to callers. This was first
reported in #2866 where a `saveAllAs(..., NodeProjection.class)`
invocation produced nodes with properties in a different order than
declared in the Java class.

`@JsonPropertyOrder` does not apply to this path because SDN does not
use Jackson to build the parameter map; the map is built by SDN's
own entity converter and bound directly as a Cypher parameter.

### Changes

- `DefaultNeo4jEntityConverter#write`: properties map changed from
  `HashMap` to `LinkedHashMap`.
- `Schema#getRequiredBinderFunctionFor`: outer parameters map changed
  from `HashMap` to `LinkedHashMap`.
- `DefaultNeo4jEntityConverterTests`: new test
  `writeShouldPreservePropertyDeclarationOrder` that locks in the
  expected property order on write.

### Notes

The order preserved is the order in which
`PropertyHandlerSupport#doWithProperties` visits the entity's
persistent properties, which mirrors the field declaration order on
the entity. This relies on the current `BasicPersistentEntity`
implementation; Spring Data Commons' `PersistentEntity#doWithProperties`
contract does not strictly guarantee order, so the new test is the
regression guard. The internal id property is still filtered out
before the order is asserted.

Closes: #2866